### PR TITLE
Update IDs from upstream LRR

### DIFF
--- a/reporters.json
+++ b/reporters.json
@@ -1,8801 +1,8805 @@
 {
     "A.": [
         {
-            "cite_type": "state_regional",
+            "cite_type": "state_regional", 
             "editions": {
                 "A.": {
-                    "end": "1938-12-31T00:00:00",
+                    "end": "1938-12-31T00:00:00", 
                     "start": "1885-01-01T00:00:00"
-                },
+                }, 
                 "A.2d": {
-                    "end": "2010-12-31T00:00:00",
+                    "end": "2010-12-31T00:00:00", 
                     "start": "1938-01-01T00:00:00"
-                },
+                }, 
                 "A.3d": {
-                    "end": null,
+                    "end": null, 
                     "start": "2010-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ct;supreme.court",
-                "us;de;supreme.court",
-                "us;federal;district.columbia.court.appeals",
-                "us;md;court.appeals",
-                "us;me;supreme.judicial.court",
-                "us;nh;supreme.court",
-                "us;nj;supreme.court",
-                "us;pa;supreme.court",
-                "us;ri;supreme.court",
-                "us;vt;supreme.court"
-            ],
-            "name": "Atlantic Reporter",
+                "us:ct;supreme.court", 
+                "us:dc;court.appeals", 
+                "us:de;supreme.court", 
+                "us:md;court.appeals", 
+                "us:me;supreme.judicial.court", 
+                "us:nh;supreme.court", 
+                "us:nj;supreme.court", 
+                "us:pa;supreme.court", 
+                "us:ri;supreme.court", 
+                "us:vt;supreme.court"
+            ], 
+            "name": "Atlantic Reporter", 
             "variations": {
-                "A. 2d": "A.2d",
-                "A. 3d": "A.3d",
-                "A.R.": "A.",
-                "A.Rep.": "A.",
-                "At.": "A.",
-                "Atl.": "A.",
-                "Atl.2d": "A.2d",
+                "A. 2d": "A.2d", 
+                "A. 3d": "A.3d", 
+                "A.R.": "A.", 
+                "A.Rep.": "A.", 
+                "At.": "A.", 
+                "Atl.": "A.", 
+                "Atl.2d": "A.2d", 
                 "Atl.R.": "A."
             }
         }
-    ],
+    ], 
     "A.D.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "A.D.": {
-                    "end": "1955-12-31T00:00:00",
+                    "end": "1955-12-31T00:00:00", 
                     "start": "1896-01-01T00:00:00"
-                },
+                }, 
                 "A.D.2d": {
-                    "end": "2004-12-31T00:00:00",
+                    "end": "2004-12-31T00:00:00", 
                     "start": "1955-01-01T00:00:00"
-                },
+                }, 
                 "A.D.3d": {
-                    "end": null,
+                    "end": null, 
                     "start": "2003-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "New York Supreme Court Appellate Division Reports",
+                "us:ny;court.appeals"
+            ], 
+            "name": "New York Supreme Court Appellate Division Reports", 
             "variations": {
-                "A.D. 2d": "A.D.2d",
-                "A.D. 3d": "A.D.3d",
-                "AD 2d": "A.D.2d",
-                "AD 3d": "A.D.3d",
-                "Ap.": "A.D.",
-                "Ap.2d.": "A.D.",
-                "App.Div.": "A.D.",
-                "App.Div.(N.Y.)": "A.D.",
-                "App.Div.2d.": "A.D.",
-                "N.Y.App.Dec.": "A.D.",
+                "A.D. 2d": "A.D.2d", 
+                "A.D. 3d": "A.D.3d", 
+                "AD 2d": "A.D.2d", 
+                "AD 3d": "A.D.3d", 
+                "Ap.": "A.D.", 
+                "Ap.2d.": "A.D.", 
+                "App.Div.": "A.D.", 
+                "App.Div.(N.Y.)": "A.D.", 
+                "App.Div.2d.": "A.D.", 
+                "N.Y.App.Dec.": "A.D.", 
                 "N.Y.App.Div.": "A.D."
             }
         }
-    ],
+    ], 
     "A.K. Marsh.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "A.K. Marsh.": {
-                    "end": "1821-12-31T00:00:00",
+                    "end": "1821-12-31T00:00:00", 
                     "start": "1817-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ky;supreme.court"
-            ],
-            "name": "Kentucky Reports, Marshall, A.K.",
+                "us:ky;supreme.court"
+            ], 
+            "name": "Kentucky Reports, Marshall, A.K.", 
             "variations": {
-                "Ky.(A.K.Marsh.)": "A.K. Marsh.",
-                "Mar.": "A.K. Marsh.",
-                "Marsh.": "A.K. Marsh.",
-                "Marsh.(Ky.)": "A.K. Marsh.",
+                "Ky.(A.K.Marsh.)": "A.K. Marsh.", 
+                "Mar.": "A.K. Marsh.", 
+                "Marsh.": "A.K. Marsh.", 
+                "Marsh.(Ky.)": "A.K. Marsh.", 
                 "Marsh.A.K.": "A.K. Marsh."
             }
         }
-    ],
+    ], 
     "AZ": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "AZ": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;az;supreme.court"
-            ],
-            "name": "Arizona Neutral Citation",
+                "us:az;supreme.court"
+            ], 
+            "name": "Arizona Neutral Citation", 
             "variations": {}
         }
-    ],
+    ], 
     "Abb. N. Cas.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Abb. N. Cas.": {
-                    "end": "1894-12-31T00:00:00",
+                    "end": "1894-12-31T00:00:00", 
                     "start": "1876-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Abbott's New Cases",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Abbott's New Cases", 
             "variations": {
-                "A.N.": "Abb. N. Cas.",
-                "A.N.C.": "Abb. N. Cas.",
+                "A.N.": "Abb. N. Cas.", 
+                "A.N.C.": "Abb. N. Cas.", 
                 "Abb.N.C.": "Abb. N. Cas."
             }
         }
-    ],
+    ], 
     "Abb. Pr.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Abb. Pr.": {
-                    "end": "1875-12-31T00:00:00",
+                    "end": "1875-12-31T00:00:00", 
                     "start": "1854-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Abbott's Practice Reports",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Abbott's Practice Reports", 
             "variations": {
-                "Abb.P.R.": "Abb. Pr.",
-                "Abb.Pr.Rep.": "Abb. Pr.",
-                "Abb.Prac.": "Abb. Pr.",
-                "Abbott P.R.": "Abb. Pr.",
-                "Abbott Pr.Rep.": "Abb. Pr.",
-                "Abbott Pract.Cas.": "Abb. Pr.",
-                "Abbott's Pr.Rep.": "Abb. Pr.",
+                "Abb.P.R.": "Abb. Pr.", 
+                "Abb.Pr.Rep.": "Abb. Pr.", 
+                "Abb.Prac.": "Abb. Pr.", 
+                "Abbott P.R.": "Abb. Pr.", 
+                "Abbott Pr.Rep.": "Abb. Pr.", 
+                "Abbott Pract.Cas.": "Abb. Pr.", 
+                "Abbott's Pr.Rep.": "Abb. Pr.", 
                 "Abbott's Prac.Rep.": "Abb. Pr."
             }
         }
-    ],
+    ], 
     "Aik.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Aik.": {
-                    "end": "1828-12-31T00:00:00",
+                    "end": "1828-12-31T00:00:00", 
                     "start": "1825-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;vt;supreme.court"
-            ],
-            "name": "Vermont Reports, Aikens",
+                "us:vt;supreme.court"
+            ], 
+            "name": "Vermont Reports, Aikens", 
             "variations": {}
         }
-    ],
+    ], 
     "Ala.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ala.": {
-                    "end": "1976-12-31T00:00:00",
+                    "end": "1976-12-31T00:00:00", 
                     "start": "1840-01-01T00:00:00"
-                },
+                }, 
                 "Ala. 2d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1977-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;al;supreme.court"
-            ],
-            "name": "Alabama Reports",
+                "us:al;supreme.court"
+            ], 
+            "name": "Alabama Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Ala. App.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ala. App.": {
-                    "end": "1976-12-31T00:00:00",
+                    "end": "1976-12-31T00:00:00", 
                     "start": "1910-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;al;supreme.court"
-            ],
-            "name": "Alabama Appellate Courts Reports",
+                "us:al;supreme.court"
+            ], 
+            "name": "Alabama Appellate Courts Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Alaska": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Alaska": {
-                    "end": "1959-12-31T00:00:00",
+                    "end": "1959-12-31T00:00:00", 
                     "start": "1884-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ak;supreme.court"
-            ],
-            "name": "Alaska Reports",
+                "us:ak;supreme.court"
+            ], 
+            "name": "Alaska Reports", 
             "variations": {
                 "Alk.": "Alaska"
             }
         }
-    ],
+    ], 
     "Alaska Fed.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Alaska Fed.": {
-                    "end": "1937-12-31T00:00:00",
+                    "end": "1937-12-31T00:00:00", 
                     "start": "1869-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ak;supreme.court"
-            ],
-            "name": "Alaska Federal Reports",
+                "us:ak;supreme.court"
+            ], 
+            "name": "Alaska Federal Reports", 
             "variations": {
-                "A.F.Rep.": "Alaska Fed.",
-                "Alaska Fed.": "Alaska Fed.",
-                "Alaska Fed.R.": "Alaska Fed.",
+                "A.F.Rep.": "Alaska Fed.", 
+                "Alaska Fed.": "Alaska Fed.", 
+                "Alaska Fed.R.": "Alaska Fed.", 
                 "Alaska Fed.Rep.": "Alaska Fed."
             }
         }
-    ],
+    ], 
     "Allen": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Allen": {
-                    "end": "1867-12-31T00:00:00",
+                    "end": "1867-12-31T00:00:00", 
                     "start": "1861-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ma;appeals.court"
-            ],
-            "name": "Massachusetts Reports, Allen",
+                "us:ma;appeals.court"
+            ], 
+            "name": "Massachusetts Reports, Allen", 
             "variations": {
-                "All.": "Allen",
+                "All.": "Allen", 
                 "Mass.(Allen)": "Allen"
             }
         }
-    ],
+    ], 
     "Am. Samoa": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Am. Samoa": {
-                    "end": null,
+                    "end": null, 
                     "start": "1900-01-01T00:00:00"
-                },
+                }, 
                 "Am. Samoa 2d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1900-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;high.court.american.samoa"
-            ],
-            "name": "American Samoa Reports",
+                "us:as;high.court"
+            ], 
+            "name": "American Samoa Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Ant. N.P. Cas.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ant. N.P. Cas.": {
-                    "end": "1851-12-31T00:00:00",
+                    "end": "1851-12-31T00:00:00", 
                     "start": "1807-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Anthon's Nisi Prius Cases",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Anthon's Nisi Prius Cases", 
             "variations": {
-                "Anth.": "Ant. N.P. Cas.",
+                "Anth.": "Ant. N.P. Cas.", 
                 "Anthon N.P.(N.Y.)": "Ant. N.P. Cas."
             }
         }
-    ],
+    ], 
     "App. D.C.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "App. D.C.": {
-                    "end": "1941-12-31T00:00:00",
+                    "end": "1941-12-31T00:00:00", 
                     "start": "1893-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;district.columbia.court.appeals"
-            ],
-            "name": "Appeal Cases, District of Columbia",
+                "us:dc;court.appeals"
+            ], 
+            "name": "Appeal Cases, District of Columbia", 
             "variations": {}
         }
-    ],
+    ], 
     "Ariz.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ariz.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1866-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;az;supreme.court"
-            ],
-            "name": "Arizona Reporter",
+                "us:az;supreme.court"
+            ], 
+            "name": "Arizona Reporter", 
             "variations": {}
         }
-    ],
+    ], 
     "Ariz. App.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ariz. App.": {
-                    "end": "1976-12-31T00:00:00",
+                    "end": "1976-12-31T00:00:00", 
                     "start": "1965-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;az;supreme.court"
-            ],
-            "name": "Arizona Appeals Reports",
+                "us:az;supreme.court"
+            ], 
+            "name": "Arizona Appeals Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Ark.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ark.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1837-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ar;supreme.court"
-            ],
-            "name": "Arkansas Reports",
+                "us:ar;supreme.court"
+            ], 
+            "name": "Arkansas Reports", 
             "variations": {
                 "Ak.": "Ark."
             }
         }
-    ],
+    ], 
     "Ark. App.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ark. App.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1981-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ar;supreme.court"
-            ],
-            "name": "Arkansas Appellate Reports",
+                "us:ar;supreme.court"
+            ], 
+            "name": "Arkansas Appellate Reports", 
             "variations": {
                 "Ak. App.": "Ark. App."
             }
         }
-    ],
+    ], 
     "B. Mon.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "B. Mon.": {
-                    "end": "1857-12-31T00:00:00",
+                    "end": "1857-12-31T00:00:00", 
                     "start": "1840-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ky;supreme.court"
-            ],
-            "name": "Kentucky Reports, Monroe, Ben",
+                "us:ky;supreme.court"
+            ], 
+            "name": "Kentucky Reports, Monroe, Ben", 
             "variations": {
-                "Ky.(B.Mon.)": "B. Mon.",
-                "Mon.": "B. Mon.",
-                "Mon.B.": "B. Mon.",
+                "Ky.(B.Mon.)": "B. Mon.", 
+                "Mon.": "B. Mon.", 
+                "Mon.B.": "B. Mon.", 
                 "Monroe, B.": "B. Mon."
             }
         }
-    ],
+    ], 
     "B.R.": [
         {
-            "cite_type": "specialty",
+            "cite_type": "specialty", 
             "editions": {
                 "B.R.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1979-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;ak;d;bankruptcy.court",
-                "us;federal;al;md;bankruptcy.court",
-                "us;federal;al;nd;bankruptcy.court",
-                "us;federal;al;sd;bankruptcy.court",
-                "us;federal;ar;ed;bankruptcy.court",
-                "us;federal;ar;wd;bankruptcy.court",
-                "us;federal;az;d;bankruptcy.court",
-                "us;federal;bankruptcy.appellate.panel.1.circuit",
-                "us;federal;bankruptcy.appellate.panel.10.circuit",
-                "us;federal;bankruptcy.appellate.panel.2.circuit",
-                "us;federal;bankruptcy.appellate.panel.6.circuit",
-                "us;federal;bankruptcy.appellate.panel.8.circuit",
-                "us;federal;bankruptcy.appellate.panel.9.circuit",
-                "us;federal;bankruptcy.court.d.guam",
-                "us;federal;bankruptcy.court.d.puerto.rico",
-                "us;federal;bankruptcy.court.d.virgin.islands",
-                "us;federal;bankruptcy.court.district.columbia",
-                "us;federal;bankruptcy.court.northern.mariana.islands",
-                "us;federal;ca;cd;bankruptcy.court",
-                "us;federal;ca;ed;bankruptcy.court",
-                "us;federal;ca;nd;bankruptcy.court",
-                "us;federal;ca;sd;bankruptcy.court",
-                "us;federal;co;d;bankruptcy.court",
-                "us;federal;ct;d;bankruptcy.court",
-                "us;federal;de;d;bankruptcy.court",
-                "us;federal;fl;md;bankruptcy.court",
-                "us;federal;fl;nd;bankruptcy.court",
-                "us;federal;fl;sd;bankruptcy.court",
-                "us;federal;ga;md;bankruptcy.court",
-                "us;federal;ga;nd;bankruptcy.court",
-                "us;federal;ga;sd;bankruptcy.court",
-                "us;federal;hi;d;bankruptcy.court",
-                "us;federal;ia;nd;bankruptcy.court",
-                "us;federal;ia;sd;bankruptcy.court",
-                "us;federal;id;d;bankruptcy.court",
-                "us;federal;il;cd;bankruptcy.court",
-                "us;federal;il;nd;bankruptcy.court",
-                "us;federal;il;sd;bankruptcy.court",
-                "us;federal;in;nd;bankruptcy.court",
-                "us;federal;in;sd;bankruptcy.court",
-                "us;federal;ks;d;bankruptcy.court",
-                "us;federal;ky;ed;bankruptcy.court",
-                "us;federal;ky;wd;bankruptcy.court",
-                "us;federal;la;ed;bankruptcy.court",
-                "us;federal;la;md;bankruptcy.court",
-                "us;federal;la;wd;bankruptcy.court",
-                "us;federal;ma;d;bankruptcy.court",
-                "us;federal;md;d;bankruptcy.court",
-                "us;federal;me;d;bankruptcy.appellate.panel",
-                "us;federal;me;d;bankruptcy.court",
-                "us;federal;mi;ed;bankruptcy.court",
-                "us;federal;mi;wd;bankruptcy.court",
-                "us;federal;mn;d;bankruptcy.court",
-                "us;federal;mo;ed;bankruptcy.court",
-                "us;federal;mo;wd;bankruptcy.court",
-                "us;federal;ms;nd;bankruptcy.court",
-                "us;federal;ms;sd;bankruptcy.court",
-                "us;federal;mt;d;bankruptcy.court",
-                "us;federal;nc;ed;bankruptcy.court",
-                "us;federal;nc;md;bankruptcy.court",
-                "us;federal;nc;wd;bankruptcy.court",
-                "us;federal;nd;d;bankruptcy.court",
-                "us;federal;ne;d;bankruptcy.court",
-                "us;federal;nh;d;bankruptcy.court",
-                "us;federal;nj;d;bankruptcy.court",
-                "us;federal;nm;d;bankruptcy.court",
-                "us;federal;nv;d;bankruptcy.court",
-                "us;federal;ny;ed;bankruptcy.court",
-                "us;federal;ny;nd;bankruptcy.court",
-                "us;federal;ny;sd;bankruptcy.court",
-                "us;federal;ny;wd;bankruptcy.court",
-                "us;federal;oh;nd;bankruptcy.court",
-                "us;federal;oh;sd;bankruptcy.court",
-                "us;federal;ok;ed;bankruptcy.court",
-                "us;federal;ok;nd;bankruptcy.court",
-                "us;federal;ok;wd;bankruptcy.court",
-                "us;federal;or;d;bankruptcy.court",
-                "us;federal;pa;ed;bankruptcy.court",
-                "us;federal;pa;md;bankruptcy.court",
-                "us;federal;pa;wd;bankruptcy.court",
-                "us;federal;ri;d;bankruptcy.court",
-                "us;federal;sc;d;bankruptcy.court",
-                "us;federal;sd;d;bankruptcy.court",
-                "us;federal;tn;d;bankruptcy.court",
-                "us;federal;tn;ed;bankruptcy.court",
-                "us;federal;tn;md;bankruptcy.court",
-                "us;federal;tn;wd;bankruptcy.court",
-                "us;federal;tx;ed;bankruptcy.court",
-                "us;federal;tx;nd;bankruptcy.court",
-                "us;federal;tx;sd;bankruptcy.court",
-                "us;federal;ut;d;bankruptcy.court",
-                "us;federal;va;ed;bankruptcy.court",
-                "us;federal;va;wd;bankruptcy.court",
-                "us;federal;vt;d;bankruptcy.court",
-                "us;federal;wa;ed;bankruptcy.court",
-                "us;federal;wa;wd;bankruptcy.court",
-                "us;federal;wi;ed;bankruptcy.court",
-                "us;federal;wi;wd;bankruptcy.court",
-                "us;federal;wv;sd;bankruptcy.court",
-                "us;federal;wy;d;bankruptcy.court"
-            ],
-            "name": "Bankruptcy Reporter",
+                "us:c0:dc.d;bankruptcy.court", 
+                "us:c10:co.d;bankruptcy.court", 
+                "us:c10:ks.d;bankruptcy.court", 
+                "us:c10:nm.d;bankruptcy.court", 
+                "us:c10:ok.ed;bankruptcy.court", 
+                "us:c10:ok.nd;bankruptcy.court", 
+                "us:c10:ok.wd;bankruptcy.court", 
+                "us:c10:ut.d;bankruptcy.court", 
+                "us:c10:wy.d;bankruptcy.court", 
+                "us:c10;bankruptcy.appellate.panel", 
+                "us:c11:al.md;bankruptcy.court", 
+                "us:c11:al.nd;bankruptcy.court", 
+                "us:c11:al.sd;bankruptcy.court", 
+                "us:c11:fl.md;bankruptcy.court", 
+                "us:c11:fl.nd;bankruptcy.court", 
+                "us:c11:fl.sd;bankruptcy.court", 
+                "us:c11:ga.md;bankruptcy.court", 
+                "us:c11:ga.nd;bankruptcy.court", 
+                "us:c11:ga.sd;bankruptcy.court", 
+                "us:c1:ma.d;bankruptcy.court", 
+                "us:c1:me.d;bankruptcy.appellate.panel", 
+                "us:c1:me.d;bankruptcy.court", 
+                "us:c1:nh.d;bankruptcy.court", 
+                "us:c1:pr.d;bankruptcy.court", 
+                "us:c1:ri.d;bankruptcy.court", 
+                "us:c1;bankruptcy.appellate.panel", 
+                "us:c2:ct.d;bankruptcy.court", 
+                "us:c2:ny.ed;bankruptcy.court", 
+                "us:c2:ny.nd;bankruptcy.court", 
+                "us:c2:ny.sd;bankruptcy.court", 
+                "us:c2:ny.wd;bankruptcy.court", 
+                "us:c2:vt.d;bankruptcy.court", 
+                "us:c2;bankruptcy.appellate.panel", 
+                "us:c3:de.d;bankruptcy.court", 
+                "us:c3:nj.d;bankruptcy.court", 
+                "us:c3:pa.ed;bankruptcy.court", 
+                "us:c3:pa.md;bankruptcy.court", 
+                "us:c3:pa.wd;bankruptcy.court", 
+                "us:c3:vi.d;bankruptcy.court", 
+                "us:c4:md.d;bankruptcy.court", 
+                "us:c4:nc.ed;bankruptcy.court", 
+                "us:c4:nc.md;bankruptcy.court", 
+                "us:c4:nc.wd;bankruptcy.court", 
+                "us:c4:sc.d;bankruptcy.court", 
+                "us:c4:va.ed;bankruptcy.court", 
+                "us:c4:va.wd;bankruptcy.court", 
+                "us:c4:wv.nd;bankruptcy.court", 
+                "us:c4:wv.sd;bankruptcy.court", 
+                "us:c5:la.ed;bankruptcy.court", 
+                "us:c5:la.md;bankruptcy.court", 
+                "us:c5:la.wd;bankruptcy.court", 
+                "us:c5:ms.nd;bankruptcy.court", 
+                "us:c5:ms.sd;bankruptcy.court", 
+                "us:c5:tx.ed;bankruptcy.court", 
+                "us:c5:tx.nd;bankruptcy.court", 
+                "us:c5:tx.sd;bankruptcy.court", 
+                "us:c5:tx.wd;bankruptcy.court", 
+                "us:c6:ky.ed;bankruptcy.court", 
+                "us:c6:ky.wd;bankruptcy.court", 
+                "us:c6:mi.ed;bankruptcy.court", 
+                "us:c6:mi.wd;bankruptcy.court", 
+                "us:c6:oh.nd;bankruptcy.court", 
+                "us:c6:oh.sd;bankruptcy.court", 
+                "us:c6:tn.d;bankruptcy.court", 
+                "us:c6:tn.ed;bankruptcy.court", 
+                "us:c6:tn.md;bankruptcy.court", 
+                "us:c6:tn.wd;bankruptcy.court", 
+                "us:c6;bankruptcy.appellate.panel", 
+                "us:c7:il.cd;bankruptcy.court", 
+                "us:c7:il.nd;bankruptcy.court", 
+                "us:c7:il.sd;bankruptcy.court", 
+                "us:c7:in.nd;bankruptcy.court", 
+                "us:c7:in.sd;bankruptcy.court", 
+                "us:c7:wi.ed;bankruptcy.court", 
+                "us:c7:wi.wd;bankruptcy.court", 
+                "us:c8:ar.ed;bankruptcy.court", 
+                "us:c8:ar.wd;bankruptcy.court", 
+                "us:c8:ia.nd;bankruptcy.court", 
+                "us:c8:ia.sd;bankruptcy.court", 
+                "us:c8:mn.d;bankruptcy.court", 
+                "us:c8:mo.ed;bankruptcy.court", 
+                "us:c8:mo.wd;bankruptcy.court", 
+                "us:c8:nd.d;bankruptcy.court", 
+                "us:c8:ne.d;bankruptcy.court", 
+                "us:c8:sd.d;bankruptcy.court", 
+                "us:c8;bankruptcy.appellate.panel", 
+                "us:c9:ak.d;bankruptcy.court", 
+                "us:c9:az.d;bankruptcy.court", 
+                "us:c9:ca.cd;bankruptcy.court", 
+                "us:c9:ca.ed;bankruptcy.court", 
+                "us:c9:ca.nd;bankruptcy.court", 
+                "us:c9:ca.sd;bankruptcy.court", 
+                "us:c9:gu.d;bankruptcy.court", 
+                "us:c9:hi.d;bankruptcy.court", 
+                "us:c9:id.d;bankruptcy.court", 
+                "us:c9:mp.d;bankruptcy.court", 
+                "us:c9:mt.d;bankruptcy.court", 
+                "us:c9:nv.d;bankruptcy.court", 
+                "us:c9:or.d;bankruptcy.court", 
+                "us:c9:wa.ed;bankruptcy.court", 
+                "us:c9:wa.wd;bankruptcy.court", 
+                "us:c9;bankruptcy.appellate.panel"
+            ], 
+            "name": "Bankruptcy Reporter", 
             "variations": {
-                "B. R.": "B.R.",
+                "B. R.": "B.R.", 
                 "BR": "B.R."
             }
         }
-    ],
+    ], 
     "B.T.A.": [
         {
-            "cite_type": "specialty",
+            "cite_type": "specialty", 
             "editions": {
                 "B.T.A.": {
-                    "end": "1942-12-31T00:00:00",
+                    "end": "1942-12-31T00:00:00", 
                     "start": "1924-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;tax.court"
-            ],
-            "name": "Reports of the United States Board of Tax Appeals",
+                "us:c;tax.court"
+            ], 
+            "name": "Reports of the United States Board of Tax Appeals", 
             "variations": {}
         }
-    ],
+    ], 
     "B.T.A.M. (P-H)": [
         {
-            "cite_type": "specialty",
+            "cite_type": "specialty", 
             "editions": {
                 "B.T.A.M. (P-H)": {
-                    "end": "1942-12-31T00:00:00",
+                    "end": "1942-12-31T00:00:00", 
                     "start": "1928-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;tax.court"
-            ],
-            "name": "Board of Tax Appeals Memorandum Decisions",
+                "us:c;tax.court"
+            ], 
+            "name": "Board of Tax Appeals Memorandum Decisions", 
             "variations": {}
         }
-    ],
+    ], 
     "Bail.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Bail.": {
-                    "end": "1832-12-31T00:00:00",
+                    "end": "1832-12-31T00:00:00", 
                     "start": "1828-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Bailey",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Bailey", 
             "variations": {
-                "Bai.": "Bail.",
-                "Bail.L.": "Bail.",
-                "Bail.L.(S.C.)": "Bail.",
-                "Bailey": "Bail.",
+                "Bai.": "Bail.", 
+                "Bail.L.": "Bail.", 
+                "Bail.L.(S.C.)": "Bail.", 
+                "Bailey": "Bail.", 
                 "S.C.L.(Bail.)": "Bail."
             }
         }
-    ],
+    ], 
     "Bail. Eq.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Bail. Eq.": {
-                    "end": "1831-12-31T00:00:00",
+                    "end": "1831-12-31T00:00:00", 
                     "start": "1830-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Bailey's Equity",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Bailey's Equity", 
             "variations": {
-                "Bai.Eq.": "Bail. Eq.",
-                "Bail.Eq.(S.C.)": "Bail. Eq.",
-                "Bailey": "Bail. Eq.",
-                "Bailey Ch.": "Bail. Eq.",
-                "Bailey Eq.": "Bail. Eq.",
+                "Bai.Eq.": "Bail. Eq.", 
+                "Bail.Eq.(S.C.)": "Bail. Eq.", 
+                "Bailey": "Bail. Eq.", 
+                "Bailey Ch.": "Bail. Eq.", 
+                "Bailey Eq.": "Bail. Eq.", 
                 "S.C.Eq.(Bail.Eq.)": "Bail. Eq."
             }
         }
-    ],
+    ], 
     "Barb.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Barb.": {
-                    "end": "1877-12-31T00:00:00",
+                    "end": "1877-12-31T00:00:00", 
                     "start": "1847-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Barbour's Supreme Court Reports",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Barbour's Supreme Court Reports", 
             "variations": {
-                "B.": "Barb.",
+                "B.": "Barb.", 
                 "Barb.S.C.": "Barb."
             }
         }
-    ],
+    ], 
     "Barb. Ch.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Barb. Ch.": {
-                    "end": "1848-12-31T00:00:00",
+                    "end": "1848-12-31T00:00:00", 
                     "start": "1845-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Barbour's Chancery Reports",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Barbour's Chancery Reports", 
             "variations": {
                 "Barb.Ch.(N.Y.)": "Barb. Ch."
             }
         }
-    ],
+    ], 
     "Bay": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Bay": {
-                    "end": "1804-12-31T00:00:00",
+                    "end": "1804-12-31T00:00:00", 
                     "start": "1783-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Bay",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Bay", 
             "variations": {
                 "S.C.L.(Bay)": "Bay"
             }
         }
-    ],
+    ], 
     "Bibb": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Bibb": {
-                    "end": "1817-12-31T00:00:00",
+                    "end": "1817-12-31T00:00:00", 
                     "start": "1808-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ky;supreme.court"
-            ],
-            "name": "Kentucky Reports, Bibb",
+                "us:ky;supreme.court"
+            ], 
+            "name": "Kentucky Reports, Bibb", 
             "variations": {
-                "Bibb(Ky.)": "Bibb",
+                "Bibb(Ky.)": "Bibb", 
                 "Ky.(Bibb)": "Bibb"
             }
         }
-    ],
+    ], 
     "Binn.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Binn.": {
-                    "end": "1814-12-31T00:00:00",
+                    "end": "1814-12-31T00:00:00", 
                     "start": "1799-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;pa;supreme.court"
-            ],
-            "name": "Pennsylvania State Reports, Binney",
+                "us:pa;supreme.court"
+            ], 
+            "name": "Pennsylvania State Reports, Binney", 
             "variations": {
-                "Bin.": "Binn.",
+                "Bin.": "Binn.", 
                 "Binn.(Pa.)": "Binn."
             }
         }
-    ],
+    ], 
     "Black": [
         {
-            "cite_type": "scotus_early",
+            "cite_type": "scotus_early", 
             "editions": {
                 "Black": {
-                    "end": "1862-12-31T00:00:00",
+                    "end": "1862-12-31T00:00:00", 
                     "start": "1861-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;supreme.court"
-            ],
-            "name": "Black's Supreme Court Reports",
+                "us;supreme.court"
+            ], 
+            "name": "Black's Supreme Court Reports", 
             "variations": {
-                "Black R.": "Black",
+                "Black R.": "Black", 
                 "U.S.(Black)": "Black"
             }
         }
-    ],
+    ], 
     "Blackf.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Blackf.": {
-                    "end": "1847-12-31T00:00:00",
+                    "end": "1847-12-31T00:00:00", 
                     "start": "1817-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;in;supreme.court"
-            ],
-            "name": "Indiana Reports, Blackford",
+                "us:in;supreme.court"
+            ], 
+            "name": "Indiana Reports, Blackford", 
             "variations": {
-                "Black.": "Blackf.",
+                "Black.": "Blackf.", 
                 "Blackf.(Ind.)": "Blackf."
             }
         }
-    ],
+    ], 
     "Blume Sup. Ct. Trans.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Blume Sup. Ct. Trans.": {
-                    "end": "1836-12-31T00:00:00",
+                    "end": "1836-12-31T00:00:00", 
                     "start": "1805-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;mi;supreme.court"
-            ],
-            "name": "Blume, Supreme Court Transactions",
+                "us:mi;supreme.court"
+            ], 
+            "name": "Blume, Supreme Court Transactions", 
             "variations": {
                 "Blume Sup.Ct.Trans.": "Blume Sup. Ct. Trans."
             }
         }
-    ],
+    ], 
     "Blume Unrep. Op.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Blume Unrep. Op.": {
-                    "end": "1843-12-31T00:00:00",
+                    "end": "1843-12-31T00:00:00", 
                     "start": "1836-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;mi;supreme.court"
-            ],
-            "name": "Blume, Unreported Opinions",
+                "us:mi;supreme.court"
+            ], 
+            "name": "Blume, Unreported Opinions", 
             "variations": {
                 "Blume Op.": "Blume Unrep. Op."
             }
         }
-    ],
+    ], 
     "Boyce": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Boyce": {
-                    "end": "1920-12-31T00:00:00",
+                    "end": "1920-12-31T00:00:00", 
                     "start": "1909-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;de;supreme.court"
-            ],
-            "name": "Delaware Reports, Boyce",
+                "us:de;supreme.court"
+            ], 
+            "name": "Delaware Reports, Boyce", 
             "variations": {
                 "Del.(Boyce)": "Boyce"
             }
         }
-    ],
+    ], 
     "Bradf.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Bradf.": {
-                    "end": "1841-12-31T00:00:00",
+                    "end": "1841-12-31T00:00:00", 
                     "start": "1838-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ia;supreme.court"
-            ],
-            "name": "Iowa Reports, Bradford",
+                "us:ia;supreme.court"
+            ], 
+            "name": "Iowa Reports, Bradford", 
             "variations": {
-                "Brad.": "Bradf.",
+                "Brad.": "Bradf.", 
                 "Bradford": "Bradf."
             }
         }
-    ],
+    ], 
     "Brayt.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Brayt.": {
-                    "end": "1819-12-31T00:00:00",
+                    "end": "1819-12-31T00:00:00", 
                     "start": "1815-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;vt;supreme.court"
-            ],
-            "name": "Vermont Reports, Brayton",
+                "us:vt;supreme.court"
+            ], 
+            "name": "Vermont Reports, Brayton", 
             "variations": {
                 "Brayton (Vt.)": "Brayt."
             }
         }
-    ],
+    ], 
     "Breese": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Breese": {
-                    "end": "1831-12-31T00:00:00",
+                    "end": "1831-12-31T00:00:00", 
                     "start": "1819-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;il;supreme.court"
-            ],
-            "name": "Illinois Reports, Breese",
+                "us:il;supreme.court"
+            ], 
+            "name": "Illinois Reports, Breese", 
             "variations": {
                 "Ill.(Breese)": "Breese"
             }
         }
-    ],
+    ], 
     "Brev.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Brev.": {
-                    "end": "1816-12-31T00:00:00",
+                    "end": "1816-12-31T00:00:00", 
                     "start": "1793-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Brevard",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Brevard", 
             "variations": {
                 "S.C.L.(Brev)": "Brev."
             }
         }
-    ],
+    ], 
     "Brief Times Rptr.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Brief Times Rptr.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;co;supreme.court"
-            ],
-            "name": "Brief Times Reporter",
+                "us:co;supreme.court"
+            ], 
+            "name": "Brief Times Reporter", 
             "variations": {}
         }
-    ],
+    ], 
     "Bur.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Bur.": {
-                    "end": "1843-12-31T00:00:00",
+                    "end": "1843-12-31T00:00:00", 
                     "start": "1841-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;wi;supreme.court"
-            ],
-            "name": "Wisconsin Reports, Burnett",
+                "us:wi;supreme.court"
+            ], 
+            "name": "Wisconsin Reports, Burnett", 
             "variations": {
-                "Burnett": "Bur.",
+                "Burnett": "Bur.", 
                 "Burnett (Wis.)": "Bur."
             }
         }
-    ],
+    ], 
     "Busb.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Busb.": {
-                    "end": "1853-12-31T00:00:00",
+                    "end": "1853-12-31T00:00:00", 
                     "start": "1852-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nc;supreme.court"
-            ],
-            "name": "North Carolina Reports, Busbee's Law",
+                "us:nc;supreme.court"
+            ], 
+            "name": "North Carolina Reports, Busbee's Law", 
             "variations": {
-                "Busb.L.": "Busb.",
+                "Busb.L.": "Busb.", 
                 "N.C.(Busb.)": "Busb."
             }
         }
-    ],
+    ], 
     "Busb. Eq.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Busb. Eq.": {
-                    "end": "1853-12-31T00:00:00",
+                    "end": "1853-12-31T00:00:00", 
                     "start": "1852-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nc;supreme.court"
-            ],
-            "name": "North Carolina Reports, Busbee's Equity",
+                "us:nc;supreme.court"
+            ], 
+            "name": "North Carolina Reports, Busbee's Equity", 
             "variations": {
-                "Busbee Eq.(N.C.)": "Busb. Eq.",
+                "Busbee Eq.(N.C.)": "Busb. Eq.", 
                 "N.C.(Busb.Eq.)": "Busb. Eq."
             }
         }
-    ],
+    ], 
     "Bush": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Bush": {
-                    "end": "1879-12-31T00:00:00",
+                    "end": "1879-12-31T00:00:00", 
                     "start": "1866-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ky;supreme.court"
-            ],
-            "name": "Kentucky Reports, Bush",
+                "us:ky;supreme.court"
+            ], 
+            "name": "Kentucky Reports, Bush", 
             "variations": {
-                "Bush (Ky.)": "Bush",
+                "Bush (Ky.)": "Bush", 
                 "Ky.(Bush)": "Bush"
             }
         }
-    ],
+    ], 
     "C.C.P.A.": [
         {
-            "cite_type": "specialty",
+            "cite_type": "specialty", 
             "editions": {
                 "C.C.P.A.": {
-                    "end": "1982-12-31T00:00:00",
+                    "end": "1982-12-31T00:00:00", 
                     "start": "1929-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;court.customs.patent.appeals"
-            ],
-            "name": "Court of Customs and Patent Appeals Reports",
+                "us:c;court.customs.patent.appeals"
+            ], 
+            "name": "Court of Customs and Patent Appeals Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "C.M.A.": [
         {
-            "cite_type": "specialty",
+            "cite_type": "specialty", 
             "editions": {
                 "C.M.A.": {
-                    "end": "1975-12-31T00:00:00",
+                    "end": "1975-12-31T00:00:00", 
                     "start": "1951-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;court.appeals.armed.forces"
-            ],
-            "name": "Decisions of the United States Court of Military Appeals",
+                "us:c;court.appeals.armed.forces"
+            ], 
+            "name": "Decisions of the United States Court of Military Appeals", 
             "variations": {}
         }
-    ],
+    ], 
     "C.M.R.": [
         {
-            "cite_type": "specialty",
+            "cite_type": "specialty", 
             "editions": {
                 "C.M.R.": {
-                    "end": "1975-12-31T00:00:00",
+                    "end": "1975-12-31T00:00:00", 
                     "start": "1951-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;courts.martial"
-            ],
-            "name": "Court Martial Records",
+                "us:c;courts.martial"
+            ], 
+            "name": "Court Martial Records", 
             "variations": {}
         }
-    ],
+    ], 
     "CO": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "CO": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;co;supreme.court"
-            ],
-            "name": "Colorado Neutral Citation",
+                "us:co;supreme.court"
+            ], 
+            "name": "Colorado Neutral Citation", 
             "variations": {}
         }
-    ],
+    ], 
     "COA": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "COA": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;co;supreme.court"
-            ],
-            "name": "Colorado Court of Appeals Neutral Citation",
+                "us:co;court.appeals"
+            ], 
+            "name": "Colorado Court of Appeals Neutral Citation", 
             "variations": {}
         }
-    ],
+    ], 
     "Cai. Cas.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Cai. Cas.": {
-                    "end": "1805-12-31T00:00:00",
+                    "end": "1805-12-31T00:00:00", 
                     "start": "1796-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Caines' Cases",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Caines' Cases", 
             "variations": {
-                "Cai.": "Cai. Cas.",
-                "Cai.Cas.Err.": "Cai. Cas.",
-                "Cain.": "Cai. Cas.",
-                "Caines": "Cai. Cas.",
-                "Caines (N.Y.)": "Cai. Cas.",
-                "Caines Cas.": "Cai. Cas.",
+                "Cai.": "Cai. Cas.", 
+                "Cai.Cas.Err.": "Cai. Cas.", 
+                "Cain.": "Cai. Cas.", 
+                "Caines": "Cai. Cas.", 
+                "Caines (N.Y.)": "Cai. Cas.", 
+                "Caines Cas.": "Cai. Cas.", 
                 "N.Y.Cas.Err.": "Cai. Cas."
             }
         }
-    ],
+    ], 
     "Cai. R.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Cai. R.": {
-                    "end": "1805-12-31T00:00:00",
+                    "end": "1805-12-31T00:00:00", 
                     "start": "1803-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Caines' Reports",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Caines' Reports", 
             "variations": {
                 "Cai.R.": "Cai. R."
             }
         }
-    ],
+    ], 
     "Cal.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Cal.": {
-                    "end": "1934-12-31T00:00:00",
+                    "end": "1934-12-31T00:00:00", 
                     "start": "1850-01-01T00:00:00"
-                },
+                }, 
                 "Cal. 2d": {
-                    "end": "1969-12-31T00:00:00",
+                    "end": "1969-12-31T00:00:00", 
                     "start": "1934-01-01T00:00:00"
-                },
+                }, 
                 "Cal. 3d": {
-                    "end": "1991-12-31T00:00:00",
+                    "end": "1991-12-31T00:00:00", 
                     "start": "1969-01-01T00:00:00"
-                },
+                }, 
                 "Cal. 4th": {
-                    "end": null,
+                    "end": null, 
                     "start": "1991-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ca;supreme.court"
-            ],
-            "name": "California Reports",
+                "us:ca;supreme.court"
+            ], 
+            "name": "California Reports", 
             "variations": {
-                "Cal.2d": "Cal. 2d",
-                "Cal.3d": "Cal. 3d",
+                "Cal.2d": "Cal. 2d", 
+                "Cal.3d": "Cal. 3d", 
                 "Cal.4th": "Cal. 4th"
             }
         }
-    ],
+    ], 
     "Cal. App.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Cal. App.": {
-                    "end": "1934-12-31T00:00:00",
+                    "end": "1934-12-31T00:00:00", 
                     "start": "1905-01-01T00:00:00"
-                },
+                }, 
                 "Cal. App. 2d": {
-                    "end": "1969-12-31T00:00:00",
+                    "end": "1969-12-31T00:00:00", 
                     "start": "1934-01-01T00:00:00"
-                },
+                }, 
                 "Cal. App. 3d": {
-                    "end": "1991-12-31T00:00:00",
+                    "end": "1991-12-31T00:00:00", 
                     "start": "1969-01-01T00:00:00"
-                },
+                }, 
                 "Cal. App. 4th": {
-                    "end": null,
+                    "end": null, 
                     "start": "1991-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ca;supreme.court"
-            ],
-            "name": "California Appellate Reports",
+                "us:ca;supreme.court"
+            ], 
+            "name": "California Appellate Reports", 
             "variations": {
-                "Cal. App.2d": "Cal. App. 2d",
-                "Cal. App.3d": "Cal. App. 3d",
-                "Cal. App.4th": "Cal. App. 4th",
-                "Cal.App.": "Cal. App.",
-                "Cal.App. 2d": "Cal. App. 2d",
-                "Cal.App. 3d": "Cal. App. 3d",
-                "Cal.App. 4th": "Cal. App. 4th",
-                "Cal.App.2d": "Cal. App. 2d",
-                "Cal.App.3d": "Cal. App. 3d",
+                "Cal. App.2d": "Cal. App. 2d", 
+                "Cal. App.3d": "Cal. App. 3d", 
+                "Cal. App.4th": "Cal. App. 4th", 
+                "Cal.App.": "Cal. App.", 
+                "Cal.App. 2d": "Cal. App. 2d", 
+                "Cal.App. 3d": "Cal. App. 3d", 
+                "Cal.App. 4th": "Cal. App. 4th", 
+                "Cal.App.2d": "Cal. App. 2d", 
+                "Cal.App.3d": "Cal. App. 3d", 
                 "Cal.App.4th": "Cal. App. 4th"
             }
         }
-    ],
+    ], 
     "Cal. App. Supp.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Cal. App. Supp.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1929-01-01T00:00:00"
-                },
+                }, 
                 "Cal. App. Supp. 2d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1929-01-01T00:00:00"
-                },
+                }, 
                 "Cal. App. Supp. 3d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1929-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ca;supreme.court"
-            ],
-            "name": "California Appellate Reports, Supplement",
+                "us:ca;supreme.court"
+            ], 
+            "name": "California Appellate Reports, Supplement", 
             "variations": {
-                "Cal.App. 2d Supp.": "Cal. App. Supp. 2d",
-                "Cal.App. 3d Supp.": "Cal. App. Supp. 3d",
-                "Cal.App. Supp. 2d": "Cal. App. Supp. 2d",
-                "Cal.App. Supp. 3d": "Cal. App. Supp. 3d",
-                "Cal.App. Supp.2d": "Cal. App. Supp. 2d",
-                "Cal.App. Supp.3d": "Cal. App. Supp. 3d",
-                "Cal.App.2d Supp.": "Cal. App. Supp. 2d",
-                "Cal.App.3d Supp.": "Cal. App. Supp. 3d",
-                "Cal.App.Supp.": "Cal. App. Supp.",
+                "Cal.App. 2d Supp.": "Cal. App. Supp. 2d", 
+                "Cal.App. 3d Supp.": "Cal. App. Supp. 3d", 
+                "Cal.App. Supp. 2d": "Cal. App. Supp. 2d", 
+                "Cal.App. Supp. 3d": "Cal. App. Supp. 3d", 
+                "Cal.App. Supp.2d": "Cal. App. Supp. 2d", 
+                "Cal.App. Supp.3d": "Cal. App. Supp. 3d", 
+                "Cal.App.2d Supp.": "Cal. App. Supp. 2d", 
+                "Cal.App.3d Supp.": "Cal. App. Supp. 3d", 
+                "Cal.App.Supp.": "Cal. App. Supp.", 
                 "Cal.App.Supp.2d": "Cal. App. Supp. 2d"
             }
         }
-    ],
+    ], 
     "Cal. Rptr.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Cal. Rptr.": {
-                    "end": "1991-12-31T00:00:00",
+                    "end": "1991-12-31T00:00:00", 
                     "start": "1959-01-01T00:00:00"
-                },
+                }, 
                 "Cal. Rptr. 2d": {
-                    "end": "2003-12-31T00:00:00",
+                    "end": "2003-12-31T00:00:00", 
                     "start": "1992-01-01T00:00:00"
-                },
+                }, 
                 "Cal. Rptr. 3d": {
-                    "end": null,
+                    "end": null, 
                     "start": "2003-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ca;supreme.court"
-            ],
-            "name": "West's California Reporter",
+                "us:ca;supreme.court"
+            ], 
+            "name": "West's California Reporter", 
             "variations": {
-                "Cal. Rptr.2d": "Cal. Rptr. 2d",
-                "Cal. Rptr.3d": "Cal. Rptr. 3d",
-                "Cal.Rptr.": "Cal. Rptr.",
-                "Cal.Rptr. 2d": "Cal. Rptr. 2d",
-                "Cal.Rptr. 3d": "Cal. Rptr. 3d",
-                "Cal.Rptr.2d": "Cal. Rptr. 2d",
+                "Cal. Rptr.2d": "Cal. Rptr. 2d", 
+                "Cal. Rptr.3d": "Cal. Rptr. 3d", 
+                "Cal.Rptr.": "Cal. Rptr.", 
+                "Cal.Rptr. 2d": "Cal. Rptr. 2d", 
+                "Cal.Rptr. 3d": "Cal. Rptr. 3d", 
+                "Cal.Rptr.2d": "Cal. Rptr. 2d", 
                 "Cal.Rptr.3d": "Cal. Rptr. 3d"
             }
         }
-    ],
+    ], 
     "Cal. Unrep.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Cal. Unrep.": {
-                    "end": "1910-12-31T00:00:00",
+                    "end": "1910-12-31T00:00:00", 
                     "start": "1855-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ca;supreme.court"
-            ],
-            "name": "California Unreported Cases",
+                "us:ca;supreme.court"
+            ], 
+            "name": "California Unreported Cases", 
             "variations": {
                 "Cal.Unrep.Cas.": "Cal. Unrep."
             }
         }
-    ],
+    ], 
     "Call": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Call": {
-                    "end": "1825-12-31T00:00:00",
+                    "end": "1825-12-31T00:00:00", 
                     "start": "1779-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;va;supreme.court"
-            ],
-            "name": "Virginia Reports, Call",
+                "us:va;supreme.court"
+            ], 
+            "name": "Virginia Reports, Call", 
             "variations": {
-                "Call (Va.)": "Call",
+                "Call (Va.)": "Call", 
                 "Va.(Call)": "Call"
             }
         }
-    ],
+    ], 
     "Cam. & Nor.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Cam. & Nor.": {
-                    "end": "1804-12-31T00:00:00",
+                    "end": "1804-12-31T00:00:00", 
                     "start": "1800-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nc;supreme.court"
-            ],
-            "name": "North Carolina Reports, Conference by Cameron & Norwood",
+                "us:nc;supreme.court"
+            ], 
+            "name": "North Carolina Reports, Conference by Cameron & Norwood", 
             "variations": {
-                "Cam.& N.": "Cam. & Nor.",
-                "N.C.(Cam.& Nor.)": "Cam. & Nor.",
-                "N.C.Conf.": "Cam. & Nor.",
+                "Cam.& N.": "Cam. & Nor.", 
+                "N.C.(Cam.& Nor.)": "Cam. & Nor.", 
+                "N.C.Conf.": "Cam. & Nor.", 
                 "N.C.Conf.Rep.": "Cam. & Nor."
             }
         }
-    ],
+    ], 
     "Car. L. Rep.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Car. L. Rep.": {
-                    "end": "1816-12-31T00:00:00",
+                    "end": "1816-12-31T00:00:00", 
                     "start": "1811-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nc;supreme.court"
-            ],
-            "name": "Carolina Law Repository",
+                "us:nc;supreme.court"
+            ], 
+            "name": "Carolina Law Repository", 
             "variations": {
-                "Car.Law.Repos.": "Car. L. Rep.",
+                "Car.Law.Repos.": "Car. L. Rep.", 
                 "N.C.(Car.L.Rep.)": "Car. L. Rep."
             }
         }
-    ],
+    ], 
     "Chand.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Chand.": {
-                    "end": "1852-12-31T00:00:00",
+                    "end": "1852-12-31T00:00:00", 
                     "start": "1849-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;wi;supreme.court"
-            ],
-            "name": "Wisconsin Reports, Chandler",
+                "us:wi;supreme.court"
+            ], 
+            "name": "Wisconsin Reports, Chandler", 
             "variations": {
-                "Chand.(Wis.)": "Chand.",
+                "Chand.(Wis.)": "Chand.", 
                 "Chandl.": "Chand."
             }
         }
-    ],
+    ], 
     "Chev.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Chev.": {
-                    "end": "1840-12-31T00:00:00",
+                    "end": "1840-12-31T00:00:00", 
                     "start": "1839-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Cheves",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Cheves", 
             "variations": {
-                "Cheves": "Chev.",
-                "Cheves L.(S.C.)": "Chev.",
+                "Cheves": "Chev.", 
+                "Cheves L.(S.C.)": "Chev.", 
                 "S.C.L.(Chev.)": "Chev."
             }
         }
-    ],
+    ], 
     "Chev. Eq.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Chev. Eq.": {
-                    "end": "1840-12-31T00:00:00",
+                    "end": "1840-12-31T00:00:00", 
                     "start": "1839-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Cheves' Equity",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Cheves' Equity", 
             "variations": {
-                "Chev.Ch.": "Chev. Eq.",
-                "Cheves Eq.(S.C.)": "Chev. Eq.",
+                "Chev.Ch.": "Chev. Eq.", 
+                "Cheves Eq.(S.C.)": "Chev. Eq.", 
                 "S.C.Eq.(Chev.Eq.)": "Chev. Eq."
             }
         }
-    ],
+    ], 
     "Cl. Ch.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Cl. Ch.": {
-                    "end": "1841-12-31T00:00:00",
+                    "end": "1841-12-31T00:00:00", 
                     "start": "1839-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Clarke's Chancery Reports",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Clarke's Chancery Reports", 
             "variations": {
-                "Cl.R.": "Cl. Ch.",
-                "Clarke": "Cl. Ch.",
-                "Clarke Ch.": "Cl. Ch.",
+                "Cl.R.": "Cl. Ch.", 
+                "Clarke": "Cl. Ch.", 
+                "Clarke Ch.": "Cl. Ch.", 
                 "Clarke Ch.(N.Y.)": "Cl. Ch."
             }
         }
-    ],
+    ], 
     "Cl. Ct.": [
         {
-            "cite_type": "specialty",
+            "cite_type": "specialty", 
             "editions": {
                 "Cl. Ct.": {
-                    "end": "1992-12-31T00:00:00",
+                    "end": "1992-12-31T00:00:00", 
                     "start": "1983-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;court.claims"
-            ],
-            "name": "United States Claims Court Reporter",
+                "us:c;court.claims"
+            ], 
+            "name": "United States Claims Court Reporter", 
             "variations": {}
         }
-    ],
+    ], 
     "Cold.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Cold.": {
-                    "end": "1870-12-31T00:00:00",
+                    "end": "1870-12-31T00:00:00", 
                     "start": "1860-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tn;supreme.court"
-            ],
-            "name": "Tennessee Reports, Coldwell",
+                "us:tn;supreme.court"
+            ], 
+            "name": "Tennessee Reports, Coldwell", 
             "variations": {
-                "Col.": "Cold.",
-                "Coldw.": "Cold.",
+                "Col.": "Cold.", 
+                "Coldw.": "Cold.", 
                 "Tenn.(Cold.)": "Cold."
             }
         }
-    ],
+    ], 
     "Cole. & Cai. Cas.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Cole. & Cai. Cas.": {
-                    "end": "1805-12-31T00:00:00",
+                    "end": "1805-12-31T00:00:00", 
                     "start": "1794-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Coleman & Caines' Cases",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Coleman & Caines' Cases", 
             "variations": {
-                "C.& C.": "Cole. & Cai. Cas.",
-                "Col.& C.Cas.": "Cole. & Cai. Cas.",
-                "Col.& Cai.": "Cole. & Cai. Cas.",
-                "Col.& Caines Cas.(N.Y.)": "Cole. & Cai. Cas.",
-                "Cole.& C.Cas.": "Cole. & Cai. Cas.",
-                "Cole.& Cai.": "Cole. & Cai. Cas.",
+                "C.& C.": "Cole. & Cai. Cas.", 
+                "Col.& C.Cas.": "Cole. & Cai. Cas.", 
+                "Col.& Cai.": "Cole. & Cai. Cas.", 
+                "Col.& Caines Cas.(N.Y.)": "Cole. & Cai. Cas.", 
+                "Cole.& C.Cas.": "Cole. & Cai. Cas.", 
+                "Cole.& Cai.": "Cole. & Cai. Cas.", 
                 "Colem.& C.Cas.": "Cole. & Cai. Cas."
             }
         }
-    ],
+    ], 
     "Cole. Cas.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Cole. Cas.": {
-                    "end": "1800-12-31T00:00:00",
+                    "end": "1800-12-31T00:00:00", 
                     "start": "1791-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Coleman's Cases",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Coleman's Cases", 
             "variations": {
-                "C.C.": "Cole. Cas.",
-                "Col.Cas.": "Cole. Cas.",
-                "Col.Cas.(N.Y.)": "Cole. Cas.",
-                "Cole.Cas.Pr.": "Cole. Cas.",
+                "C.C.": "Cole. Cas.", 
+                "Col.Cas.": "Cole. Cas.", 
+                "Col.Cas.(N.Y.)": "Cole. Cas.", 
+                "Cole.Cas.Pr.": "Cole. Cas.", 
                 "Colem.Cas.": "Cole. Cas."
             }
         }
-    ],
+    ], 
     "Colo.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Colo.": {
-                    "end": "1980-12-31T00:00:00",
+                    "end": "1980-12-31T00:00:00", 
                     "start": "1864-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;co;supreme.court"
-            ],
-            "name": "Colorado Reports",
+                "us:co;supreme.court"
+            ], 
+            "name": "Colorado Reports", 
             "variations": {
                 "Col.": "Colo."
             }
         }
-    ],
+    ], 
     "Colo. Law.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Colo. Law.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;co;supreme.court"
-            ],
-            "name": "Colorado Lawyer",
+                "us:co;supreme.court"
+            ], 
+            "name": "Colorado Lawyer", 
             "variations": {
                 "Colorado Law.": "Colo. Law."
             }
         }
-    ],
+    ], 
     "Conn.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Conn.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1814-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ct;supreme.court"
-            ],
-            "name": "Connecticut Reports",
+                "us:ct;supreme.court"
+            ], 
+            "name": "Connecticut Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Conn. App.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Conn. App.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1983-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ct;supreme.court"
-            ],
-            "name": "Connecticut Appellate Reports",
+                "us:ct;supreme.court"
+            ], 
+            "name": "Connecticut Appellate Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Conn. Cir. Ct": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Conn. Cir. Ct": {
-                    "end": "1974-12-31T00:00:00",
+                    "end": "1974-12-31T00:00:00", 
                     "start": "1961-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ct;supreme.court"
-            ],
-            "name": "Connecticut Circuit Court Reports",
+                "us:ct;supreme.court"
+            ], 
+            "name": "Connecticut Circuit Court Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Conn. L. Rptr.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Conn. L. Rptr.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1990-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ct;supreme.court"
-            ],
-            "name": "Connecticut Law Reporter",
+                "us:ct;supreme.court"
+            ], 
+            "name": "Connecticut Law Reporter", 
             "variations": {}
         }
-    ],
+    ], 
     "Conn. Super. Ct.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Conn. Super. Ct.": {
-                    "end": "1994-12-31T00:00:00",
+                    "end": "1994-12-31T00:00:00", 
                     "start": "1986-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ct;supreme.court"
-            ],
-            "name": "Connecticut Superior Court Reports",
+                "us:ct;supreme.court"
+            ], 
+            "name": "Connecticut Superior Court Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Conn. Supp.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Conn. Supp.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1935-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ct;supreme.court"
-            ],
-            "name": "Connecticut Supplement",
+                "us:ct;supreme.court"
+            ], 
+            "name": "Connecticut Supplement", 
             "variations": {}
         }
-    ],
+    ], 
     "Cooke": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Cooke": {
-                    "end": "1814-12-31T00:00:00",
+                    "end": "1814-12-31T00:00:00", 
                     "start": "1811-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tn;supreme.court"
-            ],
-            "name": "Tennessee Reports, Cooke",
+                "us:tn;supreme.court"
+            ], 
+            "name": "Tennessee Reports, Cooke", 
             "variations": {
-                "Cooke (Tenn.)": "Cooke",
+                "Cooke (Tenn.)": "Cooke", 
                 "Tenn.(Cooke)": "Cooke"
             }
         }
-    ],
+    ], 
     "Cow.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Cow.": {
-                    "end": "1829-12-31T00:00:00",
+                    "end": "1829-12-31T00:00:00", 
                     "start": "1823-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Cowen's Reports",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Cowen's Reports", 
             "variations": {
-                "C.": "Cow.",
+                "C.": "Cow.", 
                 "Cow.N.Y.": "Cow."
             }
         }
-    ],
+    ], 
     "Cranch": [
         {
-            "cite_type": "scotus_early",
+            "cite_type": "scotus_early", 
             "editions": {
                 "Cranch": {
-                    "end": "1815-12-31T00:00:00",
+                    "end": "1815-12-31T00:00:00", 
                     "start": "1801-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;supreme.court"
-            ],
-            "name": "Cranch's Supreme Court Reports",
+                "us;supreme.court"
+            ], 
+            "name": "Cranch's Supreme Court Reports", 
             "variations": {
-                "Cr.": "Cranch",
-                "Cra.": "Cranch",
-                "Cranch (US)": "Cranch",
+                "Cr.": "Cranch", 
+                "Cra.": "Cranch", 
+                "Cranch (US)": "Cranch", 
                 "U.S.(Cranch)": "Cranch"
             }
-        },
+        }, 
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Cranch": {
-                    "end": "1841-12-31T00:00:00",
+                    "end": "1841-12-31T00:00:00", 
                     "start": "1801-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;district.columbia.court.appeals"
-            ],
-            "name": "District of Columbia Reports, Cranch",
+                "us:dc;court.appeals"
+            ], 
+            "name": "District of Columbia Reports, Cranch", 
             "variations": {
-                "Cranch C.C.": "Cranch",
-                "Cranch D.C.": "Cranch",
+                "Cranch C.C.": "Cranch", 
+                "Cranch D.C.": "Cranch", 
                 "D.C.(Cranch)": "Cranch"
             }
         }
-    ],
+    ], 
     "Ct. Cl.": [
         {
-            "cite_type": "specialty",
+            "cite_type": "specialty", 
             "editions": {
                 "Ct. Cl.": {
-                    "end": "1982-12-31T00:00:00",
+                    "end": "1982-12-31T00:00:00", 
                     "start": "1863-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;court.claims"
-            ],
-            "name": "Court of Claims Reports",
+                "us:c;court.claims"
+            ], 
+            "name": "Court of Claims Reports", 
             "variations": {
-                "Court Cl.": "Ct. Cl.",
+                "Court Cl.": "Ct. Cl.", 
                 "Ct.Cl.": "Ct. Cl."
             }
         }
-    ],
+    ], 
     "Ct. Cust.": [
         {
-            "cite_type": "specialty",
+            "cite_type": "specialty", 
             "editions": {
                 "Ct. Cust.": {
-                    "end": "1929-12-31T00:00:00",
+                    "end": "1929-12-31T00:00:00", 
                     "start": "1910-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;court.customs.appeals"
-            ],
-            "name": "Court of Customs Appeals Reports",
+                "us:c;court.customs.appeals"
+            ], 
+            "name": "Court of Customs Appeals Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Ct. Int'l Trade": [
         {
-            "cite_type": "federal",
+            "cite_type": "federal", 
             "editions": {
                 "Ct. Int'l Trade": {
-                    "end": null,
+                    "end": null, 
                     "start": "1980-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;court.international.trade"
-            ],
-            "name": "Court of International Trade Reports",
+                "us:c;court.international.trade"
+            ], 
+            "name": "Court of International Trade Reports", 
             "variations": {
                 "Ct.Int'l Trade": "Ct. Int'l Trade"
             }
         }
-    ],
+    ], 
     "Cush.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Cush.": {
-                    "end": "1853-12-31T00:00:00",
+                    "end": "1853-12-31T00:00:00", 
                     "start": "1848-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ma;appeals.court"
-            ],
-            "name": "Massachusetts Reports, Cushing",
+                "us:ma;appeals.court"
+            ], 
+            "name": "Massachusetts Reports, Cushing", 
             "variations": {
-                "Cush.(Mass.)": "Cush.",
-                "Cushing": "Cush.",
+                "Cush.(Mass.)": "Cush.", 
+                "Cushing": "Cush.", 
                 "Mass.(Cush.)": "Cush."
             }
         }
-    ],
+    ], 
     "Cust. B. & Dec.": [
         {
-            "cite_type": "federal",
+            "cite_type": "federal", 
             "editions": {
                 "Cust. B. & Dec.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1967-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;court.appeals.federal.circuit"
-            ],
-            "name": "Customs Bulletin and Decisions",
+                "us:c;court.appeals.federal.circuit"
+            ], 
+            "name": "Customs Bulletin and Decisions", 
             "variations": {}
         }
-    ],
+    ], 
     "Cust. Ct.": [
         {
-            "cite_type": "federal",
+            "cite_type": "federal", 
             "editions": {
                 "Cust. Ct.": {
-                    "end": "1980-12-31T00:00:00",
+                    "end": "1980-12-31T00:00:00", 
                     "start": "1938-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;customs.court"
-            ],
-            "name": "Customs Court Reports",
+                "us:c;customs.court"
+            ], 
+            "name": "Customs Court Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "D. Chip.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "D. Chip.": {
-                    "end": "1824-12-31T00:00:00",
+                    "end": "1824-12-31T00:00:00", 
                     "start": "1789-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;vt;supreme.court"
-            ],
-            "name": "Vermont Reports, Chipman, D.",
+                "us:vt;supreme.court"
+            ], 
+            "name": "Vermont Reports, Chipman, D.", 
             "variations": {
-                "Chip.": "D. Chip.",
-                "Chip.(Vt.)": "D. Chip.",
-                "Chip.D.": "D. Chip.",
-                "D.Chip.(Vt.)": "D. Chip.",
+                "Chip.": "D. Chip.", 
+                "Chip.(Vt.)": "D. Chip.", 
+                "Chip.D.": "D. Chip.", 
+                "D.Chip.(Vt.)": "D. Chip.", 
                 "D.Chipm.": "D. Chip."
             }
         }
-    ],
+    ], 
     "Dakota": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Dakota": {
-                    "end": "1889-12-31T00:00:00",
+                    "end": "1889-12-31T00:00:00", 
                     "start": "1867-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nd;supreme.court"
-            ],
-            "name": "Dakota Reports",
+                "us:nd;supreme.court"
+            ], 
+            "name": "Dakota Reports", 
             "variations": {
                 "Dak.": "Dakota"
             }
         }
-    ],
+    ], 
     "Dall.": [
         {
-            "cite_type": "scotus_early",
+            "cite_type": "scotus_early", 
             "editions": {
                 "Dall.": {
-                    "end": "1880-12-31T00:00:00",
+                    "end": "1880-12-31T00:00:00", 
                     "start": "1790-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;supreme.court"
-            ],
-            "name": "Dallas' Supreme Court Reports",
+                "us;supreme.court"
+            ], 
+            "name": "Dallas' Supreme Court Reports", 
             "variations": {
-                "Dal.": "Dall.",
-                "Dall.S.C.": "Dall.",
-                "Dallas": "Dall.",
+                "Dal.": "Dall.", 
+                "Dall.S.C.": "Dall.", 
+                "Dallas": "Dall.", 
                 "U.S.(Dall.)": "Dall."
             }
-        },
+        }, 
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Dall.": {
-                    "end": "1806-12-31T00:00:00",
+                    "end": "1806-12-31T00:00:00", 
                     "start": "1754-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;pa;supreme.court"
-            ],
-            "name": "Pennsylvania State Reports, Dallas",
+                "us:pa;supreme.court"
+            ], 
+            "name": "Pennsylvania State Reports, Dallas", 
             "variations": {
-                "D.": "Dall.",
-                "Dal.": "Dall.",
+                "D.": "Dall.", 
+                "Dal.": "Dall.", 
                 "Dallas": "Dall."
             }
         }
-    ],
+    ], 
     "Dallam": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Dallam": {
-                    "end": "1844-12-31T00:00:00",
+                    "end": "1844-12-31T00:00:00", 
                     "start": "1840-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tx;supreme.court"
-            ],
-            "name": "Digest of the Laws of Texas (Dallam's Opinions)",
+                "us:tx;supreme.court"
+            ], 
+            "name": "Digest of the Laws of Texas (Dallam's Opinions)", 
             "variations": {
-                "Dall.(Tex.)": "Dallam",
-                "Dall.Dig.": "Dallam",
+                "Dall.(Tex.)": "Dallam", 
+                "Dall.Dig.": "Dallam", 
                 "Dallam Dig.(Tex.)": "Dallam"
             }
         }
-    ],
+    ], 
     "Dana": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Dana": {
-                    "end": "1840-12-31T00:00:00",
+                    "end": "1840-12-31T00:00:00", 
                     "start": "1833-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ky;supreme.court"
-            ],
-            "name": "Kentucky Reports, Dana",
+                "us:ky;supreme.court"
+            ], 
+            "name": "Kentucky Reports, Dana", 
             "variations": {
-                "Dan.": "Dana",
+                "Dan.": "Dana", 
                 "Ky.(Dana)": "Dana"
             }
         }
-    ],
+    ], 
     "Day": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Day": {
-                    "end": "1813-12-31T00:00:00",
+                    "end": "1813-12-31T00:00:00", 
                     "start": "1802-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ct;supreme.court"
-            ],
-            "name": "Day's Connecticut Reports",
+                "us:ct;supreme.court"
+            ], 
+            "name": "Day's Connecticut Reports", 
             "variations": {
                 "Day (Conn)": "Day"
             }
         }
-    ],
+    ], 
     "Del.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Del.": {
-                    "end": "1966-12-31T00:00:00",
+                    "end": "1966-12-31T00:00:00", 
                     "start": "1920-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;de;supreme.court"
-            ],
-            "name": "Delaware Reports",
+                "us:de;supreme.court"
+            ], 
+            "name": "Delaware Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Del. Cas.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Del. Cas.": {
-                    "end": "1830-12-31T00:00:00",
+                    "end": "1830-12-31T00:00:00", 
                     "start": "1792-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;de;supreme.court"
-            ],
-            "name": "Delaware Cases",
+                "us:de;supreme.court"
+            ], 
+            "name": "Delaware Cases", 
             "variations": {}
         }
-    ],
+    ], 
     "Del. Ch.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Del. Ch.": {
-                    "end": "1968-12-31T00:00:00",
+                    "end": "1968-12-31T00:00:00", 
                     "start": "1814-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;de;supreme.court"
-            ],
-            "name": "Delaware Chancery Reports",
+                "us:de;supreme.court"
+            ], 
+            "name": "Delaware Chancery Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Denio": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Denio": {
-                    "end": "1848-12-31T00:00:00",
+                    "end": "1848-12-31T00:00:00", 
                     "start": "1845-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Denio's Reports",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Denio's Reports", 
             "variations": {
                 "Den.": "Denio"
             }
         }
-    ],
+    ], 
     "Des.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Des.": {
-                    "end": "1817-12-31T00:00:00",
+                    "end": "1817-12-31T00:00:00", 
                     "start": "1784-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Desaussure's Equity",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Desaussure's Equity", 
             "variations": {
-                "Desaus.": "Des.",
-                "Desaus.Eq.": "Des.",
+                "Desaus.": "Des.", 
+                "Desaus.Eq.": "Des.", 
                 "S.C.Eq.(Des.)": "Des."
             }
         }
-    ],
+    ], 
     "Dev.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Dev.": {
-                    "end": "1834-12-31T00:00:00",
+                    "end": "1834-12-31T00:00:00", 
                     "start": "1826-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nc;supreme.court"
-            ],
-            "name": "North Carolina Reports, Devereux's Law",
+                "us:nc;supreme.court"
+            ], 
+            "name": "North Carolina Reports, Devereux's Law", 
             "variations": {
-                "Dev.L.": "Dev.",
+                "Dev.L.": "Dev.", 
                 "N.C.(Dev.)": "Dev."
             }
         }
-    ],
+    ], 
     "Dev. & Bat.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Dev. & Bat.": {
-                    "end": "1839-12-31T00:00:00",
+                    "end": "1839-12-31T00:00:00", 
                     "start": "1834-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nc;supreme.court"
-            ],
-            "name": "North Carolina Reports, Devereux & Battle's Law",
+                "us:nc;supreme.court"
+            ], 
+            "name": "North Carolina Reports, Devereux & Battle's Law", 
             "variations": {
-                "D.& B.": "Dev. & Bat.",
-                "Dev.& B.": "Dev. & Bat.",
-                "Dev.& B.L.": "Dev. & Bat.",
+                "D.& B.": "Dev. & Bat.", 
+                "Dev.& B.": "Dev. & Bat.", 
+                "Dev.& B.L.": "Dev. & Bat.", 
                 "N.C.(Dev.& Bat.)": "Dev. & Bat."
             }
         }
-    ],
+    ], 
     "Dev. & Bat. Eq.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Dev. & Bat. Eq.": {
-                    "end": "1839-12-31T00:00:00",
+                    "end": "1839-12-31T00:00:00", 
                     "start": "1834-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nc;supreme.court"
-            ],
-            "name": "North Carolina Reports, Devereux & Battle's Equity",
+                "us:nc;supreme.court"
+            ], 
+            "name": "North Carolina Reports, Devereux & Battle's Equity", 
             "variations": {
-                "D.& B.": "Dev. & Bat. Eq.",
-                "Dev.& B.": "Dev. & Bat. Eq.",
-                "Dev.& B.Eq.": "Dev. & Bat. Eq.",
+                "D.& B.": "Dev. & Bat. Eq.", 
+                "Dev.& B.": "Dev. & Bat. Eq.", 
+                "Dev.& B.Eq.": "Dev. & Bat. Eq.", 
                 "N.C.(Dev.& Bat.Eq.)": "Dev. & Bat. Eq."
             }
         }
-    ],
+    ], 
     "Dev. Eq.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Dev. Eq.": {
-                    "end": "1834-12-31T00:00:00",
+                    "end": "1834-12-31T00:00:00", 
                     "start": "1826-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nc;supreme.court"
-            ],
-            "name": "North Carolina Reports, Devereux's Equity",
+                "us:nc;supreme.court"
+            ], 
+            "name": "North Carolina Reports, Devereux's Equity", 
             "variations": {
-                "Dev.": "Dev. Eq.",
+                "Dev.": "Dev. Eq.", 
                 "N.C.(Dev.Eq.)": "Dev. Eq."
             }
         }
-    ],
+    ], 
     "Doug.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Doug.": {
-                    "end": "1847-12-31T00:00:00",
+                    "end": "1847-12-31T00:00:00", 
                     "start": "1843-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;mi;supreme.court"
-            ],
-            "name": "Michigan Reports, Douglass",
+                "us:mi;supreme.court"
+            ], 
+            "name": "Michigan Reports, Douglass", 
             "variations": {
-                "Doug.(Mich.)": "Doug.",
+                "Doug.(Mich.)": "Doug.", 
                 "Dougl.(Mich.)": "Doug."
             }
         }
-    ],
+    ], 
     "Dud.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Dud.": {
-                    "end": "1838-12-31T00:00:00",
+                    "end": "1838-12-31T00:00:00", 
                     "start": "1837-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Dudley",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Dudley", 
             "variations": {
-                "Dud.(S.C.)": "Dud.",
-                "Dud.L.": "Dud.",
-                "Dud.L.(S.C.)": "Dud.",
-                "Dudl.": "Dud.",
+                "Dud.(S.C.)": "Dud.", 
+                "Dud.L.": "Dud.", 
+                "Dud.L.(S.C.)": "Dud.", 
+                "Dudl.": "Dud.", 
                 "S.C.L.(Dud.)": "Dud."
             }
         }
-    ],
+    ], 
     "Dud. Eq.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Dud. Eq.": {
-                    "end": "1838-12-31T00:00:00",
+                    "end": "1838-12-31T00:00:00", 
                     "start": "1837-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Dudley's Equity",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Dudley's Equity", 
             "variations": {
-                "Dud.Ch.": "Dud. Eq.",
-                "Dud.Eq.(S.C.)": "Dud. Eq.",
-                "Dudl.": "Dud. Eq.",
+                "Dud.Ch.": "Dud. Eq.", 
+                "Dud.Eq.(S.C.)": "Dud. Eq.", 
+                "Dudl.": "Dud. Eq.", 
                 "S.C.Eq.(Dud.Eq.)": "Dud. Eq."
             }
         }
-    ],
+    ], 
     "Duv.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Duv.": {
-                    "end": "1866-12-31T00:00:00",
+                    "end": "1866-12-31T00:00:00", 
                     "start": "1863-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ky;supreme.court"
-            ],
-            "name": "Kentucky Reports, Duvall",
+                "us:ky;supreme.court"
+            ], 
+            "name": "Kentucky Reports, Duvall", 
             "variations": {
                 "Ky.(Duv.)": "Duv."
             }
         }
-    ],
+    ], 
     "Edm. Sel. Cas.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Edm. Sel. Cas.": {
-                    "end": "1853-12-31T00:00:00",
+                    "end": "1853-12-31T00:00:00", 
                     "start": "1834-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Edmond's Select Cases",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Edmond's Select Cases", 
             "variations": {
-                "Edm.Sel.Ca.": "Edm. Sel. Cas.",
-                "Edm.Sel.Cas.(N.Y.)": "Edm. Sel. Cas.",
+                "Edm.Sel.Ca.": "Edm. Sel. Cas.", 
+                "Edm.Sel.Cas.(N.Y.)": "Edm. Sel. Cas.", 
                 "Edmond": "Edm. Sel. Cas."
             }
         }
-    ],
+    ], 
     "Edw. Ch.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Edw. Ch.": {
-                    "end": "1850-12-31T00:00:00",
+                    "end": "1850-12-31T00:00:00", 
                     "start": "1831-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Edwards' Chancery Reports",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Edwards' Chancery Reports", 
             "variations": {
-                "Ed.C.R.": "Edw. Ch.",
-                "Ed.Ch.": "Edw. Ch.",
-                "Edw.": "Edw. Ch.",
+                "Ed.C.R.": "Edw. Ch.", 
+                "Ed.Ch.": "Edw. Ch.", 
+                "Edw.": "Edw. Ch.", 
                 "Edw.Ch.(N.Y.)": "Edw. Ch."
             }
         }
-    ],
+    ], 
     "F.": [
         {
-            "cite_type": "federal",
+            "cite_type": "federal", 
             "editions": {
                 "F.": {
-                    "end": "1924-12-31T00:00:00",
+                    "end": "1924-12-31T00:00:00", 
                     "start": "1880-01-01T00:00:00"
-                },
+                }, 
                 "F.2d": {
-                    "end": "1993-12-31T00:00:00",
+                    "end": "1993-12-31T00:00:00", 
                     "start": "1924-01-01T00:00:00"
-                },
+                }, 
                 "F.3d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1993-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;court.appeals.1.circuit",
-                "us;federal;court.appeals.10.circuit",
-                "us;federal;court.appeals.11.circuit",
-                "us;federal;court.appeals.2.circuit",
-                "us;federal;court.appeals.3.circuit",
-                "us;federal;court.appeals.4.circuit",
-                "us;federal;court.appeals.5.circuit",
-                "us;federal;court.appeals.6.circuit",
-                "us;federal;court.appeals.7.circuit",
-                "us;federal;court.appeals.8.circuit",
-                "us;federal;court.appeals.9.circuit"
-            ],
-            "name": "Federal Reporter",
+                "us:c10;court.appeals", 
+                "us:c11;court.appeals", 
+                "us:c1;court.appeals", 
+                "us:c2;court.appeals", 
+                "us:c3;court.appeals", 
+                "us:c4;court.appeals", 
+                "us:c5;court.appeals", 
+                "us:c6;court.appeals", 
+                "us:c7;court.appeals", 
+                "us:c8;court.appeals", 
+                "us:c9;court.appeals"
+            ], 
+            "name": "Federal Reporter", 
             "variations": {
-                "F. 2d": "F.2d",
-                "F. 3d": "F.3d",
-                "F.2d.": "F.2d",
-                "Fed.R.": "F.",
-                "Fed.R.2d": "F.2d",
-                "Fed.R.3d": "F.3d",
-                "Fed.Rep.": "F.",
-                "Fed.Rep.2d": "F.2d",
+                "F. 2d": "F.2d", 
+                "F. 3d": "F.3d", 
+                "F.2d.": "F.2d", 
+                "Fed.R.": "F.", 
+                "Fed.R.2d": "F.2d", 
+                "Fed.R.3d": "F.3d", 
+                "Fed.Rep.": "F.", 
+                "Fed.Rep.2d": "F.2d", 
                 "Fed.Rep.3d": "F.3d"
             }
         }
-    ],
+    ], 
     "F. App'x": [
         {
-            "cite_type": "federal",
+            "cite_type": "federal", 
             "editions": {
                 "F. App'x": {
-                    "end": null,
+                    "end": null, 
                     "start": "2001-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;court.appeals.1.circuit",
-                "us;federal;court.appeals.10.circuit",
-                "us;federal;court.appeals.11.circuit",
-                "us;federal;court.appeals.2.circuit",
-                "us;federal;court.appeals.3.circuit",
-                "us;federal;court.appeals.4.circuit",
-                "us;federal;court.appeals.5.circuit",
-                "us;federal;court.appeals.6.circuit",
-                "us;federal;court.appeals.7.circuit",
-                "us;federal;court.appeals.8.circuit",
-                "us;federal;court.appeals.9.circuit"
-            ],
-            "name": "Federal Appendix",
+                "us:c10;court.appeals", 
+                "us:c11;court.appeals", 
+                "us:c1;court.appeals", 
+                "us:c2;court.appeals", 
+                "us:c3;court.appeals", 
+                "us:c4;court.appeals", 
+                "us:c5;court.appeals", 
+                "us:c6;court.appeals", 
+                "us:c7;court.appeals", 
+                "us:c8;court.appeals", 
+                "us:c9;court.appeals"
+            ], 
+            "name": "Federal Appendix", 
             "variations": {}
         }
-    ],
+    ], 
     "F. Cas.": [
         {
-            "cite_type": "federal",
+            "cite_type": "federal", 
             "editions": {
                 "F. Cas.": {
-                    "end": "1880-01-01T00:00:00",
+                    "end": "1880-01-01T00:00:00", 
                     "start": "1789-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;court.appeals.1.circuit",
-                "us;federal;court.appeals.10.circuit",
-                "us;federal;court.appeals.11.circuit",
-                "us;federal;court.appeals.2.circuit",
-                "us;federal;court.appeals.3.circuit",
-                "us;federal;court.appeals.4.circuit",
-                "us;federal;court.appeals.5.circuit",
-                "us;federal;court.appeals.6.circuit",
-                "us;federal;court.appeals.7.circuit",
-                "us;federal;court.appeals.8.circuit",
-                "us;federal;court.appeals.9.circuit"
-            ],
-            "name": "Federal Cases",
+                "us:c10;court.appeals", 
+                "us:c11;court.appeals", 
+                "us:c1;court.appeals", 
+                "us:c2;court.appeals", 
+                "us:c3;court.appeals", 
+                "us:c4;court.appeals", 
+                "us:c5;court.appeals", 
+                "us:c6;court.appeals", 
+                "us:c7;court.appeals", 
+                "us:c8;court.appeals", 
+                "us:c9;court.appeals"
+            ], 
+            "name": "Federal Cases", 
             "variations": {
-                "F.C.": "F. Cas.",
-                "F.Cas.": "F. Cas.",
+                "F.C.": "F. Cas.", 
+                "F.Cas.": "F. Cas.", 
                 "Fed.Ca.": "F. Cas."
             }
         }
-    ],
+    ], 
     "F. Supp.": [
         {
-            "cite_type": "federal",
+            "cite_type": "federal", 
             "editions": {
                 "F. Supp.": {
-                    "end": "1988-12-31T00:00:00",
+                    "end": "1988-12-31T00:00:00", 
                     "start": "1932-01-01T00:00:00"
-                },
+                }, 
                 "F. Supp. 2d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1988-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;ak;d;district.court",
-                "us;federal;al;md;district.court",
-                "us;federal;al;nd;district.court",
-                "us;federal;al;sd;district.court",
-                "us;federal;ar;ed;district.court",
-                "us;federal;ar;wd;district.court",
-                "us;federal;az;d;district.court",
-                "us;federal;ca;cd;district.court",
-                "us;federal;ca;d;district.court",
-                "us;federal;ca;ed;district.court",
-                "us;federal;ca;nd;district.court",
-                "us;federal;ca;sd;district.court",
-                "us;federal;co;d;district.court",
-                "us;federal;ct;d;district.court",
-                "us;federal;de;d;district.court",
-                "us;federal;district.court.canal.zone",
-                "us;federal;district.court.d.guam",
-                "us;federal;district.court.d.puerto.rico",
-                "us;federal;district.court.district.columbia",
-                "us;federal;district.court.northern.mariana.islands",
-                "us;federal;district.court.virgin.islands",
-                "us;federal;fl;md;district.court",
-                "us;federal;fl;nd;district.court",
-                "us;federal;fl;sd;district.court",
-                "us;federal;ga;md;district.court",
-                "us;federal;ga;nd;district.court",
-                "us;federal;ga;sd;district.court",
-                "us;federal;hi;d;district.court",
-                "us;federal;ia;nd;district.court",
-                "us;federal;ia;sd;district.court",
-                "us;federal;id;d;district.court",
-                "us;federal;il;cd;district.court",
-                "us;federal;il;d;district.court",
-                "us;federal;il;ed;district.court",
-                "us;federal;il;nd;district.court",
-                "us;federal;il;sd;district.court",
-                "us;federal;in;d;district.court",
-                "us;federal;in;nd;district.court",
-                "us;federal;in;sd;district.court",
-                "us;federal;ks;d;district.court",
-                "us;federal;ky;ed;district.court",
-                "us;federal;ky;wd;district.court",
-                "us;federal;la;ed;district.court",
-                "us;federal;la;md;district.court",
-                "us;federal;la;wd;district.court",
-                "us;federal;ma;d;district.court",
-                "us;federal;md;d;district.court",
-                "us;federal;me;d;district.court",
-                "us;federal;mi;ed;district.court",
-                "us;federal;mi;wd;district.court",
-                "us;federal;mn;d;district.court",
-                "us;federal;mo;cd;district.court",
-                "us;federal;mo;ed;district.court",
-                "us;federal;mo;sd;district.court",
-                "us;federal;mo;wd;district.court",
-                "us;federal;ms;nd;district.court",
-                "us;federal;ms;sd;district.court",
-                "us;federal;mt;d;district.court",
-                "us;federal;nc;ed;district.court",
-                "us;federal;nc;md;district.court",
-                "us;federal;nc;wd;district.court",
-                "us;federal;nd;d;district.court",
-                "us;federal;ne;d;district.court",
-                "us;federal;nh;d;district.court",
-                "us;federal;nj;d;district.court",
-                "us;federal;nm;d;district.court",
-                "us;federal;nv;d;district.court",
-                "us;federal;ny;ed;district.court",
-                "us;federal;ny;nd;district.court",
-                "us;federal;ny;sd;district.court",
-                "us;federal;ny;wd;district.court",
-                "us;federal;oh;d;district.court",
-                "us;federal;oh;nd;district.court",
-                "us;federal;oh;sd;district.court",
-                "us;federal;ok;ed;district.court",
-                "us;federal;ok;nd;district.court",
-                "us;federal;ok;wd;district.court",
-                "us;federal;or;d;district.court",
-                "us;federal;pa;d;district.court",
-                "us;federal;pa;ed;district.court",
-                "us;federal;pa;md;district.court",
-                "us;federal;pa;wd;district.court",
-                "us;federal;ri;d;district.court",
-                "us;federal;sc;d;district.court",
-                "us;federal;sc;ed;district.court",
-                "us;federal;sc;wd;district.court",
-                "us;federal;sd;d;district.court",
-                "us;federal;tn;d;district.court",
-                "us;federal;tn;ed;district.court",
-                "us;federal;tn;md;district.court",
-                "us;federal;tn;wd;district.court",
-                "us;federal;tx;ed;district.court",
-                "us;federal;tx;nd;district.court",
-                "us;federal;tx;sd;district.court",
-                "us;federal;tx;wd;district.court",
-                "us;federal;ut;d;district.court",
-                "us;federal;va;ed;district.court",
-                "us;federal;va;wd;district.court",
-                "us;federal;vt;d;district.court",
-                "us;federal;wa;ed;district.court",
-                "us;federal;wa;wd;district.court",
-                "us;federal;wi;ed;district.court",
-                "us;federal;wi;wd;district.court",
-                "us;federal;wv;nd;district.court",
-                "us;federal;wv;sd;district.court",
-                "us;federal;wy;d;district.court"
-            ],
-            "name": "Federal Supplement",
+                "us:c0:dc.d;district.court", 
+                "us:c10:co.d;district.court", 
+                "us:c10:ks.d;district.court", 
+                "us:c10:nm.d;district.court", 
+                "us:c10:ok.ed;district.court", 
+                "us:c10:ok.nd;district.court", 
+                "us:c10:ok.wd;district.court", 
+                "us:c10:ut.d;district.court", 
+                "us:c10:wy.d;district.court", 
+                "us:c11:al.md;district.court", 
+                "us:c11:al.nd;district.court", 
+                "us:c11:al.sd;district.court", 
+                "us:c11:fl.md;district.court", 
+                "us:c11:fl.nd;district.court", 
+                "us:c11:fl.sd;district.court", 
+                "us:c11:ga.md;district.court", 
+                "us:c11:ga.nd;district.court", 
+                "us:c11:ga.sd;district.court", 
+                "us:c1:ma.d;district.court", 
+                "us:c1:me.d;district.court", 
+                "us:c1:nh.d;district.court", 
+                "us:c1:pr.d;district.court", 
+                "us:c1:ri.d;district.court", 
+                "us:c2:ct.d;district.court", 
+                "us:c2:ny.ed;district.court", 
+                "us:c2:ny.nd;district.court", 
+                "us:c2:ny.sd;district.court", 
+                "us:c2:ny.wd;district.court", 
+                "us:c2:vt.d;district.court", 
+                "us:c3:de.d;district.court", 
+                "us:c3:nj.d;district.court", 
+                "us:c3:pa.d;district.court", 
+                "us:c3:pa.ed;district.court", 
+                "us:c3:pa.md;district.court", 
+                "us:c3:pa.wd;district.court", 
+                "us:c3:vi.d;district.court", 
+                "us:c4:md.d;district.court", 
+                "us:c4:nc.ed;district.court", 
+                "us:c4:nc.md;district.court", 
+                "us:c4:nc.wd;district.court", 
+                "us:c4:sc.d;district.court", 
+                "us:c4:sc.ed;district.court", 
+                "us:c4:sc.wd;district.court", 
+                "us:c4:va.ed;district.court", 
+                "us:c4:va.wd;district.court", 
+                "us:c4:wv.nd;district.court", 
+                "us:c4:wv.sd;district.court", 
+                "us:c5:la.ed;district.court", 
+                "us:c5:la.md;district.court", 
+                "us:c5:la.wd;district.court", 
+                "us:c5:ms.nd;district.court", 
+                "us:c5:ms.sd;district.court", 
+                "us:c5:pz.d;district.court", 
+                "us:c5:tx.ed;district.court", 
+                "us:c5:tx.nd;district.court", 
+                "us:c5:tx.sd;district.court", 
+                "us:c5:tx.wd;district.court", 
+                "us:c6:ky.ed;district.court", 
+                "us:c6:ky.wd;district.court", 
+                "us:c6:mi.ed;district.court", 
+                "us:c6:mi.wd;district.court", 
+                "us:c6:oh.d;district.court", 
+                "us:c6:oh.nd;district.court", 
+                "us:c6:oh.sd;district.court", 
+                "us:c6:tn.d;district.court", 
+                "us:c6:tn.ed;district.court", 
+                "us:c6:tn.md;district.court", 
+                "us:c6:tn.wd;district.court", 
+                "us:c7:il.cd;district.court", 
+                "us:c7:il.d;district.court", 
+                "us:c7:il.ed;district.court", 
+                "us:c7:il.nd;district.court", 
+                "us:c7:il.sd;district.court", 
+                "us:c7:in.d;district.court", 
+                "us:c7:in.nd;district.court", 
+                "us:c7:in.sd;district.court", 
+                "us:c7:wi.ed;district.court", 
+                "us:c7:wi.wd;district.court", 
+                "us:c8:ar.ed;district.court", 
+                "us:c8:ar.wd;district.court", 
+                "us:c8:ia.nd;district.court", 
+                "us:c8:ia.sd;district.court", 
+                "us:c8:mn.d;district.court", 
+                "us:c8:mo.cd;district.court", 
+                "us:c8:mo.ed;district.court", 
+                "us:c8:mo.sd;district.court", 
+                "us:c8:mo.wd;district.court", 
+                "us:c8:nd.d;district.court", 
+                "us:c8:ne.d;district.court", 
+                "us:c8:sd.d;district.court", 
+                "us:c9:ak.d;district.court", 
+                "us:c9:az.d;district.court", 
+                "us:c9:ca.cd;district.court", 
+                "us:c9:ca.d;district.court", 
+                "us:c9:ca.ed;district.court", 
+                "us:c9:ca.nd;district.court", 
+                "us:c9:ca.sd;district.court", 
+                "us:c9:gu.d;district.court", 
+                "us:c9:hi.d;district.court", 
+                "us:c9:id.d;district.court", 
+                "us:c9:mp.d;district.court", 
+                "us:c9:mt.d;district.court", 
+                "us:c9:nv.d;district.court", 
+                "us:c9:or.d;district.court", 
+                "us:c9:wa.ed;district.court", 
+                "us:c9:wa.wd;district.court"
+            ], 
+            "name": "Federal Supplement", 
             "variations": {
-                "F. Supp.2d": "F. Supp. 2d",
-                "F.Supp.": "F. Supp.",
-                "F.Supp. 2d": "F. Supp. 2d",
+                "F. Supp.2d": "F. Supp. 2d", 
+                "F.Supp.": "F. Supp.", 
+                "F.Supp. 2d": "F. Supp. 2d", 
                 "F.Supp.2d": "F. Supp. 2d"
             }
         }
-    ],
+    ], 
     "F.R.D.": [
         {
-            "cite_type": "specialty",
+            "cite_type": "specialty", 
             "editions": {
                 "F.R.D.": {
-                    "end": null,
+                    "end": null, 
                     "start": "2001-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;ak;d;district.court",
-                "us;federal;al;md;district.court",
-                "us;federal;al;nd;district.court",
-                "us;federal;al;sd;district.court",
-                "us;federal;ar;ed;district.court",
-                "us;federal;ar;wd;district.court",
-                "us;federal;az;d;district.court",
-                "us;federal;ca;cd;district.court",
-                "us;federal;ca;d;district.court",
-                "us;federal;ca;ed;district.court",
-                "us;federal;ca;nd;district.court",
-                "us;federal;ca;sd;district.court",
-                "us;federal;co;d;district.court",
-                "us;federal;ct;d;district.court",
-                "us;federal;de;d;district.court",
-                "us;federal;district.court.canal.zone",
-                "us;federal;district.court.d.guam",
-                "us;federal;district.court.d.puerto.rico",
-                "us;federal;district.court.district.columbia",
-                "us;federal;district.court.northern.mariana.islands",
-                "us;federal;district.court.virgin.islands",
-                "us;federal;fl;md;district.court",
-                "us;federal;fl;nd;district.court",
-                "us;federal;fl;sd;district.court",
-                "us;federal;ga;md;district.court",
-                "us;federal;ga;nd;district.court",
-                "us;federal;ga;sd;district.court",
-                "us;federal;hi;d;district.court",
-                "us;federal;ia;nd;district.court",
-                "us;federal;ia;sd;district.court",
-                "us;federal;id;d;district.court",
-                "us;federal;il;cd;district.court",
-                "us;federal;il;d;district.court",
-                "us;federal;il;ed;district.court",
-                "us;federal;il;nd;district.court",
-                "us;federal;il;sd;district.court",
-                "us;federal;in;d;district.court",
-                "us;federal;in;nd;district.court",
-                "us;federal;in;sd;district.court",
-                "us;federal;ks;d;district.court",
-                "us;federal;ky;ed;district.court",
-                "us;federal;ky;wd;district.court",
-                "us;federal;la;ed;district.court",
-                "us;federal;la;md;district.court",
-                "us;federal;la;wd;district.court",
-                "us;federal;ma;d;district.court",
-                "us;federal;md;d;district.court",
-                "us;federal;me;d;district.court",
-                "us;federal;mi;ed;district.court",
-                "us;federal;mi;wd;district.court",
-                "us;federal;mn;d;district.court",
-                "us;federal;mo;cd;district.court",
-                "us;federal;mo;ed;district.court",
-                "us;federal;mo;sd;district.court",
-                "us;federal;mo;wd;district.court",
-                "us;federal;ms;nd;district.court",
-                "us;federal;ms;sd;district.court",
-                "us;federal;mt;d;district.court",
-                "us;federal;nc;ed;district.court",
-                "us;federal;nc;md;district.court",
-                "us;federal;nc;wd;district.court",
-                "us;federal;nd;d;district.court",
-                "us;federal;ne;d;district.court",
-                "us;federal;nh;d;district.court",
-                "us;federal;nj;d;district.court",
-                "us;federal;nm;d;district.court",
-                "us;federal;nv;d;district.court",
-                "us;federal;ny;ed;district.court",
-                "us;federal;ny;nd;district.court",
-                "us;federal;ny;sd;district.court",
-                "us;federal;ny;wd;district.court",
-                "us;federal;oh;d;district.court",
-                "us;federal;oh;nd;district.court",
-                "us;federal;oh;sd;district.court",
-                "us;federal;ok;ed;district.court",
-                "us;federal;ok;nd;district.court",
-                "us;federal;ok;wd;district.court",
-                "us;federal;or;d;district.court",
-                "us;federal;pa;d;district.court",
-                "us;federal;pa;ed;district.court",
-                "us;federal;pa;md;district.court",
-                "us;federal;pa;wd;district.court",
-                "us;federal;ri;d;district.court",
-                "us;federal;sc;d;district.court",
-                "us;federal;sc;ed;district.court",
-                "us;federal;sc;wd;district.court",
-                "us;federal;sd;d;district.court",
-                "us;federal;tn;d;district.court",
-                "us;federal;tn;ed;district.court",
-                "us;federal;tn;md;district.court",
-                "us;federal;tn;wd;district.court",
-                "us;federal;tx;ed;district.court",
-                "us;federal;tx;nd;district.court",
-                "us;federal;tx;sd;district.court",
-                "us;federal;tx;wd;district.court",
-                "us;federal;ut;d;district.court",
-                "us;federal;va;ed;district.court",
-                "us;federal;va;wd;district.court",
-                "us;federal;vt;d;district.court",
-                "us;federal;wa;ed;district.court",
-                "us;federal;wa;wd;district.court",
-                "us;federal;wi;ed;district.court",
-                "us;federal;wi;wd;district.court",
-                "us;federal;wv;nd;district.court",
-                "us;federal;wv;sd;district.court",
-                "us;federal;wy;d;district.court"
-            ],
-            "name": "Federal Rules Decisions",
+                "us:c0:dc.d;district.court", 
+                "us:c10:co.d;district.court", 
+                "us:c10:ks.d;district.court", 
+                "us:c10:nm.d;district.court", 
+                "us:c10:ok.ed;district.court", 
+                "us:c10:ok.nd;district.court", 
+                "us:c10:ok.wd;district.court", 
+                "us:c10:ut.d;district.court", 
+                "us:c10:wy.d;district.court", 
+                "us:c11:al.md;district.court", 
+                "us:c11:al.nd;district.court", 
+                "us:c11:al.sd;district.court", 
+                "us:c11:fl.md;district.court", 
+                "us:c11:fl.nd;district.court", 
+                "us:c11:fl.sd;district.court", 
+                "us:c11:ga.md;district.court", 
+                "us:c11:ga.nd;district.court", 
+                "us:c11:ga.sd;district.court", 
+                "us:c1:ma.d;district.court", 
+                "us:c1:me.d;district.court", 
+                "us:c1:nh.d;district.court", 
+                "us:c1:pr.d;district.court", 
+                "us:c1:ri.d;district.court", 
+                "us:c2:ct.d;district.court", 
+                "us:c2:ny.ed;district.court", 
+                "us:c2:ny.nd;district.court", 
+                "us:c2:ny.sd;district.court", 
+                "us:c2:ny.wd;district.court", 
+                "us:c2:vt.d;district.court", 
+                "us:c3:de.d;district.court", 
+                "us:c3:nj.d;district.court", 
+                "us:c3:pa.d;district.court", 
+                "us:c3:pa.ed;district.court", 
+                "us:c3:pa.md;district.court", 
+                "us:c3:pa.wd;district.court", 
+                "us:c3:vi.d;district.court", 
+                "us:c4:md.d;district.court", 
+                "us:c4:nc.ed;district.court", 
+                "us:c4:nc.md;district.court", 
+                "us:c4:nc.wd;district.court", 
+                "us:c4:sc.d;district.court", 
+                "us:c4:sc.ed;district.court", 
+                "us:c4:sc.wd;district.court", 
+                "us:c4:va.ed;district.court", 
+                "us:c4:va.wd;district.court", 
+                "us:c4:wv.nd;district.court", 
+                "us:c4:wv.sd;district.court", 
+                "us:c5:la.ed;district.court", 
+                "us:c5:la.md;district.court", 
+                "us:c5:la.wd;district.court", 
+                "us:c5:ms.nd;district.court", 
+                "us:c5:ms.sd;district.court", 
+                "us:c5:pz.d;district.court", 
+                "us:c5:tx.ed;district.court", 
+                "us:c5:tx.nd;district.court", 
+                "us:c5:tx.sd;district.court", 
+                "us:c5:tx.wd;district.court", 
+                "us:c6:ky.ed;district.court", 
+                "us:c6:ky.wd;district.court", 
+                "us:c6:mi.ed;district.court", 
+                "us:c6:mi.wd;district.court", 
+                "us:c6:oh.d;district.court", 
+                "us:c6:oh.nd;district.court", 
+                "us:c6:oh.sd;district.court", 
+                "us:c6:tn.d;district.court", 
+                "us:c6:tn.ed;district.court", 
+                "us:c6:tn.md;district.court", 
+                "us:c6:tn.wd;district.court", 
+                "us:c7:il.cd;district.court", 
+                "us:c7:il.d;district.court", 
+                "us:c7:il.ed;district.court", 
+                "us:c7:il.nd;district.court", 
+                "us:c7:il.sd;district.court", 
+                "us:c7:in.d;district.court", 
+                "us:c7:in.nd;district.court", 
+                "us:c7:in.sd;district.court", 
+                "us:c7:wi.ed;district.court", 
+                "us:c7:wi.wd;district.court", 
+                "us:c8:ar.ed;district.court", 
+                "us:c8:ar.wd;district.court", 
+                "us:c8:ia.nd;district.court", 
+                "us:c8:ia.sd;district.court", 
+                "us:c8:mn.d;district.court", 
+                "us:c8:mo.cd;district.court", 
+                "us:c8:mo.ed;district.court", 
+                "us:c8:mo.sd;district.court", 
+                "us:c8:mo.wd;district.court", 
+                "us:c8:nd.d;district.court", 
+                "us:c8:ne.d;district.court", 
+                "us:c8:sd.d;district.court", 
+                "us:c9:ak.d;district.court", 
+                "us:c9:az.d;district.court", 
+                "us:c9:ca.cd;district.court", 
+                "us:c9:ca.d;district.court", 
+                "us:c9:ca.ed;district.court", 
+                "us:c9:ca.nd;district.court", 
+                "us:c9:ca.sd;district.court", 
+                "us:c9:gu.d;district.court", 
+                "us:c9:hi.d;district.court", 
+                "us:c9:id.d;district.court", 
+                "us:c9:mp.d;district.court", 
+                "us:c9:mt.d;district.court", 
+                "us:c9:nv.d;district.court", 
+                "us:c9:or.d;district.court", 
+                "us:c9:wa.ed;district.court", 
+                "us:c9:wa.wd;district.court"
+            ], 
+            "name": "Federal Rules Decisions", 
             "variations": {}
         }
-    ],
+    ], 
     "FL": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "FL": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;fl;supreme.court"
-            ],
-            "name": "Florida Neutral Citation",
+                "us:fl;supreme.court"
+            ], 
+            "name": "Florida Neutral Citation", 
             "variations": {}
         }
-    ],
+    ], 
     "Fed. Cl.": [
         {
-            "cite_type": "specialty",
+            "cite_type": "specialty", 
             "editions": {
                 "Fed. Cl.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1992-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;court.federal.claims"
-            ],
-            "name": "United States Claims Court Reporter",
+                "us:c;court.federal.claims"
+            ], 
+            "name": "United States Claims Court Reporter", 
             "variations": {
                 "Fed.Cl.": "Fed. Cl."
             }
         }
-    ],
+    ], 
     "Fed. R. Serv.": [
         {
-            "cite_type": "specialty",
+            "cite_type": "specialty", 
             "editions": {
                 "Fed. R. Serv.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1938-01-01T00:00:00"
-                },
+                }, 
                 "Fed. R. Serv. 2d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1938-01-01T00:00:00"
-                },
+                }, 
                 "Fed. R. Serv. 3d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1938-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;ak;d;district.court",
-                "us;federal;al;md;district.court",
-                "us;federal;al;nd;district.court",
-                "us;federal;al;sd;district.court",
-                "us;federal;ar;ed;district.court",
-                "us;federal;ar;wd;district.court",
-                "us;federal;az;d;district.court",
-                "us;federal;ca;cd;district.court",
-                "us;federal;ca;d;district.court",
-                "us;federal;ca;ed;district.court",
-                "us;federal;ca;nd;district.court",
-                "us;federal;ca;sd;district.court",
-                "us;federal;co;d;district.court",
-                "us;federal;court.appeals.1.circuit",
-                "us;federal;court.appeals.10.circuit",
-                "us;federal;court.appeals.11.circuit",
-                "us;federal;court.appeals.2.circuit",
-                "us;federal;court.appeals.3.circuit",
-                "us;federal;court.appeals.4.circuit",
-                "us;federal;court.appeals.5.circuit",
-                "us;federal;court.appeals.6.circuit",
-                "us;federal;court.appeals.7.circuit",
-                "us;federal;court.appeals.8.circuit",
-                "us;federal;court.appeals.9.circuit",
-                "us;federal;court.appeals.dc.circuit",
-                "us;federal;ct;d;district.court",
-                "us;federal;de;d;district.court",
-                "us;federal;district.columbia.court.appeals",
-                "us;federal;district.court.canal.zone",
-                "us;federal;district.court.d.guam",
-                "us;federal;district.court.d.puerto.rico",
-                "us;federal;district.court.district.columbia",
-                "us;federal;district.court.northern.mariana.islands",
-                "us;federal;district.court.virgin.islands",
-                "us;federal;fl;md;district.court",
-                "us;federal;fl;nd;district.court",
-                "us;federal;fl;sd;district.court",
-                "us;federal;ga;md;district.court",
-                "us;federal;ga;nd;district.court",
-                "us;federal;ga;sd;district.court",
-                "us;federal;hi;d;district.court",
-                "us;federal;ia;nd;district.court",
-                "us;federal;ia;sd;district.court",
-                "us;federal;id;d;district.court",
-                "us;federal;il;cd;district.court",
-                "us;federal;il;d;district.court",
-                "us;federal;il;ed;district.court",
-                "us;federal;il;nd;district.court",
-                "us;federal;il;sd;district.court",
-                "us;federal;in;d;district.court",
-                "us;federal;in;nd;district.court",
-                "us;federal;in;sd;district.court",
-                "us;federal;ks;d;district.court",
-                "us;federal;ky;ed;district.court",
-                "us;federal;ky;wd;district.court",
-                "us;federal;la;ed;district.court",
-                "us;federal;la;md;district.court",
-                "us;federal;la;wd;district.court",
-                "us;federal;ma;d;district.court",
-                "us;federal;md;d;district.court",
-                "us;federal;me;d;district.court",
-                "us;federal;mi;ed;district.court",
-                "us;federal;mi;wd;district.court",
-                "us;federal;mn;d;district.court",
-                "us;federal;mo;cd;district.court",
-                "us;federal;mo;ed;district.court",
-                "us;federal;mo;sd;district.court",
-                "us;federal;mo;wd;district.court",
-                "us;federal;ms;nd;district.court",
-                "us;federal;ms;sd;district.court",
-                "us;federal;mt;d;district.court",
-                "us;federal;nc;ed;district.court",
-                "us;federal;nc;md;district.court",
-                "us;federal;nc;wd;district.court",
-                "us;federal;nd;d;district.court",
-                "us;federal;ne;d;district.court",
-                "us;federal;nh;d;district.court",
-                "us;federal;nj;d;district.court",
-                "us;federal;nm;d;district.court",
-                "us;federal;nv;d;district.court",
-                "us;federal;ny;ed;district.court",
-                "us;federal;ny;nd;district.court",
-                "us;federal;ny;sd;district.court",
-                "us;federal;ny;wd;district.court",
-                "us;federal;oh;d;district.court",
-                "us;federal;oh;nd;district.court",
-                "us;federal;oh;sd;district.court",
-                "us;federal;ok;ed;district.court",
-                "us;federal;ok;nd;district.court",
-                "us;federal;ok;wd;district.court",
-                "us;federal;or;d;district.court",
-                "us;federal;pa;d;district.court",
-                "us;federal;pa;ed;district.court",
-                "us;federal;pa;md;district.court",
-                "us;federal;pa;wd;district.court",
-                "us;federal;ri;d;district.court",
-                "us;federal;sc;d;district.court",
-                "us;federal;sc;ed;district.court",
-                "us;federal;sc;wd;district.court",
-                "us;federal;sd;d;district.court",
-                "us;federal;tn;d;district.court",
-                "us;federal;tn;ed;district.court",
-                "us;federal;tn;md;district.court",
-                "us;federal;tn;wd;district.court",
-                "us;federal;tx;ed;district.court",
-                "us;federal;tx;nd;district.court",
-                "us;federal;tx;sd;district.court",
-                "us;federal;tx;wd;district.court",
-                "us;federal;ut;d;district.court",
-                "us;federal;va;ed;district.court",
-                "us;federal;va;wd;district.court",
-                "us;federal;vt;d;district.court",
-                "us;federal;wa;ed;district.court",
-                "us;federal;wa;wd;district.court",
-                "us;federal;wi;ed;district.court",
-                "us;federal;wi;wd;district.court",
-                "us;federal;wv;nd;district.court",
-                "us;federal;wv;sd;district.court",
-                "us;federal;wy;d;district.court"
-            ],
-            "name": "Federal Rules Service",
+                "us:c0:dc.d;district.court", 
+                "us:c0;court.appeals", 
+                "us:c10:co.d;district.court", 
+                "us:c10:ks.d;district.court", 
+                "us:c10:nm.d;district.court", 
+                "us:c10:ok.ed;district.court", 
+                "us:c10:ok.nd;district.court", 
+                "us:c10:ok.wd;district.court", 
+                "us:c10:ut.d;district.court", 
+                "us:c10:wy.d;district.court", 
+                "us:c10;court.appeals", 
+                "us:c11:al.md;district.court", 
+                "us:c11:al.nd;district.court", 
+                "us:c11:al.sd;district.court", 
+                "us:c11:fl.md;district.court", 
+                "us:c11:fl.nd;district.court", 
+                "us:c11:fl.sd;district.court", 
+                "us:c11:ga.md;district.court", 
+                "us:c11:ga.nd;district.court", 
+                "us:c11:ga.sd;district.court", 
+                "us:c11;court.appeals", 
+                "us:c1:ma.d;district.court", 
+                "us:c1:me.d;district.court", 
+                "us:c1:nh.d;district.court", 
+                "us:c1:pr.d;district.court", 
+                "us:c1:ri.d;district.court", 
+                "us:c1;court.appeals", 
+                "us:c2:ct.d;district.court", 
+                "us:c2:ny.ed;district.court", 
+                "us:c2:ny.nd;district.court", 
+                "us:c2:ny.sd;district.court", 
+                "us:c2:ny.wd;district.court", 
+                "us:c2:vt.d;district.court", 
+                "us:c2;court.appeals", 
+                "us:c3:de.d;district.court", 
+                "us:c3:nj.d;district.court", 
+                "us:c3:pa.d;district.court", 
+                "us:c3:pa.ed;district.court", 
+                "us:c3:pa.md;district.court", 
+                "us:c3:pa.wd;district.court", 
+                "us:c3:vi.d;district.court", 
+                "us:c3;court.appeals", 
+                "us:c4:md.d;district.court", 
+                "us:c4:nc.ed;district.court", 
+                "us:c4:nc.md;district.court", 
+                "us:c4:nc.wd;district.court", 
+                "us:c4:sc.d;district.court", 
+                "us:c4:sc.ed;district.court", 
+                "us:c4:sc.wd;district.court", 
+                "us:c4:va.ed;district.court", 
+                "us:c4:va.wd;district.court", 
+                "us:c4:wv.nd;district.court", 
+                "us:c4:wv.sd;district.court", 
+                "us:c4;court.appeals", 
+                "us:c5:la.ed;district.court", 
+                "us:c5:la.md;district.court", 
+                "us:c5:la.wd;district.court", 
+                "us:c5:ms.nd;district.court", 
+                "us:c5:ms.sd;district.court", 
+                "us:c5:pz.d;district.court", 
+                "us:c5:tx.ed;district.court", 
+                "us:c5:tx.nd;district.court", 
+                "us:c5:tx.sd;district.court", 
+                "us:c5:tx.wd;district.court", 
+                "us:c5;court.appeals", 
+                "us:c6:ky.ed;district.court", 
+                "us:c6:ky.wd;district.court", 
+                "us:c6:mi.ed;district.court", 
+                "us:c6:mi.wd;district.court", 
+                "us:c6:oh.d;district.court", 
+                "us:c6:oh.nd;district.court", 
+                "us:c6:oh.sd;district.court", 
+                "us:c6:tn.d;district.court", 
+                "us:c6:tn.ed;district.court", 
+                "us:c6:tn.md;district.court", 
+                "us:c6:tn.wd;district.court", 
+                "us:c6;court.appeals", 
+                "us:c7:il.cd;district.court", 
+                "us:c7:il.d;district.court", 
+                "us:c7:il.ed;district.court", 
+                "us:c7:il.nd;district.court", 
+                "us:c7:il.sd;district.court", 
+                "us:c7:in.d;district.court", 
+                "us:c7:in.nd;district.court", 
+                "us:c7:in.sd;district.court", 
+                "us:c7:wi.ed;district.court", 
+                "us:c7:wi.wd;district.court", 
+                "us:c7;court.appeals", 
+                "us:c8:ar.ed;district.court", 
+                "us:c8:ar.wd;district.court", 
+                "us:c8:ia.nd;district.court", 
+                "us:c8:ia.sd;district.court", 
+                "us:c8:mn.d;district.court", 
+                "us:c8:mo.cd;district.court", 
+                "us:c8:mo.ed;district.court", 
+                "us:c8:mo.sd;district.court", 
+                "us:c8:mo.wd;district.court", 
+                "us:c8:nd.d;district.court", 
+                "us:c8:ne.d;district.court", 
+                "us:c8:sd.d;district.court", 
+                "us:c8;court.appeals", 
+                "us:c9:ak.d;district.court", 
+                "us:c9:az.d;district.court", 
+                "us:c9:ca.cd;district.court", 
+                "us:c9:ca.d;district.court", 
+                "us:c9:ca.ed;district.court", 
+                "us:c9:ca.nd;district.court", 
+                "us:c9:ca.sd;district.court", 
+                "us:c9:gu.d;district.court", 
+                "us:c9:hi.d;district.court", 
+                "us:c9:id.d;district.court", 
+                "us:c9:mp.d;district.court", 
+                "us:c9:mt.d;district.court", 
+                "us:c9:nv.d;district.court", 
+                "us:c9:or.d;district.court", 
+                "us:c9:wa.ed;district.court", 
+                "us:c9:wa.wd;district.court", 
+                "us:c9;court.appeals", 
+                "us:dc;court.appeals"
+            ], 
+            "name": "Federal Rules Service", 
             "variations": {
-                "Fed. R. Serv. (Callaghan)": "Fed. R. Serv.",
-                "Fed. R. Serv. 2d (Callaghan)": "Fed. R. Serv. 2d",
+                "Fed. R. Serv. (Callaghan)": "Fed. R. Serv.", 
+                "Fed. R. Serv. 2d (Callaghan)": "Fed. R. Serv. 2d", 
                 "Fed. R. Serv. 3d (West)": "Fed. R. Serv. 3d"
             }
         }
-    ],
+    ], 
     "Fla.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Fla.": {
-                    "end": "1948-12-31T00:00:00",
+                    "end": "1948-12-31T00:00:00", 
                     "start": "1846-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;fl;supreme.court"
-            ],
-            "name": "Florida Reports",
+                "us:fl;supreme.court"
+            ], 
+            "name": "Florida Reports", 
             "variations": {
-                "Flor.": "Fla.",
+                "Flor.": "Fla.", 
                 "Florida": "Fla."
             }
         }
-    ],
+    ], 
     "Fla. L. Weekly": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Fla. L. Weekly": {
-                    "end": null,
+                    "end": null, 
                     "start": "1978-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;fl;supreme.court"
-            ],
-            "name": "Florida Law Weekly",
+                "us:fl;supreme.court"
+            ], 
+            "name": "Florida Law Weekly", 
             "variations": {}
         }
-    ],
+    ], 
     "Fla. L. Weekly Supp.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Fla. L. Weekly Supp.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1992-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;fl;supreme.court"
-            ],
-            "name": "Florida Law Weekly Supplement",
+                "us:fl;supreme.court"
+            ], 
+            "name": "Florida Law Weekly Supplement", 
             "variations": {}
         }
-    ],
+    ], 
     "Fla. Supp.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Fla. Supp.": {
-                    "end": "1981-12-31T00:00:00",
+                    "end": "1981-12-31T00:00:00", 
                     "start": "1948-01-01T00:00:00"
-                },
+                }, 
                 "Fla. Supp. 2d": {
-                    "end": "1992-12-31T00:00:00",
+                    "end": "1992-12-31T00:00:00", 
                     "start": "1983-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;fl;supreme.court"
-            ],
-            "name": "Florida Supplement",
+                "us:fl;supreme.court"
+            ], 
+            "name": "Florida Supplement", 
             "variations": {
                 "Fl.S.": "Fla. Supp."
             }
         }
-    ],
+    ], 
     "G. & J.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "G. & J.": {
-                    "end": "1842-12-31T00:00:00",
+                    "end": "1842-12-31T00:00:00", 
                     "start": "1829-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;md;court.appeals"
-            ],
-            "name": "Maryland Reports, Gill & Johnson",
+                "us:md;court.appeals"
+            ], 
+            "name": "Maryland Reports, Gill & Johnson", 
             "variations": {}
         }
-    ],
+    ], 
     "Ga.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ga.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1846-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ga;supreme.court"
-            ],
-            "name": "Georgia Reports",
+                "us:ga;supreme.court"
+            ], 
+            "name": "Georgia Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Ga. App.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ga. App.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1907-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ga;supreme.court"
-            ],
-            "name": "Georgia Appeals Reports",
+                "us:ga;supreme.court"
+            ], 
+            "name": "Georgia Appeals Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Gild.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Gild.": {
-                    "end": "1889-12-31T00:00:00",
+                    "end": "1889-12-31T00:00:00", 
                     "start": "1883-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nm;supreme.court"
-            ],
-            "name": "Gildersleeve Reports",
+                "us:nm;supreme.court"
+            ], 
+            "name": "Gildersleeve Reports", 
             "variations": {
-                "Gildersleeve": "Gild.",
-                "Gildr.": "Gild.",
-                "N.M.(G.)": "Gild.",
+                "Gildersleeve": "Gild.", 
+                "Gildr.": "Gild.", 
+                "N.M.(G.)": "Gild.", 
                 "N.M.(Gild.)": "Gild."
             }
         }
-    ],
+    ], 
     "Gill": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Gill": {
-                    "end": "1851-12-31T00:00:00",
+                    "end": "1851-12-31T00:00:00", 
                     "start": "1843-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;md;court.appeals"
-            ],
-            "name": "Maryland Reports, Gill",
+                "us:md;court.appeals"
+            ], 
+            "name": "Maryland Reports, Gill", 
             "variations": {}
         }
-    ],
+    ], 
     "Gilm.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Gilm.": {
-                    "end": "1849-12-31T00:00:00",
+                    "end": "1849-12-31T00:00:00", 
                     "start": "1844-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;il;supreme.court"
-            ],
-            "name": "Illinois Reports, Gilman",
+                "us:il;supreme.court"
+            ], 
+            "name": "Illinois Reports, Gilman", 
             "variations": {
-                "Gilm.(Ill.)": "Gilm.",
-                "Gilman": "Gilm.",
+                "Gilm.(Ill.)": "Gilm.", 
+                "Gilman": "Gilm.", 
                 "Ill.(Gilm.)": "Gilm."
             }
         }
-    ],
+    ], 
     "Gilmer": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Gilmer": {
-                    "end": "1821-12-31T00:00:00",
+                    "end": "1821-12-31T00:00:00", 
                     "start": "1820-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;va;supreme.court"
-            ],
-            "name": "Virginia Reports, Gilmer",
+                "us:va;supreme.court"
+            ], 
+            "name": "Virginia Reports, Gilmer", 
             "variations": {
-                "Gil.": "Gilmer",
-                "Gilm.": "Gilmer",
-                "Gilmer (Va.)": "Gilmer",
+                "Gil.": "Gilmer", 
+                "Gilm.": "Gilmer", 
+                "Gilmer (Va.)": "Gilmer", 
                 "Va.(Gilmer)": "Gilmer"
             }
         }
-    ],
+    ], 
     "Grant": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Grant": {
-                    "end": "1863-12-31T00:00:00",
+                    "end": "1863-12-31T00:00:00", 
                     "start": "1814-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;pa;supreme.court"
-            ],
-            "name": "Pennsylvania State Reports, Grant",
+                "us:pa;supreme.court"
+            ], 
+            "name": "Pennsylvania State Reports, Grant", 
             "variations": {
-                "Gr.": "Grant",
-                "Grant (Pa.)": "Grant",
-                "Grant Cas.": "Grant",
-                "Grant Cas.(Pa.)": "Grant",
+                "Gr.": "Grant", 
+                "Grant (Pa.)": "Grant", 
+                "Grant Cas.": "Grant", 
+                "Grant Cas.(Pa.)": "Grant", 
                 "Grant Pa.": "Grant"
             }
         }
-    ],
+    ], 
     "Gratt.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Gratt.": {
-                    "end": "1880-12-31T00:00:00",
+                    "end": "1880-12-31T00:00:00", 
                     "start": "1844-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;va;supreme.court"
-            ],
-            "name": "Virginia Reports, Grattan",
+                "us:va;supreme.court"
+            ], 
+            "name": "Virginia Reports, Grattan", 
             "variations": {
-                "Gratt.(Va.)": "Gratt.",
+                "Gratt.(Va.)": "Gratt.", 
                 "Va.(Gratt.)": "Gratt."
             }
         }
-    ],
+    ], 
     "Gray": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Gray": {
-                    "end": "1860-12-31T00:00:00",
+                    "end": "1860-12-31T00:00:00", 
                     "start": "1854-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ma;appeals.court"
-            ],
-            "name": "Massachusetts Reports, Gray",
+                "us:ma;appeals.court"
+            ], 
+            "name": "Massachusetts Reports, Gray", 
             "variations": {
-                "Gray (Mass.)": "Gray",
+                "Gray (Mass.)": "Gray", 
                 "Mass.(Gray)": "Gray"
             }
         }
-    ],
+    ], 
     "Greene": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Greene": {
-                    "end": "1854-12-31T00:00:00",
+                    "end": "1854-12-31T00:00:00", 
                     "start": "1847-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ia;supreme.court"
-            ],
-            "name": "Iowa Reports, Greene",
+                "us:ia;supreme.court"
+            ], 
+            "name": "Iowa Reports, Greene", 
             "variations": {
                 "Greene G.(Iowa)": "Greene"
             }
         }
-    ],
+    ], 
     "Guam": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Guam": {
-                    "end": null,
+                    "end": null, 
                     "start": "1955-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;district.court.d.guam"
-            ],
-            "name": "Guam Reports",
+                "us:c9:gu.d;district.court"
+            ], 
+            "name": "Guam Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Gunby": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Gunby": {
-                    "end": "1885-12-31T00:00:00",
+                    "end": "1885-12-31T00:00:00", 
                     "start": "1885-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;la;supreme.court"
-            ],
-            "name": "Louisiana Court of Appeals Reports, Gunby",
+                "us:la;supreme.court"
+            ], 
+            "name": "Louisiana Court of Appeals Reports, Gunby", 
             "variations": {
                 "Gunby (La.)": "Gunby"
             }
         }
-    ],
+    ], 
     "H. & G.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "H. & G.": {
-                    "end": "1829-12-31T00:00:00",
+                    "end": "1829-12-31T00:00:00", 
                     "start": "1826-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;md;court.appeals"
-            ],
-            "name": "Maryland Reports, Harris and Gill",
+                "us:md;court.appeals"
+            ], 
+            "name": "Maryland Reports, Harris and Gill", 
             "variations": {}
         }
-    ],
+    ], 
     "H. & J.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "H. & J.": {
-                    "end": "1826-12-31T00:00:00",
+                    "end": "1826-12-31T00:00:00", 
                     "start": "1800-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;md;court.appeals"
-            ],
-            "name": "Maryland Reports, Harris and Johnson",
+                "us:md;court.appeals"
+            ], 
+            "name": "Maryland Reports, Harris and Johnson", 
             "variations": {}
         }
-    ],
+    ], 
     "H. & McH.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "H. & McH.": {
-                    "end": "1799-12-31T00:00:00",
+                    "end": "1799-12-31T00:00:00", 
                     "start": "1770-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;md;court.appeals"
-            ],
-            "name": "Maryland Reports, Harris and McHenry",
+                "us:md;court.appeals"
+            ], 
+            "name": "Maryland Reports, Harris and McHenry", 
             "variations": {}
         }
-    ],
+    ], 
     "Hard.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Hard.": {
-                    "end": "1808-12-31T00:00:00",
+                    "end": "1808-12-31T00:00:00", 
                     "start": "1805-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ky;supreme.court"
-            ],
-            "name": "Kentucky Reports, Hardin",
+                "us:ky;supreme.court"
+            ], 
+            "name": "Kentucky Reports, Hardin", 
             "variations": {
-                "Hardin": "Hard.",
-                "Hardin(Ky.)": "Hard.",
+                "Hardin": "Hard.", 
+                "Hardin(Ky.)": "Hard.", 
                 "Ky.(Hard.)": "Hard."
             }
         }
-    ],
+    ], 
     "Harp.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Harp.": {
-                    "end": "1831-12-31T00:00:00",
+                    "end": "1831-12-31T00:00:00", 
                     "start": "1823-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Harper",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Harper", 
             "variations": {
-                "Harp.L.": "Harp.",
-                "Harp.L.(S.C.)": "Harp.",
-                "Harper": "Harp.",
+                "Harp.L.": "Harp.", 
+                "Harp.L.(S.C.)": "Harp.", 
+                "Harper": "Harp.", 
                 "S.C.L.(Harp.)": "Harp."
             }
         }
-    ],
+    ], 
     "Harp. Eq.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Harp. Eq.": {
-                    "end": "1824-12-31T00:00:00",
+                    "end": "1824-12-31T00:00:00", 
                     "start": "1824-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Harper's Equity",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Harper's Equity", 
             "variations": {
-                "Harp.": "Harp. Eq.",
-                "Harp.Eq.(S.C.)": "Harp. Eq.",
-                "Harper": "Harp. Eq.",
+                "Harp.": "Harp. Eq.", 
+                "Harp.Eq.(S.C.)": "Harp. Eq.", 
+                "Harper": "Harp. Eq.", 
                 "S.C.Eq.(Harp.Eq.)": "Harp. Eq."
             }
         }
-    ],
+    ], 
     "Harrington": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Harrington": {
-                    "end": "1855-12-31T00:00:00",
+                    "end": "1855-12-31T00:00:00", 
                     "start": "1832-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;de;supreme.court"
-            ],
-            "name": "Delaware Reports, Harrington",
+                "us:de;supreme.court"
+            ], 
+            "name": "Delaware Reports, Harrington", 
             "variations": {}
         }
-    ],
+    ], 
     "Haw.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Haw.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1847-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;hi;supreme.court"
-            ],
-            "name": "Hawaii Reports",
+                "us:hi;supreme.court"
+            ], 
+            "name": "Hawaii Reports", 
             "variations": {
-                "H.": "Haw.",
-                "Hawaii": "Haw.",
+                "H.": "Haw.", 
+                "Hawaii": "Haw.", 
                 "Hawaii Rep.": "Haw."
             }
         }
-    ],
+    ], 
     "Haw. App.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Haw. App.": {
-                    "end": "1994-12-31T00:00:00",
+                    "end": "1994-12-31T00:00:00", 
                     "start": "1980-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;hi;supreme.court"
-            ],
-            "name": "Hawaii Appellate Reports",
+                "us:hi;supreme.court"
+            ], 
+            "name": "Hawaii Appellate Reports", 
             "variations": {
                 "Hawaii App.": "Haw. App."
             }
         }
-    ],
+    ], 
     "Hawks": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Hawks": {
-                    "end": "1826-12-31T00:00:00",
+                    "end": "1826-12-31T00:00:00", 
                     "start": "1820-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nc;supreme.court"
-            ],
-            "name": "North Carolina Reports, Hawks",
+                "us:nc;supreme.court"
+            ], 
+            "name": "North Carolina Reports, Hawks", 
             "variations": {
-                "Hawks(N.C.)": "Hawks",
+                "Hawks(N.C.)": "Hawks", 
                 "N.C.(Hawks)": "Hawks"
             }
         }
-    ],
+    ], 
     "Hay. & Haz.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Hay. & Haz.": {
-                    "end": "1862-12-31T00:00:00",
+                    "end": "1862-12-31T00:00:00", 
                     "start": "1841-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;district.columbia.court.appeals"
-            ],
-            "name": "District of Columbia Reports, Hayward & Hazelton",
+                "us:dc;court.appeals"
+            ], 
+            "name": "District of Columbia Reports, Hayward & Hazelton", 
             "variations": {
                 "Hayw.& H.": "Hay. & Haz."
             }
         }
-    ],
+    ], 
     "Hayw.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Hayw.": {
-                    "end": "1806-12-31T00:00:00",
+                    "end": "1806-12-31T00:00:00", 
                     "start": "1789-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nc;supreme.court"
-            ],
-            "name": "North Carolina Reports, Haywood",
+                "us:nc;supreme.court"
+            ], 
+            "name": "North Carolina Reports, Haywood", 
             "variations": {
-                "Hay.": "Hayw.",
-                "Hayw.N.C.": "Hayw.",
+                "Hay.": "Hayw.", 
+                "Hayw.N.C.": "Hayw.", 
                 "N.C.(Hayw.)": "Hayw."
             }
-        },
+        }, 
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Hayw.": {
-                    "end": "1818-12-31T00:00:00",
+                    "end": "1818-12-31T00:00:00", 
                     "start": "1816-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tn;supreme.court"
-            ],
-            "name": "Tennessee Reports, Haywood",
+                "us:tn;supreme.court"
+            ], 
+            "name": "Tennessee Reports, Haywood", 
             "variations": {
-                "Hayw.(Tenn.)": "Hayw.",
-                "Hayw.Tenn.": "Hayw.",
+                "Hayw.(Tenn.)": "Hayw.", 
+                "Hayw.Tenn.": "Hayw.", 
                 "Tenn.(Hayw.)": "Hayw."
             }
         }
-    ],
+    ], 
     "Head": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Head": {
-                    "end": "1860-12-31T00:00:00",
+                    "end": "1860-12-31T00:00:00", 
                     "start": "1858-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tn;supreme.court"
-            ],
-            "name": "Tennessee Reports, Head",
+                "us:tn;supreme.court"
+            ], 
+            "name": "Tennessee Reports, Head", 
             "variations": {
-                "Head(Tenn.)": "Head",
+                "Head(Tenn.)": "Head", 
                 "Tenn.(Head)": "Head"
             }
         }
-    ],
+    ], 
     "Heisk.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Heisk.": {
-                    "end": "1879-12-31T00:00:00",
+                    "end": "1879-12-31T00:00:00", 
                     "start": "1870-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tn;supreme.court"
-            ],
-            "name": "Tennessee Reports, Heiskell",
+                "us:tn;supreme.court"
+            ], 
+            "name": "Tennessee Reports, Heiskell", 
             "variations": {
-                "Heisk.(Tenn.)": "Heisk.",
+                "Heisk.(Tenn.)": "Heisk.", 
                 "Tenn.(Heisk.)": "Heisk."
             }
         }
-    ],
+    ], 
     "Hen. & M.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Hen. & M.": {
-                    "end": "1810-12-31T00:00:00",
+                    "end": "1810-12-31T00:00:00", 
                     "start": "1806-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;va;supreme.court"
-            ],
-            "name": "Virginia Reports, Hening & Munford",
+                "us:va;supreme.court"
+            ], 
+            "name": "Virginia Reports, Hening & Munford", 
             "variations": {
-                "H.& M.": "Hen. & M.",
-                "H.& M.(Va.)": "Hen. & M.",
-                "Hen.& Mun.": "Hen. & M.",
+                "H.& M.": "Hen. & M.", 
+                "H.& M.(Va.)": "Hen. & M.", 
+                "Hen.& Mun.": "Hen. & M.", 
                 "Va.(Hen.& M.)": "Hen. & M."
             }
         }
-    ],
+    ], 
     "Hill": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Hill": {
-                    "end": "1844-12-31T00:00:00",
+                    "end": "1844-12-31T00:00:00", 
                     "start": "1841-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Hill's New York Reports",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Hill's New York Reports", 
             "variations": {
-                "H.": "Hill",
+                "H.": "Hill", 
                 "Hill.N.Y.": "Hill"
             }
-        },
+        }, 
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Hill": {
-                    "end": "1837-12-31T00:00:00",
+                    "end": "1837-12-31T00:00:00", 
                     "start": "1833-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Hill",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Hill", 
             "variations": {
-                "Hill Law": "Hill",
-                "Hill S.C.": "Hill",
+                "Hill Law": "Hill", 
+                "Hill S.C.": "Hill", 
                 "S.C.L.(Hill)": "Hill"
             }
         }
-    ],
+    ], 
     "Hill & Den.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Hill & Den.": {
-                    "end": "1844-12-31T00:00:00",
+                    "end": "1844-12-31T00:00:00", 
                     "start": "1842-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Hill and Denio Supplement (Lalor)",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Hill and Denio Supplement (Lalor)", 
             "variations": {
-                "Hill & D.Supp.": "Hill & Den.",
-                "Hill & Den.Supp.": "Hill & Den.",
-                "Lalor": "Hill & Den.",
+                "Hill & D.Supp.": "Hill & Den.", 
+                "Hill & Den.Supp.": "Hill & Den.", 
+                "Lalor": "Hill & Den.", 
                 "Lalor Supp.": "Hill & Den."
             }
         }
-    ],
+    ], 
     "Hill Eq.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Hill Eq.": {
-                    "end": "1837-12-31T00:00:00",
+                    "end": "1837-12-31T00:00:00", 
                     "start": "1833-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Hill's Chancery",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Hill's Chancery", 
             "variations": {
-                "Hill": "Hill Eq.",
-                "Hill Ch.": "Hill Eq.",
-                "Hill Eq.(S.C.)": "Hill Eq.",
-                "Hill S.C.": "Hill Eq.",
+                "Hill": "Hill Eq.", 
+                "Hill Ch.": "Hill Eq.", 
+                "Hill Eq.(S.C.)": "Hill Eq.", 
+                "Hill S.C.": "Hill Eq.", 
                 "S.C.Eq.(Hill Eq.)": "Hill Eq."
             }
         }
-    ],
+    ], 
     "Hoff. Ch.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Hoff. Ch.": {
-                    "end": "1840-12-31T00:00:00",
+                    "end": "1840-12-31T00:00:00", 
                     "start": "1838-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Hoffman's Chancery Reports",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Hoffman's Chancery Reports", 
             "variations": {
-                "Hoff.": "Hoff. Ch.",
-                "Hoff.Cha.": "Hoff. Ch.",
-                "Hoff.N.Y.": "Hoff. Ch.",
-                "Hoffm.": "Hoff. Ch.",
+                "Hoff.": "Hoff. Ch.", 
+                "Hoff.Cha.": "Hoff. Ch.", 
+                "Hoff.N.Y.": "Hoff. Ch.", 
+                "Hoffm.": "Hoff. Ch.", 
                 "Hoffm.Ch.(N.Y.)": "Hoff. Ch."
             }
         }
-    ],
+    ], 
     "Hopk. Ch.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Hopk. Ch.": {
-                    "end": "1826-12-31T00:00:00",
+                    "end": "1826-12-31T00:00:00", 
                     "start": "1823-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Hopkins' Chancery Reports",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Hopkins' Chancery Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Houston": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Houston": {
-                    "end": "1893-12-31T00:00:00",
+                    "end": "1893-12-31T00:00:00", 
                     "start": "1855-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;de;supreme.court"
-            ],
-            "name": "Delaware Reports, Houston",
+                "us:de;supreme.court"
+            ], 
+            "name": "Delaware Reports, Houston", 
             "variations": {}
         }
-    ],
+    ], 
     "How.": [
         {
-            "cite_type": "scotus_early",
+            "cite_type": "scotus_early", 
             "editions": {
                 "How.": {
-                    "end": "1860-12-31T00:00:00",
+                    "end": "1860-12-31T00:00:00", 
                     "start": "1843-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;supreme.court"
-            ],
-            "name": "Howard's Supreme Court Reports",
+                "us;supreme.court"
+            ], 
+            "name": "Howard's Supreme Court Reports", 
             "variations": {
                 "U.S.(How.)": "How."
             }
         }
-    ],
+    ], 
     "How. Pr.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "How. Pr.": {
-                    "end": "1886-12-31T00:00:00",
+                    "end": "1886-12-31T00:00:00", 
                     "start": "1844-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Howard's Practice Reports",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Howard's Practice Reports", 
             "variations": {
-                "How.P.R.": "How. Pr.",
-                "How.Prac.(N.Y.)": "How. Pr.",
-                "N.Y.Spec.Term R.": "How. Pr.",
+                "How.P.R.": "How. Pr.", 
+                "How.Prac.(N.Y.)": "How. Pr.", 
+                "N.Y.Spec.Term R.": "How. Pr.", 
                 "N.Y.Spec.Term Rep.": "How. Pr."
             }
         }
-    ],
+    ], 
     "Howard": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Howard": {
-                    "end": "1843-12-31T00:00:00",
+                    "end": "1843-12-31T00:00:00", 
                     "start": "1834-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ms;supreme.court"
-            ],
-            "name": "Mississippi Reports, Howard",
+                "us:ms;supreme.court"
+            ], 
+            "name": "Mississippi Reports, Howard", 
             "variations": {
-                "How.": "Howard",
+                "How.": "Howard", 
                 "Miss.(Howard)": "Howard"
             }
         }
-    ],
+    ], 
     "Hughes": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Hughes": {
-                    "end": "1801-12-31T00:00:00",
+                    "end": "1801-12-31T00:00:00", 
                     "start": "1785-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ky;supreme.court"
-            ],
-            "name": "Kentucky Reports, Hughes",
+                "us:ky;supreme.court"
+            ], 
+            "name": "Kentucky Reports, Hughes", 
             "variations": {
-                "Hugh.": "Hughes",
+                "Hugh.": "Hughes", 
                 "Ky.(Hughes)": "Hughes"
             }
         }
-    ],
+    ], 
     "Hum.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Hum.": {
-                    "end": "1851-12-31T00:00:00",
+                    "end": "1851-12-31T00:00:00", 
                     "start": "1839-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tn;supreme.court"
-            ],
-            "name": "Tennessee Reports, Humphreys",
+                "us:tn;supreme.court"
+            ], 
+            "name": "Tennessee Reports, Humphreys", 
             "variations": {
-                "Humph.": "Hum.",
+                "Humph.": "Hum.", 
                 "Tenn.(Hum.)": "Hum."
             }
         }
-    ],
+    ], 
     "I.T.R.D. (BNA)": [
         {
-            "cite_type": "specialty",
+            "cite_type": "specialty", 
             "editions": {
                 "I.T.R.D. (BNA)": {
-                    "end": null,
+                    "end": null, 
                     "start": "1980-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;court.appeals.federal.circuit",
-                "us;federal;court.international.trade"
-            ],
-            "name": "International Trade Reporter Decisions",
+                "us:c;court.appeals.federal.circuit", 
+                "us:c;court.international.trade"
+            ], 
+            "name": "International Trade Reporter Decisions", 
             "variations": {}
         }
-    ],
+    ], 
     "Idaho": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Idaho": {
-                    "end": null,
+                    "end": null, 
                     "start": "1982-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;id;supreme.court"
-            ],
-            "name": "Idaho Reports",
+                "us:id;supreme.court"
+            ], 
+            "name": "Idaho Reports", 
             "variations": {
-                "Id.": "Idaho",
+                "Id.": "Idaho", 
                 "Ida.": "Idaho"
             }
         }
-    ],
+    ], 
     "Ill.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ill.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1849-01-01T00:00:00"
-                },
+                }, 
                 "Ill. 2d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1849-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;il;supreme.court"
-            ],
-            "name": "Illinois Reports",
+                "us:il;supreme.court"
+            ], 
+            "name": "Illinois Reports", 
             "variations": {
                 "Ill.2d": "Ill. 2d"
             }
         }
-    ],
+    ], 
     "Ill. App.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ill. App.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1877-01-01T00:00:00"
-                },
+                }, 
                 "Ill. App. 2d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1877-01-01T00:00:00"
-                },
+                }, 
                 "Ill. App. 3d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1877-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;il;supreme.court"
-            ],
-            "name": "Illinois Appellate Court Reports",
+                "us:il;supreme.court"
+            ], 
+            "name": "Illinois Appellate Court Reports", 
             "variations": {
-                "Ill. App.2d": "Ill. App. 2d",
-                "Ill. App.3d": "Ill. App. 3d",
-                "Ill.A.": "Ill. App.",
-                "Ill.A.2d": "Ill. App. 2d",
+                "Ill. App.2d": "Ill. App. 2d", 
+                "Ill. App.3d": "Ill. App. 3d", 
+                "Ill.A.": "Ill. App.", 
+                "Ill.A.2d": "Ill. App. 2d", 
                 "Ill.A.3d": "Ill. App. 3d"
             }
         }
-    ],
+    ], 
     "Ill. Ct. Cl.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ill. Ct. Cl.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1889-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;il;supreme.court"
-            ],
-            "name": "Illinois Court of Claims Reports",
+                "us:il;supreme.court"
+            ], 
+            "name": "Illinois Court of Claims Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Ill. Dec.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ill. Dec.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1976-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;il;supreme.court"
-            ],
-            "name": "West's Illinois Decisions",
+                "us:il;supreme.court"
+            ], 
+            "name": "West's Illinois Decisions", 
             "variations": {
-                "Ill.Dec.": "Ill. Dec.",
+                "Ill.Dec.": "Ill. Dec.", 
                 "Ill.Decs.": "Ill. Dec."
             }
         }
-    ],
+    ], 
     "Ind.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ind.": {
-                    "end": "1981-12-31T00:00:00",
+                    "end": "1981-12-31T00:00:00", 
                     "start": "1848-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;in;supreme.court"
-            ],
-            "name": "Indiana Reports",
+                "us:in;supreme.court"
+            ], 
+            "name": "Indiana Reports", 
             "variations": {
                 "Ind.Rep.": "Ind."
             }
         }
-    ],
+    ], 
     "Ind. App.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ind. App.": {
-                    "end": "1979-12-31T00:00:00",
+                    "end": "1979-12-31T00:00:00", 
                     "start": "1890-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;in;supreme.court"
-            ],
-            "name": "Indiana Court of Appeals Reports",
+                "us:in;supreme.court"
+            ], 
+            "name": "Indiana Court of Appeals Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Indian Terr.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Indian Terr.": {
-                    "end": "1907-12-31T00:00:00",
+                    "end": "1907-12-31T00:00:00", 
                     "start": "1896-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ok;supreme.court"
-            ],
-            "name": "Indian Territory Reports",
+                "us:ok;supreme.court"
+            ], 
+            "name": "Indian Territory Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Iowa": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Iowa": {
-                    "end": "1968-12-31T00:00:00",
+                    "end": "1968-12-31T00:00:00", 
                     "start": "1855-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ia;supreme.court"
-            ],
-            "name": "Iowa Reports",
+                "us:ia;supreme.court"
+            ], 
+            "name": "Iowa Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Ired.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ired.": {
-                    "end": "1852-12-31T00:00:00",
+                    "end": "1852-12-31T00:00:00", 
                     "start": "1840-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nc;supreme.court"
-            ],
-            "name": "North Carolina Reports, Iredell's Law",
+                "us:nc;supreme.court"
+            ], 
+            "name": "North Carolina Reports, Iredell's Law", 
             "variations": {
-                "Ired.L.": "Ired.",
-                "Ired.L.(N.C.)": "Ired.",
+                "Ired.L.": "Ired.", 
+                "Ired.L.(N.C.)": "Ired.", 
                 "N.C.(Ired.)": "Ired."
             }
         }
-    ],
+    ], 
     "Ired. Eq.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ired. Eq.": {
-                    "end": "1852-12-31T00:00:00",
+                    "end": "1852-12-31T00:00:00", 
                     "start": "1840-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nc;supreme.court"
-            ],
-            "name": "North Carolina Reports, Iredell's Equity",
+                "us:nc;supreme.court"
+            ], 
+            "name": "North Carolina Reports, Iredell's Equity", 
             "variations": {
-                "Ired.": "Ired. Eq.",
-                "Ired.Eq.(N.C.)": "Ired. Eq.",
+                "Ired.": "Ired. Eq.", 
+                "Ired.Eq.(N.C.)": "Ired. Eq.", 
                 "N.C.(Ired.Eq.)": "Ired. Eq."
             }
         }
-    ],
+    ], 
     "J.J. Marsh.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "J.J. Marsh.": {
-                    "end": "1832-12-31T00:00:00",
+                    "end": "1832-12-31T00:00:00", 
                     "start": "1829-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ky;supreme.court"
-            ],
-            "name": "Kentucky Reports, Marshall, J.J.",
+                "us:ky;supreme.court"
+            ], 
+            "name": "Kentucky Reports, Marshall, J.J.", 
             "variations": {
-                "J.J.Mar.": "J.J. Marsh.",
-                "J.J.Marsh.(Ky.)": "J.J. Marsh.",
-                "Ky.(J.J.Marsh.)": "J.J. Marsh.",
-                "Marsh.": "J.J. Marsh.",
-                "Marsh.(Ky.)": "J.J. Marsh.",
+                "J.J.Mar.": "J.J. Marsh.", 
+                "J.J.Marsh.(Ky.)": "J.J. Marsh.", 
+                "Ky.(J.J.Marsh.)": "J.J. Marsh.", 
+                "Marsh.": "J.J. Marsh.", 
+                "Marsh.(Ky.)": "J.J. Marsh.", 
                 "Marsh.J.J.": "J.J. Marsh."
             }
         }
-    ],
+    ], 
     "Johns.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Johns.": {
-                    "end": "1823-12-31T00:00:00",
+                    "end": "1823-12-31T00:00:00", 
                     "start": "1806-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Johnson's Reports",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Johnson's Reports", 
             "variations": {
-                "J.": "Johns.",
-                "John.": "Johns.",
-                "Johns.Ct.Err.": "Johns.",
-                "Johns.N.Y.": "Johns.",
-                "Johns.Rep.": "Johns.",
+                "J.": "Johns.", 
+                "John.": "Johns.", 
+                "Johns.Ct.Err.": "Johns.", 
+                "Johns.N.Y.": "Johns.", 
+                "Johns.Rep.": "Johns.", 
                 "Johnson": "Johns."
             }
         }
-    ],
+    ], 
     "Johns. Cas.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Johns. Cas.": {
-                    "end": "1803-12-31T00:00:00",
+                    "end": "1803-12-31T00:00:00", 
                     "start": "1799-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Johnson's Cases",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Johnson's Cases", 
             "variations": {
                 "Johns.Cas.(N.Y.)": "Johns. Cas."
             }
         }
-    ],
+    ], 
     "Johns. Ch.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Johns. Ch.": {
-                    "end": "1823-12-31T00:00:00",
+                    "end": "1823-12-31T00:00:00", 
                     "start": "1814-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Johnsons' Chancery Reports",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Johnsons' Chancery Reports", 
             "variations": {
-                "J.Ch.": "Johns. Ch.",
-                "Johns.": "Johns. Ch.",
-                "Johns.(N.Y.)": "Johns. Ch.",
-                "Johns.Ch.(N.Y.)": "Johns. Ch.",
-                "Johns.Ch.Cas.": "Johns. Ch.",
-                "Johns.Rep.": "Johns. Ch.",
+                "J.Ch.": "Johns. Ch.", 
+                "Johns.": "Johns. Ch.", 
+                "Johns.(N.Y.)": "Johns. Ch.", 
+                "Johns.Ch.(N.Y.)": "Johns. Ch.", 
+                "Johns.Ch.Cas.": "Johns. Ch.", 
+                "Johns.Rep.": "Johns. Ch.", 
                 "Johnson": "Johns. Ch."
             }
         }
-    ],
+    ], 
     "Jones": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Jones": {
-                    "end": "1862-12-31T00:00:00",
+                    "end": "1862-12-31T00:00:00", 
                     "start": "1853-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nc;supreme.court"
-            ],
-            "name": "North Carolina Reports, Jones' Law",
+                "us:nc;supreme.court"
+            ], 
+            "name": "North Carolina Reports, Jones' Law", 
             "variations": {
-                "Jones L.": "Jones",
-                "Jones N.C.": "Jones",
+                "Jones L.": "Jones", 
+                "Jones N.C.": "Jones", 
                 "N.C.(Jones)": "Jones"
             }
         }
-    ],
+    ], 
     "Jones Eq.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Jones Eq.": {
-                    "end": "1863-12-31T00:00:00",
+                    "end": "1863-12-31T00:00:00", 
                     "start": "1853-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nc;supreme.court"
-            ],
-            "name": "North Carolina Reports, Jones' Equity",
+                "us:nc;supreme.court"
+            ], 
+            "name": "North Carolina Reports, Jones' Equity", 
             "variations": {
-                "Jones": "Jones Eq.",
+                "Jones": "Jones Eq.", 
                 "N.C.(Jones Eq.)": "Jones Eq."
             }
         }
-    ],
+    ], 
     "Kan.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Kan.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1862-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ks;supreme.court"
-            ],
-            "name": "Kansas Reports",
+                "us:ks;supreme.court"
+            ], 
+            "name": "Kansas Reports", 
             "variations": {
                 "Kans.": "Kan."
             }
         }
-    ],
+    ], 
     "Kan. App.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Kan. App.": {
-                    "end": "1901-12-31T00:00:00",
+                    "end": "1901-12-31T00:00:00", 
                     "start": "1895-01-01T00:00:00"
-                },
+                }, 
                 "Kan. App. 2d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1977-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ks;supreme.court"
-            ],
-            "name": "Kansas Court of Appeals Reports",
+                "us:ks;supreme.court"
+            ], 
+            "name": "Kansas Court of Appeals Reports", 
             "variations": {
-                "Kan. App.2d": "Kan. App. 2d",
-                "Kan.App.": "Kan. App.",
-                "Kan.App. 2d": "Kan. App. 2d",
-                "Kan.App.2d": "Kan. App. 2d",
+                "Kan. App.2d": "Kan. App. 2d", 
+                "Kan.App.": "Kan. App.", 
+                "Kan.App. 2d": "Kan. App. 2d", 
+                "Kan.App.2d": "Kan. App. 2d", 
                 "Kans.App.": "Kan. App."
             }
         }
-    ],
+    ], 
     "Kirby": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Kirby": {
-                    "end": "1789-12-31T00:00:00",
+                    "end": "1789-12-31T00:00:00", 
                     "start": "1785-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ct;supreme.court"
-            ],
-            "name": "Kirby's Connecticut Reports",
+                "us:ct;supreme.court"
+            ], 
+            "name": "Kirby's Connecticut Reports", 
             "variations": {
-                "Kir.": "Kirby",
+                "Kir.": "Kirby", 
                 "Kirb.": "Kirby"
             }
         }
-    ],
+    ], 
     "Ky.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ky.": {
-                    "end": "1951-12-31T00:00:00",
+                    "end": "1951-12-31T00:00:00", 
                     "start": "1879-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ky;supreme.court"
-            ],
-            "name": "Kentucky Reports",
+                "us:ky;supreme.court"
+            ], 
+            "name": "Kentucky Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Ky. App.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ky. App.": {
-                    "end": "2000-12-31T00:00:00",
+                    "end": "2000-12-31T00:00:00", 
                     "start": "1994-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ky;supreme.court"
-            ],
-            "name": "Kentucky Appellate Reporter",
+                "us:ky;supreme.court"
+            ], 
+            "name": "Kentucky Appellate Reporter", 
             "variations": {}
         }
-    ],
+    ], 
     "Ky. L. Rptr.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ky. L. Rptr.": {
-                    "end": "1908-12-31T00:00:00",
+                    "end": "1908-12-31T00:00:00", 
                     "start": "1880-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ky;supreme.court"
-            ],
-            "name": "Kentucky Law Reporter",
+                "us:ky;supreme.court"
+            ], 
+            "name": "Kentucky Law Reporter", 
             "variations": {
-                "Ken.L.Re.": "Ky. L. Rptr.",
-                "Ky.L.R.": "Ky. L. Rptr.",
+                "Ken.L.Re.": "Ky. L. Rptr.", 
+                "Ky.L.R.": "Ky. L. Rptr.", 
                 "Ky.Law.Rep.": "Ky. L. Rptr."
             }
         }
-    ],
+    ], 
     "Ky. L. Summ.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ky. L. Summ.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1966-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ky;supreme.court"
-            ],
-            "name": "Kentucky Law Summary",
+                "us:ky;supreme.court"
+            ], 
+            "name": "Kentucky Law Summary", 
             "variations": {}
         }
-    ],
+    ], 
     "Ky. Op.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ky. Op.": {
-                    "end": "1886-12-31T00:00:00",
+                    "end": "1886-12-31T00:00:00", 
                     "start": "1864-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ky;supreme.court"
-            ],
-            "name": "Kentucky Opinions",
+                "us:ky;supreme.court"
+            ], 
+            "name": "Kentucky Opinions", 
             "variations": {
                 "Ken.Opin.": "Ky. Op."
             }
         }
-    ],
+    ], 
     "L. Ed.": [
         {
-            "cite_type": "federal",
+            "cite_type": "federal", 
             "editions": {
                 "L. Ed.": {
-                    "end": "1956-12-31T00:00:00",
+                    "end": "1956-12-31T00:00:00", 
                     "start": "1790-01-01T00:00:00"
-                },
+                }, 
                 "L. Ed. 2d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1956-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;supreme.court"
-            ],
-            "name": "Lawyer's Edition",
+                "us;supreme.court"
+            ], 
+            "name": "Lawyer's Edition", 
             "variations": {
-                "L Ed": "L. Ed.",
-                "L Ed 2d": "L. Ed. 2d",
-                "L. Ed.2d": "L. Ed. 2d",
-                "L.E.": "L. Ed.",
-                "L.E.2d": "L. Ed. 2d",
-                "L.Ed.": "L. Ed.",
-                "L.Ed. 2d": "L. Ed. 2d",
-                "L.Ed.(U.S.)": "L. Ed.",
-                "L.Ed.2d": "L. Ed. 2d",
-                "LAW ED": "L. Ed.",
-                "Law.Ed.": "L. Ed.",
-                "U.S.L.Ed.": "L. Ed.",
-                "U.S.L.Ed.2d": "L. Ed. 2d",
+                "L Ed": "L. Ed.", 
+                "L Ed 2d": "L. Ed. 2d", 
+                "L. Ed.2d": "L. Ed. 2d", 
+                "L.E.": "L. Ed.", 
+                "L.E.2d": "L. Ed. 2d", 
+                "L.Ed.": "L. Ed.", 
+                "L.Ed. 2d": "L. Ed. 2d", 
+                "L.Ed.(U.S.)": "L. Ed.", 
+                "L.Ed.2d": "L. Ed. 2d", 
+                "LAW ED": "L. Ed.", 
+                "Law.Ed.": "L. Ed.", 
+                "U.S.L.Ed.": "L. Ed.", 
+                "U.S.L.Ed.2d": "L. Ed. 2d", 
                 "U.S.Law.Ed.": "L. Ed."
             }
         }
-    ],
+    ], 
     "LA": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "LA": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;la;supreme.court"
-            ],
-            "name": "Louisiana Neutral Citation",
+                "us:la;supreme.court"
+            ], 
+            "name": "Louisiana Neutral Citation", 
             "variations": {}
         }
-    ],
+    ], 
     "LEXIS": [
         {
-            "cite_type": "specialty",
+            "cite_type": "specialty", 
             "editions": {
                 "LEXIS": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ak;supreme.court",
-                "us;al;supreme.court",
-                "us;ar;supreme.court",
-                "us;az;supreme.court",
-                "us;ca;supreme.court",
-                "us;co;supreme.court",
-                "us;ct;supreme.court",
-                "us;de;supreme.court",
-                "us;federal;court.appeals.1.circuit",
-                "us;federal;court.appeals.10.circuit",
-                "us;federal;court.appeals.11.circuit",
-                "us;federal;court.appeals.2.circuit",
-                "us;federal;court.appeals.3.circuit",
-                "us;federal;court.appeals.4.circuit",
-                "us;federal;court.appeals.5.circuit",
-                "us;federal;court.appeals.6.circuit",
-                "us;federal;court.appeals.7.circuit",
-                "us;federal;court.appeals.8.circuit",
-                "us;federal;court.appeals.9.circuit",
-                "us;federal;district.columbia.court.appeals",
-                "us;fl;supreme.court",
-                "us;ga;supreme.court",
-                "us;hi;supreme.court",
-                "us;ia;supreme.court",
-                "us;id;supreme.court",
-                "us;il;supreme.court",
-                "us;in;supreme.court",
-                "us;ks;supreme.court",
-                "us;ky;supreme.court",
-                "us;la;supreme.court",
-                "us;ma;appeals.court",
-                "us;me;supreme.judicial.court",
-                "us;mi;supreme.court",
-                "us;mn;supreme.court",
-                "us;mo;supreme.court",
-                "us;ms;supreme.court",
-                "us;mt;supreme.court",
-                "us;nc;supreme.court",
-                "us;nd;supreme.court",
-                "us;ne;supreme.court",
-                "us;nh;supreme.court",
-                "us;nj;supreme.court",
-                "us;nm;supreme.court",
-                "us;nv;supreme.court",
-                "us;ny;court.appeals",
-                "us;oh;supreme.court",
-                "us;ok;supreme.court",
-                "us;or;supreme.court",
-                "us;pa;supreme.court",
-                "us;ri;supreme.court",
-                "us;sc;supreme.court",
-                "us;sd;supreme.court",
-                "us;tn;supreme.court",
-                "us;tx;supreme.court",
-                "us;ut;supreme.court",
-                "us;va;supreme.court",
-                "us;vt;supreme.court",
-                "us;wa;supreme.court",
-                "us;wi;supreme.court",
-                "us;wv;supreme.court",
-                "us;wy;supreme.court"
-            ],
-            "name": "LexisNexis Citation",
+                "us:ak;supreme.court", 
+                "us:al;supreme.court", 
+                "us:ar;supreme.court", 
+                "us:az;supreme.court", 
+                "us:c10;court.appeals", 
+                "us:c11;court.appeals", 
+                "us:c1;court.appeals", 
+                "us:c2;court.appeals", 
+                "us:c3;court.appeals", 
+                "us:c4;court.appeals", 
+                "us:c5;court.appeals", 
+                "us:c6;court.appeals", 
+                "us:c7;court.appeals", 
+                "us:c8;court.appeals", 
+                "us:c9;court.appeals", 
+                "us:ca;supreme.court", 
+                "us:co;supreme.court", 
+                "us:ct;supreme.court", 
+                "us:dc;court.appeals", 
+                "us:de;supreme.court", 
+                "us:fl;supreme.court", 
+                "us:ga;supreme.court", 
+                "us:hi;supreme.court", 
+                "us:ia;supreme.court", 
+                "us:id;supreme.court", 
+                "us:il;supreme.court", 
+                "us:in;supreme.court", 
+                "us:ks;supreme.court", 
+                "us:ky;supreme.court", 
+                "us:la;supreme.court", 
+                "us:ma;appeals.court", 
+                "us:me;supreme.judicial.court", 
+                "us:mi;supreme.court", 
+                "us:mn;supreme.court", 
+                "us:mo;supreme.court", 
+                "us:ms;supreme.court", 
+                "us:mt;supreme.court", 
+                "us:nc;supreme.court", 
+                "us:nd;supreme.court", 
+                "us:ne;supreme.court", 
+                "us:nh;supreme.court", 
+                "us:nj;supreme.court", 
+                "us:nm;supreme.court", 
+                "us:nv;supreme.court", 
+                "us:ny;court.appeals", 
+                "us:oh;supreme.court", 
+                "us:ok;supreme.court", 
+                "us:or;supreme.court", 
+                "us:pa;supreme.court", 
+                "us:ri;supreme.court", 
+                "us:sc;supreme.court", 
+                "us:sd;supreme.court", 
+                "us:tn;supreme.court", 
+                "us:tx;supreme.court", 
+                "us:ut;supreme.court", 
+                "us:va;supreme.court", 
+                "us:vt;supreme.court", 
+                "us:wa;supreme.court", 
+                "us:wi;supreme.court", 
+                "us:wv;supreme.court", 
+                "us:wy;supreme.court"
+            ], 
+            "name": "LexisNexis Citation", 
             "variations": {}
         }
-    ],
+    ], 
     "La.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "La.": {
-                    "end": "1972-12-31T00:00:00",
+                    "end": "1972-12-31T00:00:00", 
                     "start": "1830-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;la;supreme.court"
-            ],
-            "name": "Louisiana Reports",
+                "us:la;supreme.court"
+            ], 
+            "name": "Louisiana Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "La. Ann.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "La. Ann.": {
-                    "end": "1900-12-31T00:00:00",
+                    "end": "1900-12-31T00:00:00", 
                     "start": "1846-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;la;supreme.court"
-            ],
-            "name": "Louisiana Annual Reports",
+                "us:la;supreme.court"
+            ], 
+            "name": "Louisiana Annual Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "La. App.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "La. App.": {
-                    "end": "1932-12-31T00:00:00",
+                    "end": "1932-12-31T00:00:00", 
                     "start": "1924-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;la;supreme.court"
-            ],
-            "name": "Louisiana Court of Appeals Reports",
+                "us:la;supreme.court"
+            ], 
+            "name": "Louisiana Court of Appeals Reports", 
             "variations": {
                 "La.A.": "La. App."
             }
         }
-    ],
+    ], 
     "Lans.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Lans.": {
-                    "end": "1873-12-31T00:00:00",
+                    "end": "1873-12-31T00:00:00", 
                     "start": "1869-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Lansing's Reports",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Lansing's Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Lans. Ch.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Lans. Ch.": {
-                    "end": "1826-12-31T00:00:00",
+                    "end": "1826-12-31T00:00:00", 
                     "start": "1824-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Lansing's Chancery Reports",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Lansing's Chancery Reports", 
             "variations": {
-                "L.": "Lans. Ch.",
+                "L.": "Lans. Ch.", 
                 "Lans.": "Lans. Ch."
             }
         }
-    ],
+    ], 
     "Leigh": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Leigh": {
-                    "end": "1842-12-31T00:00:00",
+                    "end": "1842-12-31T00:00:00", 
                     "start": "1829-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;va;supreme.court"
-            ],
-            "name": "Virginia Reports, Leigh",
+                "us:va;supreme.court"
+            ], 
+            "name": "Virginia Reports, Leigh", 
             "variations": {
-                "Leigh (Va.)": "Leigh",
+                "Leigh (Va.)": "Leigh", 
                 "Va.(Leigh)": "Leigh"
             }
         }
-    ],
+    ], 
     "Litt.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Litt.": {
-                    "end": "1824-12-31T00:00:00",
+                    "end": "1824-12-31T00:00:00", 
                     "start": "1822-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ky;supreme.court"
-            ],
-            "name": "Kentucky Reports, Littell",
+                "us:ky;supreme.court"
+            ], 
+            "name": "Kentucky Reports, Littell", 
             "variations": {
-                "Ky.(Litt.)": "Litt.",
-                "Lit.": "Litt.",
-                "Litt.(Ky.)": "Litt.",
+                "Ky.(Litt.)": "Litt.", 
+                "Lit.": "Litt.", 
+                "Litt.(Ky.)": "Litt.", 
                 "Littell": "Litt."
             }
         }
-    ],
+    ], 
     "Litt. Sel. Cas.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Litt. Sel. Cas.": {
-                    "end": "1821-12-31T00:00:00",
+                    "end": "1821-12-31T00:00:00", 
                     "start": "1795-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ky;supreme.court"
-            ],
-            "name": "Kentucky Reports, Littell's Selected Cases",
+                "us:ky;supreme.court"
+            ], 
+            "name": "Kentucky Reports, Littell's Selected Cases", 
             "variations": {
-                "Ky.(Lit.Sel.Cas.)": "Litt. Sel. Cas.",
+                "Ky.(Lit.Sel.Cas.)": "Litt. Sel. Cas.", 
                 "Lit.Sel.Ca.": "Litt. Sel. Cas."
             }
         }
-    ],
+    ], 
     "Lock. Rev. Cas.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Lock. Rev. Cas.": {
-                    "end": "1847-12-31T00:00:00",
+                    "end": "1847-12-31T00:00:00", 
                     "start": "1799-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Lockwood's Reversed Cases",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Lockwood's Reversed Cases", 
             "variations": {}
         }
-    ],
+    ], 
     "M.J.": [
         {
-            "cite_type": "specialty",
+            "cite_type": "specialty", 
             "editions": {
                 "M.J.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1975-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;court.appeals.armed.forces"
-            ],
-            "name": "Military Justice Reporter",
+                "us:c;court.appeals.armed.forces"
+            ], 
+            "name": "Military Justice Reporter", 
             "variations": {
                 "M. J.": "M.J."
             }
         }
-    ],
+    ], 
     "ME": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "ME": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;me;supreme.judicial.court"
-            ],
-            "name": "Maine Neutral Citation",
+                "us:me;supreme.judicial.court"
+            ], 
+            "name": "Maine Neutral Citation", 
             "variations": {}
         }
-    ],
+    ], 
     "MS": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "MS": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ms;supreme.court"
-            ],
-            "name": "Mississippi Neutral Citation",
+                "us:ms;supreme.court"
+            ], 
+            "name": "Mississippi Neutral Citation", 
             "variations": {}
         }
-    ],
+    ], 
     "MT": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "MT": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;mt;supreme.court"
-            ],
-            "name": "Montana Neutral Citation",
+                "us:mt;supreme.court"
+            ], 
+            "name": "Montana Neutral Citation", 
             "variations": {}
         }
-    ],
+    ], 
     "MacArth.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "MacArth.": {
-                    "end": "1879-12-31T00:00:00",
+                    "end": "1879-12-31T00:00:00", 
                     "start": "1873-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;district.columbia.court.appeals"
-            ],
-            "name": "District of Columbia Reports, MacArthur",
+                "us:dc;court.appeals"
+            ], 
+            "name": "District of Columbia Reports, MacArthur", 
             "variations": {
-                "D.C.(MacArth.)": "MacArth.",
-                "MacAr.": "MacArth.",
+                "D.C.(MacArth.)": "MacArth.", 
+                "MacAr.": "MacArth.", 
                 "MacArthur": "MacArth."
             }
         }
-    ],
+    ], 
     "MacArth. & M.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "MacArth. & M.": {
-                    "end": "1880-12-31T00:00:00",
+                    "end": "1880-12-31T00:00:00", 
                     "start": "1879-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;district.columbia.court.appeals"
-            ],
-            "name": "District of Columbia Reports, MacArthur and Mackey",
+                "us:dc;court.appeals"
+            ], 
+            "name": "District of Columbia Reports, MacArthur and Mackey", 
             "variations": {
-                "D.C.(MacArth.& M.)": "MacArth. & M.",
-                "MacAr.& M.": "MacArth. & M.",
-                "MacAr.& Mackey": "MacArth. & M.",
-                "MacArth.& M.(Dist.Col.)": "MacArth. & M.",
+                "D.C.(MacArth.& M.)": "MacArth. & M.", 
+                "MacAr.& M.": "MacArth. & M.", 
+                "MacAr.& Mackey": "MacArth. & M.", 
+                "MacArth.& M.(Dist.Col.)": "MacArth. & M.", 
                 "MacArthur & M.": "MacArth. & M."
             }
         }
-    ],
+    ], 
     "Mackey": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Mackey": {
-                    "end": "1892-12-31T00:00:00",
+                    "end": "1892-12-31T00:00:00", 
                     "start": "1863-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;district.columbia.court.appeals"
-            ],
-            "name": "District of Columbia Reports, Mackey",
+                "us:dc;court.appeals"
+            ], 
+            "name": "District of Columbia Reports, Mackey", 
             "variations": {
                 "D.C.(Mackey)": "Mackey"
             }
         }
-    ],
+    ], 
     "Mart.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Mart.": {
-                    "end": "1830-12-31T00:00:00",
+                    "end": "1830-12-31T00:00:00", 
                     "start": "1809-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;la;supreme.court"
-            ],
-            "name": "Louisiana Reports, Martin",
+                "us:la;supreme.court"
+            ], 
+            "name": "Louisiana Reports, Martin", 
             "variations": {}
-        },
+        }, 
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Mart.": {
-                    "end": "1797-12-31T00:00:00",
+                    "end": "1797-12-31T00:00:00", 
                     "start": "1778-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nc;supreme.court"
-            ],
-            "name": "North Carolina Reports, Martin",
+                "us:nc;supreme.court"
+            ], 
+            "name": "North Carolina Reports, Martin", 
             "variations": {
-                "Mart.Dec.": "Mart.",
-                "Mart.N.C.": "Mart.",
-                "Martin": "Mart.",
+                "Mart.Dec.": "Mart.", 
+                "Mart.N.C.": "Mart.", 
+                "Martin": "Mart.", 
                 "N.C.(Mart.)": "Mart."
             }
         }
-    ],
+    ], 
     "Mart. & Yer.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Mart. & Yer.": {
-                    "end": "1828-12-31T00:00:00",
+                    "end": "1828-12-31T00:00:00", 
                     "start": "1825-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tn;supreme.court"
-            ],
-            "name": "Tennessee Reports, Martin & Yerger",
+                "us:tn;supreme.court"
+            ], 
+            "name": "Tennessee Reports, Martin & Yerger", 
             "variations": {
-                "M.& Y.": "Mart. & Yer.",
-                "M.& Y.R.": "Mart. & Yer.",
-                "Mart.& Y.": "Mart. & Yer.",
-                "Mart.& Y.(Tenn.)": "Mart. & Yer.",
+                "M.& Y.": "Mart. & Yer.", 
+                "M.& Y.R.": "Mart. & Yer.", 
+                "Mart.& Y.": "Mart. & Yer.", 
+                "Mart.& Y.(Tenn.)": "Mart. & Yer.", 
                 "Mart.& Yerg.": "Mart. & Yer."
             }
         }
-    ],
+    ], 
     "Marvel": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Marvel": {
-                    "end": "1897-12-31T00:00:00",
+                    "end": "1897-12-31T00:00:00", 
                     "start": "1893-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;de;supreme.court"
-            ],
-            "name": "Delaware Reports, Marvel",
+                "us:de;supreme.court"
+            ], 
+            "name": "Delaware Reports, Marvel", 
             "variations": {}
         }
-    ],
+    ], 
     "Mass.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Mass.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1867-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ma;appeals.court"
-            ],
-            "name": "Massachusetts Reports",
+                "us:ma;appeals.court"
+            ], 
+            "name": "Massachusetts Reports", 
             "variations": {
-                "Ma.": "Mass.",
+                "Ma.": "Mass.", 
                 "Mas.": "Mass."
             }
         }
-    ],
+    ], 
     "Mass. App. Ct.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Mass. App. Ct.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1972-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ma;appeals.court"
-            ],
-            "name": "Massachusetts Appeals Court Reports",
+                "us:ma;appeals.court"
+            ], 
+            "name": "Massachusetts Appeals Court Reports", 
             "variations": {
                 "Ma.A.": "Mass. App. Ct."
             }
         }
-    ],
+    ], 
     "Mass. App. Dec.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Mass. App. Dec.": {
-                    "end": "1977-12-31T00:00:00",
+                    "end": "1977-12-31T00:00:00", 
                     "start": "1941-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ma;appeals.court"
-            ],
-            "name": "Massachusetts Appellate Decisions",
+                "us:ma;appeals.court"
+            ], 
+            "name": "Massachusetts Appellate Decisions", 
             "variations": {}
         }
-    ],
+    ], 
     "Mass. App. Div.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Mass. App. Div.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1936-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ma;appeals.court"
-            ],
-            "name": "Reports of Massachusetts Appellate Division",
+                "us:ma;appeals.court"
+            ], 
+            "name": "Reports of Massachusetts Appellate Division", 
             "variations": {}
         }
-    ],
+    ], 
     "Mass. Supp.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Mass. Supp.": {
-                    "end": "1983-12-31T00:00:00",
+                    "end": "1983-12-31T00:00:00", 
                     "start": "1980-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ma;appeals.court"
-            ],
-            "name": "Massachusetts Reports Supplement",
+                "us:ma;appeals.court"
+            ], 
+            "name": "Massachusetts Reports Supplement", 
             "variations": {}
         }
-    ],
+    ], 
     "McCahon": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "McCahon": {
-                    "end": "1868-12-31T00:00:00",
+                    "end": "1868-12-31T00:00:00", 
                     "start": "1858-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ks;supreme.court"
-            ],
-            "name": "Kansas Reports, McCahon",
+                "us:ks;supreme.court"
+            ], 
+            "name": "Kansas Reports, McCahon", 
             "variations": {
                 "McCah.": "McCahon"
             }
         }
-    ],
+    ], 
     "McCord": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "McCord": {
-                    "end": "1828-12-31T00:00:00",
+                    "end": "1828-12-31T00:00:00", 
                     "start": "1821-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, McCord",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, McCord", 
             "variations": {
                 "S.C.L.(McCord)": "McCord"
             }
         }
-    ],
+    ], 
     "McCord Eq.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "McCord Eq.": {
-                    "end": "1827-12-31T00:00:00",
+                    "end": "1827-12-31T00:00:00", 
                     "start": "1825-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, McCord's Chancery",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, McCord's Chancery", 
             "variations": {
-                "McCord Ch.": "McCord Eq.",
+                "McCord Ch.": "McCord Eq.", 
                 "S.C.L.(McCord Eq.)": "McCord Eq."
             }
         }
-    ],
+    ], 
     "McGl.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "McGl.": {
-                    "end": "1884-12-31T00:00:00",
+                    "end": "1884-12-31T00:00:00", 
                     "start": "1881-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;la;supreme.court"
-            ],
-            "name": "Louisiana Court of Appeals Reports, McGloin",
+                "us:la;supreme.court"
+            ], 
+            "name": "Louisiana Court of Appeals Reports, McGloin", 
             "variations": {
                 "McGloin": "McGl."
             }
         }
-    ],
+    ], 
     "McMul.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "McMul.": {
-                    "end": "1842-12-31T00:00:00",
+                    "end": "1842-12-31T00:00:00", 
                     "start": "1840-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, McMullen",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, McMullen", 
             "variations": {
-                "McMul.L.(S.C.)": "McMul.",
+                "McMul.L.(S.C.)": "McMul.", 
                 "S.C.L.(McMul.)": "McMul."
             }
         }
-    ],
+    ], 
     "McMul. Eq.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "McMul. Eq.": {
-                    "end": "1842-12-31T00:00:00",
+                    "end": "1842-12-31T00:00:00", 
                     "start": "1840-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, McMullen's Equity",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, McMullen's Equity", 
             "variations": {
-                "McMul.Eq.(S.C.)": "McMul. Eq.",
+                "McMul.Eq.(S.C.)": "McMul. Eq.", 
                 "S.C.L.(McMullan Eq.)": "McMul. Eq."
             }
         }
-    ],
+    ], 
     "Md.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Md.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1851-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;md;court.appeals"
-            ],
-            "name": "Maryland Reports",
+                "us:md;court.appeals"
+            ], 
+            "name": "Maryland Reports", 
             "variations": {
                 "Maryland": "Md."
             }
         }
-    ],
+    ], 
     "Md. App.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Md. App.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1967-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;md;court.appeals"
-            ],
-            "name": "Maryland Appellate Reports",
+                "us:md;court.appeals"
+            ], 
+            "name": "Maryland Appellate Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Me.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Me.": {
-                    "end": "1965-12-31T00:00:00",
+                    "end": "1965-12-31T00:00:00", 
                     "start": "1820-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;me;supreme.judicial.court"
-            ],
-            "name": "Maine Reports",
+                "us:me;supreme.judicial.court"
+            ], 
+            "name": "Maine Reports", 
             "variations": {
-                "Mai.": "Me.",
+                "Mai.": "Me.", 
                 "Maine": "Me."
             }
         }
-    ],
+    ], 
     "Meigs": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Meigs": {
-                    "end": "1839-12-31T00:00:00",
+                    "end": "1839-12-31T00:00:00", 
                     "start": "1838-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tn;supreme.court"
-            ],
-            "name": "Tennessee Reports, Meigs",
+                "us:tn;supreme.court"
+            ], 
+            "name": "Tennessee Reports, Meigs", 
             "variations": {
                 "Tenn.(Meigs)": "Meigs"
             }
         }
-    ],
+    ], 
     "Met.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Met.": {
-                    "end": "1863-12-31T00:00:00",
+                    "end": "1863-12-31T00:00:00", 
                     "start": "1858-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ky;supreme.court"
-            ],
-            "name": "Kentucky Reports, Metcalf",
+                "us:ky;supreme.court"
+            ], 
+            "name": "Kentucky Reports, Metcalf", 
             "variations": {
-                "Ky.(Met.)": "Met.",
-                "Metc.": "Met.",
+                "Ky.(Met.)": "Met.", 
+                "Metc.": "Met.", 
                 "Metc.Ky.": "Met."
             }
-        },
+        }, 
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Met.": {
-                    "end": "1847-12-31T00:00:00",
+                    "end": "1847-12-31T00:00:00", 
                     "start": "1840-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ma;appeals.court"
-            ],
-            "name": "Massachusetts Reports, Metcalf",
+                "us:ma;appeals.court"
+            ], 
+            "name": "Massachusetts Reports, Metcalf", 
             "variations": {
-                "Mass.(Met.)": "Met.",
-                "Metc.": "Met.",
+                "Mass.(Met.)": "Met.", 
+                "Metc.": "Met.", 
                 "Metc.Mass.": "Met."
             }
         }
-    ],
+    ], 
     "Mich.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Mich.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1847-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;mi;supreme.court"
-            ],
-            "name": "Michigan Reports",
+                "us:mi;supreme.court"
+            ], 
+            "name": "Michigan Reports", 
             "variations": {
                 "Mich.": "Mich."
             }
         }
-    ],
+    ], 
     "Mich. App.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Mich. App.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1965-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;mi;supreme.court"
-            ],
-            "name": "Michigan Appeals Reports",
+                "us:mi;supreme.court"
+            ], 
+            "name": "Michigan Appeals Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Mich. Ct. Cl.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Mich. Ct. Cl.": {
-                    "end": "1942-12-31T00:00:00",
+                    "end": "1942-12-31T00:00:00", 
                     "start": "1938-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;mi;supreme.court"
-            ],
-            "name": "Michigan Court of Claims Reports",
+                "us:mi;supreme.court"
+            ], 
+            "name": "Michigan Court of Claims Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Mill": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Mill": {
-                    "end": "1818-12-31T00:00:00",
+                    "end": "1818-12-31T00:00:00", 
                     "start": "1817-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Mill (Constitutional)",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Mill (Constitutional)", 
             "variations": {
-                "Const.": "Mill",
-                "Const.S.C.": "Mill",
-                "Mill Const.": "Mill",
-                "Mill Const.(S.C.)": "Mill",
+                "Const.": "Mill", 
+                "Const.S.C.": "Mill", 
+                "Mill Const.": "Mill", 
+                "Mill Const.(S.C.)": "Mill", 
                 "S.C.L.(Mill)": "Mill"
             }
         }
-    ],
+    ], 
     "Minn.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Minn.": {
-                    "end": "1977-12-31T00:00:00",
+                    "end": "1977-12-31T00:00:00", 
                     "start": "1851-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;mn;supreme.court"
-            ],
-            "name": "Minnesota Reports",
+                "us:mn;supreme.court"
+            ], 
+            "name": "Minnesota Reports", 
             "variations": {
                 "Min.": "Minn."
             }
         }
-    ],
+    ], 
     "Minor": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Minor": {
-                    "end": "1826-01-01T00:00:00",
+                    "end": "1826-01-01T00:00:00", 
                     "start": "1820-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;al;supreme.court"
-            ],
-            "name": "Minor's Alabama Reports",
+                "us:al;supreme.court"
+            ], 
+            "name": "Minor's Alabama Reports", 
             "variations": {
-                "Min.": "Minor",
+                "Min.": "Minor", 
                 "Minor (Ala.)": "Minor"
             }
         }
-    ],
+    ], 
     "Misc.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Misc.": {
-                    "end": "1955-12-31T00:00:00",
+                    "end": "1955-12-31T00:00:00", 
                     "start": "1892-01-01T00:00:00"
-                },
+                }, 
                 "Misc. 2d": {
-                    "end": "2004-12-31T00:00:00",
+                    "end": "2004-12-31T00:00:00", 
                     "start": "1955-01-01T00:00:00"
-                },
+                }, 
                 "Misc. 3d": {
-                    "end": null,
+                    "end": null, 
                     "start": "2004-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "New York Miscellaneous Reports",
+                "us:ny;court.appeals"
+            ], 
+            "name": "New York Miscellaneous Reports", 
             "variations": {
-                "Misc 2d": "Misc. 2d",
-                "Misc 3d": "Misc. 3d",
-                "Misc.2d": "Misc. 2d",
+                "Misc 2d": "Misc. 2d", 
+                "Misc 3d": "Misc. 3d", 
+                "Misc.2d": "Misc. 2d", 
                 "Misc.3d": "Misc. 3d"
             }
         }
-    ],
+    ], 
     "Miss.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Miss.": {
-                    "end": "1966-12-31T00:00:00",
+                    "end": "1966-12-31T00:00:00", 
                     "start": "1851-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ms;supreme.court"
-            ],
-            "name": "Mississippi Reports",
+                "us:ms;supreme.court"
+            ], 
+            "name": "Mississippi Reports", 
             "variations": {
                 "Mis.": "Miss."
             }
         }
-    ],
+    ], 
     "Mo.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Mo.": {
-                    "end": "1956-12-31T00:00:00",
+                    "end": "1956-12-31T00:00:00", 
                     "start": "1821-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;mo;supreme.court"
-            ],
-            "name": "Missouri Reports",
+                "us:mo;supreme.court"
+            ], 
+            "name": "Missouri Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Mo. App.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Mo. App.": {
-                    "end": "1954-12-31T00:00:00",
+                    "end": "1954-12-31T00:00:00", 
                     "start": "1876-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;mo;supreme.court"
-            ],
-            "name": "Missouri Appeals Reports",
+                "us:mo;supreme.court"
+            ], 
+            "name": "Missouri Appeals Reports", 
             "variations": {
                 "Mo.App.Rep.": "Mo. App."
             }
         }
-    ],
+    ], 
     "Monag.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Monag.": {
-                    "end": "1890-12-31T00:00:00",
+                    "end": "1890-12-31T00:00:00", 
                     "start": "1888-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;pa;supreme.court"
-            ],
-            "name": "Pennsylvania State Reports, Monaghan",
+                "us:pa;supreme.court"
+            ], 
+            "name": "Pennsylvania State Reports, Monaghan", 
             "variations": {
-                "Mon.": "Monag.",
-                "Mona.": "Monag.",
-                "Monaghan": "Monag.",
+                "Mon.": "Monag.", 
+                "Mona.": "Monag.", 
+                "Monaghan": "Monag.", 
                 "Monaghan(Pa.)": "Monag."
             }
         }
-    ],
+    ], 
     "Mont.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Mont.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1868-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;mt;supreme.court"
-            ],
-            "name": "Montana Reports",
+                "us:mt;supreme.court"
+            ], 
+            "name": "Montana Reports", 
             "variations": {
                 "Mont.": "Mont."
             }
         }
-    ],
+    ], 
     "Morris": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Morris": {
-                    "end": "1846-12-31T00:00:00",
+                    "end": "1846-12-31T00:00:00", 
                     "start": "1839-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ia;supreme.court"
-            ],
-            "name": "Iowa Reports, Morris",
+                "us:ia;supreme.court"
+            ], 
+            "name": "Iowa Reports, Morris", 
             "variations": {
-                "Mor.Ia.": "Morris",
+                "Mor.Ia.": "Morris", 
                 "Morr.": "Morris"
             }
         }
-    ],
+    ], 
     "Munf.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Munf.": {
-                    "end": "1820-12-31T00:00:00",
+                    "end": "1820-12-31T00:00:00", 
                     "start": "1810-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;va;supreme.court"
-            ],
-            "name": "Virginia Reports, Munford",
+                "us:va;supreme.court"
+            ], 
+            "name": "Virginia Reports, Munford", 
             "variations": {}
         }
-    ],
+    ], 
     "Mur.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Mur.": {
-                    "end": "1819-12-31T00:00:00",
+                    "end": "1819-12-31T00:00:00", 
                     "start": "1804-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nc;supreme.court"
-            ],
-            "name": "North Carolina Reports, Murphey",
+                "us:nc;supreme.court"
+            ], 
+            "name": "North Carolina Reports, Murphey", 
             "variations": {
-                "Murph.": "Mur.",
-                "Murph.(N.C.)": "Mur.",
+                "Murph.": "Mur.", 
+                "Murph.(N.C.)": "Mur.", 
                 "N.C.(Mur.)": "Mur."
             }
         }
-    ],
+    ], 
     "N. Chip.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "N. Chip.": {
-                    "end": "1791-12-31T00:00:00",
+                    "end": "1791-12-31T00:00:00", 
                     "start": "1789-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;vt;supreme.court"
-            ],
-            "name": "Vermont Reports, Chipman, N.",
+                "us:vt;supreme.court"
+            ], 
+            "name": "Vermont Reports, Chipman, N.", 
             "variations": {
-                "Chip.N.": "N. Chip.",
-                "N.Chip.(Vt.)": "N. Chip.",
+                "Chip.N.": "N. Chip.", 
+                "N.Chip.(Vt.)": "N. Chip.", 
                 "N.Chipm.": "N. Chip."
             }
         }
-    ],
+    ], 
     "N. Mar. I.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "N. Mar. I.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1989-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;district.court.northern.mariana.islands"
-            ],
-            "name": "Northern Mariana Islands Reporter",
+                "us:c9:mp.d;district.court"
+            ], 
+            "name": "Northern Mariana Islands Reporter", 
             "variations": {}
         }
-    ],
+    ], 
     "N. Mar. I. Commw. Rptr.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "N. Mar. I. Commw. Rptr.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1979-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;district.court.northern.mariana.islands"
-            ],
-            "name": "Northern Mariana Islands Commonwealth Reporter",
+                "us:c9:mp.d;district.court"
+            ], 
+            "name": "Northern Mariana Islands Commonwealth Reporter", 
             "variations": {}
         }
-    ],
+    ], 
     "N.C.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "N.C.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1868-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nc;supreme.court"
-            ],
-            "name": "North Carolina Reports",
+                "us:nc;supreme.court"
+            ], 
+            "name": "North Carolina Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "N.C. App.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "N.C. App.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1968-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nc;supreme.court"
-            ],
-            "name": "North Carolina Court of Appeals Reports",
+                "us:nc;supreme.court"
+            ], 
+            "name": "North Carolina Court of Appeals Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "N.D.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "N.D.": {
-                    "end": "1953-12-31T00:00:00",
+                    "end": "1953-12-31T00:00:00", 
                     "start": "1890-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nd;supreme.court"
-            ],
-            "name": "North Dakota Reports",
+                "us:nd;supreme.court"
+            ], 
+            "name": "North Dakota Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "N.E.": [
         {
-            "cite_type": "state_regional",
+            "cite_type": "state_regional", 
             "editions": {
                 "N.E.": {
-                    "end": "1936-12-31T00:00:00",
+                    "end": "1936-12-31T00:00:00", 
                     "start": "1884-01-01T00:00:00"
-                },
+                }, 
                 "N.E.2d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1936-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;il;supreme.court",
-                "us;in;supreme.court",
-                "us;ma;appeals.court",
-                "us;ny;court.appeals",
-                "us;oh;supreme.court"
-            ],
-            "name": "North Eastern Reporter",
+                "us:il;supreme.court", 
+                "us:in;supreme.court", 
+                "us:ma;appeals.court", 
+                "us:ny;court.appeals", 
+                "us:oh;supreme.court"
+            ], 
+            "name": "North Eastern Reporter", 
             "variations": {
-                "N. E.": "N.E.",
-                "N. E. 2d": "N.E.2d",
-                "N. E.2d": "N.E.2d",
-                "N.E. 2d": "N.E.2d",
-                "N.E.Rep.": "N.E.",
-                "NE": "N.E.",
-                "NE 2d": "N.E.2d",
+                "N. E.": "N.E.", 
+                "N. E. 2d": "N.E.2d", 
+                "N. E.2d": "N.E.2d", 
+                "N.E. 2d": "N.E.2d", 
+                "N.E.Rep.": "N.E.", 
+                "NE": "N.E.", 
+                "NE 2d": "N.E.2d", 
                 "No.East Rep.": "N.E."
             }
         }
-    ],
+    ], 
     "N.H.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "N.H.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1816-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nh;supreme.court"
-            ],
-            "name": "New Hampshire Reports",
+                "us:nh;supreme.court"
+            ], 
+            "name": "New Hampshire Reports", 
             "variations": {
                 "N.H.R.": "N.H."
             }
         }
-    ],
+    ], 
     "N.J.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "N.J.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1948-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nj;supreme.court"
-            ],
-            "name": "New Jersey Reports",
+                "us:nj;supreme.court"
+            ], 
+            "name": "New Jersey Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "N.J. Admin.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "N.J. Admin.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1982-01-01T00:00:00"
-                },
+                }, 
                 "N.J. Admin. 2d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1982-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nj;supreme.court"
-            ],
-            "name": "New Jersey Administrative Reports",
+                "us:nj;supreme.court"
+            ], 
+            "name": "New Jersey Administrative Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "N.J. Eq.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "N.J. Eq.": {
-                    "end": "1948-12-31T00:00:00",
+                    "end": "1948-12-31T00:00:00", 
                     "start": "1830-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nj;supreme.court"
-            ],
-            "name": "New Jersey Equity Reports",
+                "us:nj;supreme.court"
+            ], 
+            "name": "New Jersey Equity Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "N.J. Misc.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "N.J. Misc.": {
-                    "end": "1949-12-31T00:00:00",
+                    "end": "1949-12-31T00:00:00", 
                     "start": "1923-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nj;supreme.court"
-            ],
-            "name": "New Jersey Miscellaneous Reports",
+                "us:nj;supreme.court"
+            ], 
+            "name": "New Jersey Miscellaneous Reports", 
             "variations": {
-                "N.J.M.": "N.J. Misc.",
+                "N.J.M.": "N.J. Misc.", 
                 "NJM": "N.J. Misc."
             }
         }
-    ],
+    ], 
     "N.J. Super.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "N.J. Super.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1948-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nj;supreme.court"
-            ],
-            "name": "New Jersey Superior Court Reports",
+                "us:nj;supreme.court"
+            ], 
+            "name": "New Jersey Superior Court Reports", 
             "variations": {
                 "N.J.S.": "N.J. Super."
             }
         }
-    ],
+    ], 
     "N.J. Tax": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "N.J. Tax": {
-                    "end": null,
+                    "end": null, 
                     "start": "1979-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nj;supreme.court"
-            ],
-            "name": "New Jersey Tax Court",
+                "us:nj;supreme.court"
+            ], 
+            "name": "New Jersey Tax Court", 
             "variations": {}
         }
-    ],
+    ], 
     "N.J.L.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "N.J.L.": {
-                    "end": "1948-12-31T00:00:00",
+                    "end": "1948-12-31T00:00:00", 
                     "start": "1790-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nj;supreme.court"
-            ],
-            "name": "New Jersey Law Reports",
+                "us:nj;supreme.court"
+            ], 
+            "name": "New Jersey Law Reports", 
             "variations": {
                 "N.J.Law": "N.J.L."
             }
         }
-    ],
+    ], 
     "N.M.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "N.M.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1852-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nm;supreme.court"
-            ],
-            "name": "New Mexico Reports",
+                "us:nm;supreme.court"
+            ], 
+            "name": "New Mexico Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "N.W.": [
         {
-            "cite_type": "state_regional",
+            "cite_type": "state_regional", 
             "editions": {
                 "N.W.": {
-                    "end": "1942-12-31T00:00:00",
+                    "end": "1942-12-31T00:00:00", 
                     "start": "1880-01-01T00:00:00"
-                },
+                }, 
                 "N.W.2d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1942-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ia;supreme.court",
-                "us;mi;supreme.court",
-                "us;mn;supreme.court",
-                "us;nd;supreme.court",
-                "us;ne;supreme.court",
-                "us;sd;supreme.court",
-                "us;wi;supreme.court"
-            ],
-            "name": "North Western Reporter",
+                "us:ia;supreme.court", 
+                "us:mi;supreme.court", 
+                "us:mn;supreme.court", 
+                "us:nd;supreme.court", 
+                "us:ne;supreme.court", 
+                "us:sd;supreme.court", 
+                "us:wi;supreme.court"
+            ], 
+            "name": "North Western Reporter", 
             "variations": {
-                "N. W.": "N.W.",
-                "N. W. 2d": "N.W.2d",
-                "N. W.2d": "N.W.2d",
-                "N.W. 2d": "N.W.2d",
-                "NW": "N.W.",
-                "NW 2d": "N.W.2d",
-                "No.West Rep.": "N.W.",
+                "N. W.": "N.W.", 
+                "N. W. 2d": "N.W.2d", 
+                "N. W.2d": "N.W.2d", 
+                "N.W. 2d": "N.W.2d", 
+                "NW": "N.W.", 
+                "NW 2d": "N.W.2d", 
+                "No.West Rep.": "N.W.", 
                 "Northw.Rep.": "N.W."
             }
         }
-    ],
+    ], 
     "N.Y.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "N.Y.": {
-                    "end": "1956-12-31T00:00:00",
+                    "end": "1956-12-31T00:00:00", 
                     "start": "1847-01-01T00:00:00"
-                },
+                }, 
                 "N.Y.2d": {
-                    "end": "2004-01-01T00:00:00",
+                    "end": "2004-01-01T00:00:00", 
                     "start": "1956-01-01T00:00:00"
-                },
+                }, 
                 "N.Y.3d": {
-                    "end": null,
+                    "end": null, 
                     "start": "2004-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "New York Reports",
+                "us:ny;court.appeals"
+            ], 
+            "name": "New York Reports", 
             "variations": {
-                "N. Y.": "N.Y.",
-                "N.Y. 2d": "N.Y.2d",
-                "N.Y. 3d": "N.Y.3d",
-                "NY 2d": "N.Y.2d",
+                "N. Y.": "N.Y.", 
+                "N.Y. 2d": "N.Y.2d", 
+                "N.Y. 3d": "N.Y.3d", 
+                "NY 2d": "N.Y.2d", 
                 "NY 3d": "N.Y.3d"
             }
         }
-    ],
+    ], 
     "N.Y. Ch. Ann.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "N.Y. Ch. Ann.": {
-                    "end": "1847-12-31T00:00:00",
+                    "end": "1847-12-31T00:00:00", 
                     "start": "1814-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "New York Chancery Reports Annotated",
+                "us:ny;court.appeals"
+            ], 
+            "name": "New York Chancery Reports Annotated", 
             "variations": {
                 "N.Y.Ch.R.Ann.": "N.Y. Ch. Ann."
             }
         }
-    ],
+    ], 
     "N.Y. Sup. Ct.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "N.Y. Sup. Ct.": {
-                    "end": "1896-12-31T00:00:00",
+                    "end": "1896-12-31T00:00:00", 
                     "start": "1873-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Supreme Court Reports",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Supreme Court Reports", 
             "variations": {
-                "N.Y.Supr.Ct.": "N.Y. Sup. Ct.",
+                "N.Y.Supr.Ct.": "N.Y. Sup. Ct.", 
                 "N.Y.Suprm.Ct.": "N.Y. Sup. Ct."
             }
         }
-    ],
+    ], 
     "N.Y.S.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "N.Y.S.": {
-                    "end": "1937-12-31T00:00:00",
+                    "end": "1937-12-31T00:00:00", 
                     "start": "1888-01-01T00:00:00"
-                },
+                }, 
                 "N.Y.S.2d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1938-01-01T00:00:00"
-                },
+                }, 
                 "N.Y.S.3d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1938-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "New York Supplement",
+                "us:ny;court.appeals"
+            ], 
+            "name": "New York Supplement", 
             "variations": {
-                "N.Y.S. 2d": "N.Y.S.2d",
-                "N.Y.S. 3d": "N.Y.S.3d",
-                "NYS": "N.Y.S.",
-                "NYS 2d": "N.Y.S.2d",
-                "NYS 3d": "N.Y.S.3d",
+                "N.Y.S. 2d": "N.Y.S.2d", 
+                "N.Y.S. 3d": "N.Y.S.3d", 
+                "NYS": "N.Y.S.", 
+                "NYS 2d": "N.Y.S.2d", 
+                "NYS 3d": "N.Y.S.3d", 
                 "New York Supp.": "N.Y.S."
             }
         }
-    ],
+    ], 
     "ND": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "ND": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nd;supreme.court"
-            ],
-            "name": "North Dakota Neutral Citation",
+                "us:nd;supreme.court"
+            ], 
+            "name": "North Dakota Neutral Citation", 
             "variations": {}
         }
-    ],
+    ], 
     "ND App": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "ND App": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nd;supreme.court"
-            ],
-            "name": "North Dakota Neutral Citation, Court of Appeals",
+                "us:nd;court.appeals"
+            ], 
+            "name": "North Dakota Neutral Citation, Court of Appeals", 
             "variations": {}
         }
-    ],
+    ], 
     "NM": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "NM": {
-                    "end": null,
+                    "end": null, 
                     "start": "1852-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nm;supreme.court"
-            ],
-            "name": "New Mexico Neutral Citation",
+                "us:nm;supreme.court"
+            ], 
+            "name": "New Mexico Neutral Citation", 
             "variations": {}
         }
-    ],
+    ], 
     "NMCA": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "NMCA": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nm;supreme.court"
-            ],
-            "name": "New Mexico Neutral Citation (Court of Appeals)",
+                "us:nm;court.appeals"
+            ], 
+            "name": "New Mexico Neutral Citation (Court of Appeals)", 
             "variations": {}
         }
-    ],
+    ], 
     "NMCERT": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "NMCERT": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nm;supreme.court"
-            ],
-            "name": "New Mexico Neutral Citation",
+                "us:nm;supreme.court"
+            ], 
+            "name": "New Mexico Neutral Citation", 
             "variations": {}
         }
-    ],
+    ], 
     "NMSC": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "NMSC": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nm;supreme.court"
-            ],
-            "name": "New Mexico Neutral Citation (Supreme Court)",
+                "us:nm;supreme.court"
+            ], 
+            "name": "New Mexico Neutral Citation (Supreme Court)", 
             "variations": {}
         }
-    ],
+    ], 
     "NY Slip Op": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "NY Slip Op": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "New York Slip Opinion",
+                "us:ny;court.appeals"
+            ], 
+            "name": "New York Slip Opinion", 
             "variations": {}
         }
-    ],
+    ], 
     "Navajo Rptr.": [
         {
-            "cite_type": "federal",
+            "cite_type": "federal", 
             "editions": {
                 "Navajo Rptr.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1969-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;judicial.branch.navajo.nation"
-            ],
-            "name": "Navajo Reporter",
+                "us:navajo;supreme.court"
+            ], 
+            "name": "Navajo Reporter", 
             "variations": {}
         }
-    ],
+    ], 
     "Neb.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Neb.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1860-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ne;supreme.court"
-            ],
-            "name": "Nebraska Reports",
+                "us:ne;supreme.court"
+            ], 
+            "name": "Nebraska Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Neb. Ct. App.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Neb. Ct. App.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1922-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ne;supreme.court"
-            ],
-            "name": "Nebraska Court of Appeals Reports",
+                "us:ne;supreme.court"
+            ], 
+            "name": "Nebraska Court of Appeals Reports", 
             "variations": {
-                "Neb. App.": "Neb. Ct. App.",
+                "Neb. App.": "Neb. Ct. App.", 
                 "Neb.App.R.": "Neb. Ct. App."
             }
         }
-    ],
+    ], 
     "Nev.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Nev.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1865-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nv;supreme.court"
-            ],
-            "name": "Nevada Reports",
+                "us:nv;supreme.court"
+            ], 
+            "name": "Nevada Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Nev. Adv. Op. No.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Nev. Adv. Op. No.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nv;supreme.court"
-            ],
-            "name": "Nevada Advanced Opinion",
+                "us:nv;supreme.court"
+            ], 
+            "name": "Nevada Advanced Opinion", 
             "variations": {}
         }
-    ],
+    ], 
     "Nott & McC.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Nott & McC.": {
-                    "end": "1820-12-31T00:00:00",
+                    "end": "1820-12-31T00:00:00", 
                     "start": "1817-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Nott and McCord",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Nott and McCord", 
             "variations": {
-                "N.& Mc.": "Nott & McC.",
-                "Nott & M'C.(S.C.)": "Nott & McC.",
-                "Nott & McC.": "Nott & McC.",
+                "N.& Mc.": "Nott & McC.", 
+                "Nott & M'C.(S.C.)": "Nott & McC.", 
+                "Nott & McC.": "Nott & McC.", 
                 "S.C.L.(Nott & McC.)": "Nott & McC."
             }
         }
-    ],
+    ], 
     "OH": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "OH": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;oh;supreme.court"
-            ],
-            "name": "Ohio Neutral Citation",
+                "us:oh;supreme.court"
+            ], 
+            "name": "Ohio Neutral Citation", 
             "variations": {
                 "-Ohio-": "OH"
             }
         }
-    ],
+    ], 
     "OK": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "OK": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ok;supreme.court"
-            ],
-            "name": "Oklahoma Neutral Citation",
+                "us:ok;supreme.court"
+            ], 
+            "name": "Oklahoma Neutral Citation", 
             "variations": {}
         }
-    ],
+    ], 
     "OK CIV APP": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "OK CIV APP": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ok;supreme.court"
-            ],
-            "name": "Oklahoma Neutral Citation (Civic Appeals)",
+                "us:ok;court.civil.appeals"
+            ], 
+            "name": "Oklahoma Neutral Citation (Civic Appeals)", 
             "variations": {}
         }
-    ],
+    ], 
     "OK CR": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "OK CR": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ok;supreme.court"
-            ],
-            "name": "Oklahoma Neutral Citation",
+                "us:ok;court.criminal.appeals"
+            ], 
+            "name": "Oklahoma Neutral Citation", 
             "variations": {}
         }
-    ],
+    ], 
     "Ohio": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ohio": {
-                    "end": "1851-12-31T00:00:00",
+                    "end": "1851-12-31T00:00:00", 
                     "start": "1821-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;oh;supreme.court"
-            ],
-            "name": "Ohio Reports",
+                "us:oh;supreme.court"
+            ], 
+            "name": "Ohio Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Ohio App.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ohio App.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1913-01-01T00:00:00"
-                },
+                }, 
                 "Ohio App. 2d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1913-01-01T00:00:00"
-                },
+                }, 
                 "Ohio App. 3d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1913-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;oh;supreme.court"
-            ],
-            "name": "Ohio Appellate Reports",
+                "us:oh;supreme.court"
+            ], 
+            "name": "Ohio Appellate Reports", 
             "variations": {
-                "App.": "Ohio App.",
-                "O.A.R.": "Ohio App.",
-                "O.A.R.2d": "Ohio App. 2d",
-                "O.A.R.3d": "Ohio App. 3d",
-                "O.App.": "Ohio App.",
-                "O.App.2d": "Ohio App. 2d",
-                "O.App.3d": "Ohio App. 3d",
-                "Oh.A.": "Ohio App.",
-                "Oh.A.2d": "Ohio App. 2d",
+                "App.": "Ohio App.", 
+                "O.A.R.": "Ohio App.", 
+                "O.A.R.2d": "Ohio App. 2d", 
+                "O.A.R.3d": "Ohio App. 3d", 
+                "O.App.": "Ohio App.", 
+                "O.App.2d": "Ohio App. 2d", 
+                "O.App.3d": "Ohio App. 3d", 
+                "Oh.A.": "Ohio App.", 
+                "Oh.A.2d": "Ohio App. 2d", 
                 "Oh.App.3d": "Ohio App. 3d"
             }
         }
-    ],
+    ], 
     "Ohio App. Unrep.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ohio App. Unrep.": {
-                    "end": "1990-12-31T00:00:00",
+                    "end": "1990-12-31T00:00:00", 
                     "start": "1990-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;oh;supreme.court"
-            ],
-            "name": "Unreported Ohio Appellate Cases (Anderson)",
+                "us:oh;supreme.court"
+            ], 
+            "name": "Unreported Ohio Appellate Cases (Anderson)", 
             "variations": {}
         }
-    ],
+    ], 
     "Ohio B.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ohio B.": {
-                    "end": "1987-12-31T00:00:00",
+                    "end": "1987-12-31T00:00:00", 
                     "start": "1982-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;oh;supreme.court"
-            ],
-            "name": "Ohio Bar Reports",
+                "us:oh;supreme.court"
+            ], 
+            "name": "Ohio Bar Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Ohio C.C.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ohio C.C.": {
-                    "end": "1901-12-31T00:00:00",
+                    "end": "1901-12-31T00:00:00", 
                     "start": "1885-01-01T00:00:00"
-                },
+                }, 
                 "Ohio C.C. (n.s.)": {
-                    "end": "1922-12-31T00:00:00",
+                    "end": "1922-12-31T00:00:00", 
                     "start": "1901-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;oh;supreme.court"
-            ],
-            "name": "Ohio Circuit Court Reports",
+                "us:oh;supreme.court"
+            ], 
+            "name": "Ohio Circuit Court Reports", 
             "variations": {
-                "O.C.C.N.S.": "Ohio C.C. (n.s.)",
-                "Oh.Cir.Ct.": "Ohio C.C.",
-                "Oh.Cir.Ct.N.S.": "Ohio C.C. (n.s.)",
-                "Ohio C.C.N.S.": "Ohio C.C. (n.s.)",
-                "Ohio C.C.R.": "Ohio C.C.",
-                "Ohio C.C.R.N.S.": "Ohio C.C. (n.s.)",
-                "Ohio Cir.Ct.": "Ohio C.C.",
-                "Ohio Cir.Ct.(N.S.)": "Ohio C.C. (n.s.)",
-                "Ohio Cir.Ct.R.N.S.": "Ohio C.C. (n.s.)",
+                "O.C.C.N.S.": "Ohio C.C. (n.s.)", 
+                "Oh.Cir.Ct.": "Ohio C.C.", 
+                "Oh.Cir.Ct.N.S.": "Ohio C.C. (n.s.)", 
+                "Ohio C.C.N.S.": "Ohio C.C. (n.s.)", 
+                "Ohio C.C.R.": "Ohio C.C.", 
+                "Ohio C.C.R.N.S.": "Ohio C.C. (n.s.)", 
+                "Ohio Cir.Ct.": "Ohio C.C.", 
+                "Ohio Cir.Ct.(N.S.)": "Ohio C.C. (n.s.)", 
+                "Ohio Cir.Ct.R.N.S.": "Ohio C.C. (n.s.)", 
                 "Ohio Cr.Ct.R.": "Ohio C.C."
             }
         }
-    ],
+    ], 
     "Ohio C.C. Dec.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ohio C.C. Dec.": {
-                    "end": "1923-12-31T00:00:00",
+                    "end": "1923-12-31T00:00:00", 
                     "start": "1901-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;oh;supreme.court"
-            ],
-            "name": "Ohio Circuit Court Decisions",
+                "us:oh;supreme.court"
+            ], 
+            "name": "Ohio Circuit Court Decisions", 
             "variations": {
-                "O.C.C.": "Ohio C.C. Dec.",
+                "O.C.C.": "Ohio C.C. Dec.", 
                 "Ohio Cir.Ct.": "Ohio C.C. Dec."
             }
         }
-    ],
+    ], 
     "Ohio Cir. Dec.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ohio Cir. Dec.": {
-                    "end": "1901-12-31T00:00:00",
+                    "end": "1901-12-31T00:00:00", 
                     "start": "1885-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;oh;supreme.court"
-            ],
-            "name": "Ohio Circuit Decisions",
+                "us:oh;supreme.court"
+            ], 
+            "name": "Ohio Circuit Decisions", 
             "variations": {
-                "O.C.D.": "Ohio Cir. Dec.",
-                "Oh.Cir.Dec.": "Ohio Cir. Dec.",
-                "Ohio C.D.": "Ohio Cir. Dec.",
+                "O.C.D.": "Ohio Cir. Dec.", 
+                "Oh.Cir.Dec.": "Ohio Cir. Dec.", 
+                "Ohio C.D.": "Ohio Cir. Dec.", 
                 "Ohio C.Dec.": "Ohio Cir. Dec."
             }
         }
-    ],
+    ], 
     "Ohio Dec.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ohio Dec.": {
-                    "end": "1920-12-31T00:00:00",
+                    "end": "1920-12-31T00:00:00", 
                     "start": "1894-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;oh;supreme.court"
-            ],
-            "name": "Ohio Decisions",
+                "us:oh;supreme.court"
+            ], 
+            "name": "Ohio Decisions", 
             "variations": {
-                "O.D.": "Ohio Dec.",
+                "O.D.": "Ohio Dec.", 
                 "Oh.Dec.": "Ohio Dec."
             }
         }
-    ],
+    ], 
     "Ohio Dec. Reprint": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ohio Dec. Reprint": {
-                    "end": "1873-12-31T00:00:00",
+                    "end": "1873-12-31T00:00:00", 
                     "start": "1840-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;oh;supreme.court"
-            ],
-            "name": "Ohio Decisions, Reprint",
+                "us:oh;supreme.court"
+            ], 
+            "name": "Ohio Decisions, Reprint", 
             "variations": {
-                "O.Dec.Rep.": "Ohio Dec. Reprint",
+                "O.Dec.Rep.": "Ohio Dec. Reprint", 
                 "Oh.Dec.(Reprint)": "Ohio Dec. Reprint"
             }
         }
-    ],
+    ], 
     "Ohio Law. Abs.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ohio Law. Abs.": {
-                    "end": "1964-12-31T00:00:00",
+                    "end": "1964-12-31T00:00:00", 
                     "start": "1922-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;oh;supreme.court"
-            ],
-            "name": "Ohio Law Abstracts",
+                "us:oh;supreme.court"
+            ], 
+            "name": "Ohio Law Abstracts", 
             "variations": {
-                "O.L.A.": "Ohio Law. Abs.",
-                "O.L.Abs.": "Ohio Law. Abs.",
-                "Ohio Abs.": "Ohio Law. Abs.",
-                "Ohio L.Abs.": "Ohio Law. Abs.",
+                "O.L.A.": "Ohio Law. Abs.", 
+                "O.L.Abs.": "Ohio Law. Abs.", 
+                "Ohio Abs.": "Ohio Law. Abs.", 
+                "Ohio L.Abs.": "Ohio Law. Abs.", 
                 "Ohio Law Abst.": "Ohio Law. Abs."
             }
         }
-    ],
+    ], 
     "Ohio Misc.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ohio Misc.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1962-01-01T00:00:00"
-                },
+                }, 
                 "Ohio Misc. 2d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1962-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;oh;supreme.court"
-            ],
-            "name": "Ohio Miscellaneous",
+                "us:oh;supreme.court"
+            ], 
+            "name": "Ohio Miscellaneous", 
             "variations": {
-                "O.Misc.": "Ohio Misc.",
-                "O.Misc.2d": "Ohio Misc. 2d",
+                "O.Misc.": "Ohio Misc.", 
+                "O.Misc.2d": "Ohio Misc. 2d", 
                 "Ohio Misc.Dec.": "Ohio Misc."
             }
         }
-    ],
+    ], 
     "Ohio N.P.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ohio N.P.": {
-                    "end": "1934-12-31T00:00:00",
+                    "end": "1934-12-31T00:00:00", 
                     "start": "1894-01-01T00:00:00"
-                },
+                }, 
                 "Ohio N.P. (n.s.)": {
-                    "end": "1934-12-31T00:00:00",
+                    "end": "1934-12-31T00:00:00", 
                     "start": "1894-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;oh;supreme.court"
-            ],
-            "name": "Ohio Nisi Prius Reports",
+                "us:oh;supreme.court"
+            ], 
+            "name": "Ohio Nisi Prius Reports", 
             "variations": {
-                "O.N.P.": "Ohio N.P.",
-                "O.N.P.N.S.": "Ohio N.P. (n.s.)",
-                "Oh.N.P.": "Ohio N.P.",
-                "Oh.N.P.(N.S).": "Ohio N.P. (n.s.)",
+                "O.N.P.": "Ohio N.P.", 
+                "O.N.P.N.S.": "Ohio N.P. (n.s.)", 
+                "Oh.N.P.": "Ohio N.P.", 
+                "Oh.N.P.(N.S).": "Ohio N.P. (n.s.)", 
                 "Ohio N.P.N.S.": "Ohio N.P. (n.s.)"
             }
         }
-    ],
+    ], 
     "Ohio Op.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ohio Op.": {
-                    "end": "1982-12-31T00:00:00",
+                    "end": "1982-12-31T00:00:00", 
                     "start": "1934-01-01T00:00:00"
-                },
+                }, 
                 "Ohio Op. 2d": {
-                    "end": "1982-12-31T00:00:00",
+                    "end": "1982-12-31T00:00:00", 
                     "start": "1934-01-01T00:00:00"
-                },
+                }, 
                 "Ohio Op. 3d": {
-                    "end": "1982-12-31T00:00:00",
+                    "end": "1982-12-31T00:00:00", 
                     "start": "1934-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;oh;supreme.court"
-            ],
-            "name": "Ohio Opinions",
+                "us:oh;supreme.court"
+            ], 
+            "name": "Ohio Opinions", 
             "variations": {
-                "O.O.": "Ohio Op.",
-                "Ohio Op.2d": "Ohio Op. 2d",
-                "Ohio Op.3d": "Ohio Op. 3d",
+                "O.O.": "Ohio Op.", 
+                "Ohio Op.2d": "Ohio Op. 2d", 
+                "Ohio Op.3d": "Ohio Op. 3d", 
                 "Ohio Ops.": "Ohio Op."
             }
         }
-    ],
+    ], 
     "Ohio St.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ohio St.": {
-                    "end": "1964-12-31T00:00:00",
+                    "end": "1964-12-31T00:00:00", 
                     "start": "1840-01-01T00:00:00"
-                },
+                }, 
                 "Ohio St. 2d": {
-                    "end": "1991-12-31T00:00:00",
+                    "end": "1991-12-31T00:00:00", 
                     "start": "1965-01-01T00:00:00"
-                },
+                }, 
                 "Ohio St. 3d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1991-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;oh;supreme.court"
-            ],
-            "name": "Ohio State Reports",
+                "us:oh;supreme.court"
+            ], 
+            "name": "Ohio State Reports", 
             "variations": {
-                "O.S.": "Ohio St.",
-                "O.S.2d": "Ohio St. 2d",
-                "O.S.3d": "Ohio St. 3d",
-                "Oh.St.": "Ohio St.",
-                "Ohio St.2d": "Ohio St. 2d",
+                "O.S.": "Ohio St.", 
+                "O.S.2d": "Ohio St. 2d", 
+                "O.S.3d": "Ohio St. 3d", 
+                "Oh.St.": "Ohio St.", 
+                "Ohio St.2d": "Ohio St. 2d", 
                 "Ohio St.3d": "Ohio St. 3d"
             }
         }
-    ],
+    ], 
     "Okla.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Okla.": {
-                    "end": "1953-12-31T00:00:00",
+                    "end": "1953-12-31T00:00:00", 
                     "start": "1890-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ok;supreme.court"
-            ],
-            "name": "Oklahoma Reports",
+                "us:ok;supreme.court"
+            ], 
+            "name": "Oklahoma Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Okla. Crim.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Okla. Crim.": {
-                    "end": "1953-12-31T00:00:00",
+                    "end": "1953-12-31T00:00:00", 
                     "start": "1908-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ok;supreme.court"
-            ],
-            "name": "Oklahoma Criminal Reports",
+                "us:ok;supreme.court"
+            ], 
+            "name": "Oklahoma Criminal Reports", 
             "variations": {
-                "O.Cr.": "Okla. Crim.",
-                "Okl.Cr.": "Okla. Crim.",
-                "Okla.": "Okla. Crim.",
+                "O.Cr.": "Okla. Crim.", 
+                "Okl.Cr.": "Okla. Crim.", 
+                "Okla.": "Okla. Crim.", 
                 "Okla.Cr.": "Okla. Crim."
             }
         }
-    ],
+    ], 
     "Or.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Or.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1853-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;or;supreme.court"
-            ],
-            "name": "Oregon Reports",
+                "us:or;supreme.court"
+            ], 
+            "name": "Oregon Reports", 
             "variations": {
                 "O.": "Or."
             }
         }
-    ],
+    ], 
     "Or. App.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Or. App.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1969-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;or;supreme.court"
-            ],
-            "name": "Oregon Reports, Court of Appeals",
+                "us:or;supreme.court"
+            ], 
+            "name": "Oregon Reports, Court of Appeals", 
             "variations": {
                 "Or.A.": "Or. App."
             }
         }
-    ],
+    ], 
     "Or. Tax": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Or. Tax": {
-                    "end": null,
+                    "end": null, 
                     "start": "1962-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;or;supreme.court"
-            ],
-            "name": "Oregon Tax Reports",
+                "us:or;supreme.court"
+            ], 
+            "name": "Oregon Tax Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Overt.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Overt.": {
-                    "end": "1816-12-31T00:00:00",
+                    "end": "1816-12-31T00:00:00", 
                     "start": "1791-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tn;supreme.court"
-            ],
-            "name": "Tennessee Reports, Overton",
+                "us:tn;supreme.court"
+            ], 
+            "name": "Tennessee Reports, Overton", 
             "variations": {
                 "Tenn.(Overt.)": "Overt."
             }
         }
-    ],
+    ], 
     "P.": [
         {
-            "cite_type": "state_regional",
+            "cite_type": "state_regional", 
             "editions": {
                 "P.": {
-                    "end": "1931-12-31T00:00:00",
+                    "end": "1931-12-31T00:00:00", 
                     "start": "1883-01-01T00:00:00"
-                },
+                }, 
                 "P.2d": {
-                    "end": "2000-12-31T00:00:00",
+                    "end": "2000-12-31T00:00:00", 
                     "start": "1931-01-01T00:00:00"
-                },
+                }, 
                 "P.3d": {
-                    "end": null,
+                    "end": null, 
                     "start": "2000-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ak;supreme.court",
-                "us;az;supreme.court",
-                "us;ca;supreme.court",
-                "us;co;supreme.court",
-                "us;hi;supreme.court",
-                "us;id;supreme.court",
-                "us;ks;supreme.court",
-                "us;mt;supreme.court",
-                "us;nm;supreme.court",
-                "us;nv;supreme.court",
-                "us;ok;supreme.court",
-                "us;or;supreme.court",
-                "us;ut;supreme.court",
-                "us;wa;supreme.court",
-                "us;wy;supreme.court"
-            ],
-            "name": "Pacific Reporter",
+                "us:ak;supreme.court", 
+                "us:az;supreme.court", 
+                "us:ca;supreme.court", 
+                "us:co;supreme.court", 
+                "us:hi;supreme.court", 
+                "us:id;supreme.court", 
+                "us:ks;supreme.court", 
+                "us:mt;supreme.court", 
+                "us:nm;supreme.court", 
+                "us:nv;supreme.court", 
+                "us:ok;supreme.court", 
+                "us:or;supreme.court", 
+                "us:ut;supreme.court", 
+                "us:wa;supreme.court", 
+                "us:wy;supreme.court"
+            ], 
+            "name": "Pacific Reporter", 
             "variations": {
-                "P": "P.",
-                "P 2d": "P.2d",
-                "P 3d": "P.3d",
-                "P. 2d": "P.2d",
-                "P. 3d": "P.3d",
-                "P.R.": "P.",
-                "Pac.": "P.",
-                "Pac.R.": "P.",
+                "P": "P.", 
+                "P 2d": "P.2d", 
+                "P 3d": "P.3d", 
+                "P. 2d": "P.2d", 
+                "P. 3d": "P.3d", 
+                "P.R.": "P.", 
+                "Pac.": "P.", 
+                "Pac.R.": "P.", 
                 "Pac.Rep.": "P."
             }
         }
-    ],
+    ], 
     "P.R. Dec.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "P.R. Dec.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1899-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;district.court.d.puerto.rico"
-            ],
-            "name": "Decisiones de Puerto Rico",
+                "us:c1:pr.d;district.court"
+            ], 
+            "name": "Decisiones de Puerto Rico", 
             "variations": {}
         }
-    ],
+    ], 
     "P.R. Offic. Trans.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "P.R. Offic. Trans.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1978-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;district.court.d.puerto.rico"
-            ],
-            "name": "Official Translations of the Opinions of the Supreme Court of Puerto Rico",
+                "us:c1:pr.d;district.court"
+            ], 
+            "name": "Official Translations of the Opinions of the Supreme Court of Puerto Rico", 
             "variations": {}
         }
-    ],
+    ], 
     "P.R. Sent.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "P.R. Sent.": {
-                    "end": "1902-12-31T00:00:00",
+                    "end": "1902-12-31T00:00:00", 
                     "start": "1899-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;district.court.d.puerto.rico"
-            ],
-            "name": "Sentencias del Tribunal Supremo de Puerto Rico",
+                "us:c1:pr.d;district.court"
+            ], 
+            "name": "Sentencias del Tribunal Supremo de Puerto Rico", 
             "variations": {}
         }
-    ],
+    ], 
     "P.R.R.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "P.R.R.": {
-                    "end": "1978-12-31T00:00:00",
+                    "end": "1978-12-31T00:00:00", 
                     "start": "1899-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;district.court.d.puerto.rico"
-            ],
-            "name": "Puerto Rico Reports",
+                "us:c1:pr.d;district.court"
+            ], 
+            "name": "Puerto Rico Reports", 
             "variations": {
-                "P.R.": "P.R.R.",
+                "P.R.": "P.R.R.", 
                 "Puerto Rico": "P.R.R."
             }
         }
-    ],
+    ], 
     "PA": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "PA": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;pa;supreme.court"
-            ],
-            "name": "Pennsylvania Neutral Citation",
+                "us:pa;supreme.court"
+            ], 
+            "name": "Pennsylvania Neutral Citation", 
             "variations": {}
         }
-    ],
+    ], 
     "Pa.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Pa.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1845-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;pa;supreme.court"
-            ],
-            "name": "Pennsylvania State Reports",
+                "us:pa;supreme.court"
+            ], 
+            "name": "Pennsylvania State Reports", 
             "variations": {
-                "P.S.R.": "Pa.",
-                "Pa.Rep.": "Pa.",
-                "Pa.St.": "Pa.",
-                "Pa.State": "Pa.",
-                "Penn.": "Pa.",
-                "Penn.Rep.": "Pa.",
-                "Penn.St.": "Pa.",
+                "P.S.R.": "Pa.", 
+                "Pa.Rep.": "Pa.", 
+                "Pa.St.": "Pa.", 
+                "Pa.State": "Pa.", 
+                "Penn.": "Pa.", 
+                "Penn.Rep.": "Pa.", 
+                "Penn.St.": "Pa.", 
                 "Penn.St.R.": "Pa."
             }
         }
-    ],
+    ], 
     "Pa. C.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Pa. C.": {
-                    "end": "1921-12-31T00:00:00",
+                    "end": "1921-12-31T00:00:00", 
                     "start": "1870-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;pa;supreme.court"
-            ],
-            "name": "Pennsylvania County Court Reports",
+                "us:pa;supreme.court"
+            ], 
+            "name": "Pennsylvania County Court Reports", 
             "variations": {
-                "P.C.R.": "Pa. C.",
-                "Pa.C.C.": "Pa. C.",
-                "Pa.Co.Ct.": "Pa. C.",
-                "Pa.Co.Ct.R.": "Pa. C.",
-                "Pa.County Ct.": "Pa. C.",
+                "P.C.R.": "Pa. C.", 
+                "Pa.C.C.": "Pa. C.", 
+                "Pa.Co.Ct.": "Pa. C.", 
+                "Pa.Co.Ct.R.": "Pa. C.", 
+                "Pa.County Ct.": "Pa. C.", 
                 "Penn.Co.Ct.Rep.": "Pa. C."
             }
         }
-    ],
+    ], 
     "Pa. Commw.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Pa. Commw.": {
-                    "end": "1994-12-31T00:00:00",
+                    "end": "1994-12-31T00:00:00", 
                     "start": "1970-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;pa;supreme.court"
-            ],
-            "name": "Pennsylvania Commonwealth Court",
+                "us:pa;supreme.court"
+            ], 
+            "name": "Pennsylvania Commonwealth Court", 
             "variations": {
-                "Pa. Commonwealth Ct.": "Pa. Commw.",
-                "Pa.C.": "Pa. Commw.",
+                "Pa. Commonwealth Ct.": "Pa. Commw.", 
+                "Pa.C.": "Pa. Commw.", 
                 "Pa.Commw.Ct.": "Pa. Commw."
             }
         }
-    ],
+    ], 
     "Pa. D.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Pa. D.": {
-                    "end": "1921-12-31T00:00:00",
+                    "end": "1921-12-31T00:00:00", 
                     "start": "1892-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;pa;supreme.court"
-            ],
-            "name": "Pennsylvania District Reports",
+                "us:pa;supreme.court"
+            ], 
+            "name": "Pennsylvania District Reports", 
             "variations": {
-                "Dist.Rep.": "Pa. D.",
-                "Pa.Dist.": "Pa. D.",
-                "Pa.Dist.R.": "Pa. D.",
+                "Dist.Rep.": "Pa. D.", 
+                "Pa.Dist.": "Pa. D.", 
+                "Pa.Dist.R.": "Pa. D.", 
                 "Penn.Dist.Rep.": "Pa. D."
             }
         }
-    ],
+    ], 
     "Pa. D. & C.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Pa. D. & C.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1921-01-01T00:00:00"
-                },
+                }, 
                 "Pa. D. & C.2d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1921-01-01T00:00:00"
-                },
+                }, 
                 "Pa. D. & C.3d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1921-01-01T00:00:00"
-                },
+                }, 
                 "Pa. D. & C.4th": {
-                    "end": null,
+                    "end": null, 
                     "start": "1921-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;pa;supreme.court"
-            ],
-            "name": "Pennsylvania District and County Reports",
+                "us:pa;supreme.court"
+            ], 
+            "name": "Pennsylvania District and County Reports", 
             "variations": {
-                "Pa.Dist.& C.Rep.": "Pa. D. & C.",
+                "Pa.Dist.& C.Rep.": "Pa. D. & C.", 
                 "Pa.Dist.& Co.": "Pa. D. & C."
             }
         }
-    ],
+    ], 
     "Pa. Super.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Pa. Super.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1895-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;pa;supreme.court"
-            ],
-            "name": "Pennsylvania Superior Court Reports",
+                "us:pa;supreme.court"
+            ], 
+            "name": "Pennsylvania Superior Court Reports", 
             "variations": {
-                "Pa. Superior Ct.": "Pa. Super.",
-                "Pa.S.": "Pa. Super.",
+                "Pa. Superior Ct.": "Pa. Super.", 
+                "Pa.S.": "Pa. Super.", 
                 "Pa.Super.Ct.": "Pa. Super."
             }
         }
-    ],
+    ], 
     "Paige Ch.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Paige Ch.": {
-                    "end": "1845-12-31T00:00:00",
+                    "end": "1845-12-31T00:00:00", 
                     "start": "1828-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Paige's Chancery Reports",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Paige's Chancery Reports", 
             "variations": {
-                "Pai.": "Paige Ch.",
-                "Pai.Ch.": "Paige Ch.",
+                "Pai.": "Paige Ch.", 
+                "Pai.Ch.": "Paige Ch.", 
                 "Paige": "Paige Ch."
             }
         }
-    ],
+    ], 
     "Peck": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Peck": {
-                    "end": "1824-12-31T00:00:00",
+                    "end": "1824-12-31T00:00:00", 
                     "start": "1821-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tn;supreme.court"
-            ],
-            "name": "Tennessee Reports, Peck",
+                "us:tn;supreme.court"
+            ], 
+            "name": "Tennessee Reports, Peck", 
             "variations": {
-                "Peck (Tenn.)": "Peck",
+                "Peck (Tenn.)": "Peck", 
                 "Tenn.(Peck)": "Peck"
             }
         }
-    ],
+    ], 
     "Pelt.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Pelt.": {
-                    "end": "1924-12-31T00:00:00",
+                    "end": "1924-12-31T00:00:00", 
                     "start": "1917-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;la;supreme.court"
-            ],
-            "name": "Peltier's Opinions, Parish at Orleans",
+                "us:la;supreme.court"
+            ], 
+            "name": "Peltier's Opinions, Parish at Orleans", 
             "variations": {}
         }
-    ],
+    ], 
     "Pen. & W.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Pen. & W.": {
-                    "end": "1832-12-31T00:00:00",
+                    "end": "1832-12-31T00:00:00", 
                     "start": "1829-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;pa;supreme.court"
-            ],
-            "name": "Pennsylvania State Reports, Penrose and Watts",
+                "us:pa;supreme.court"
+            ], 
+            "name": "Pennsylvania State Reports, Penrose and Watts", 
             "variations": {
-                "P.& W.": "Pen. & W.",
-                "P.R.": "Pen. & W.",
+                "P.& W.": "Pen. & W.", 
+                "P.R.": "Pen. & W.", 
                 "Penr.& W.": "Pen. & W."
             }
         }
-    ],
+    ], 
     "Pennewill": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Pennewill": {
-                    "end": "1909-12-31T00:00:00",
+                    "end": "1909-12-31T00:00:00", 
                     "start": "1897-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;de;supreme.court"
-            ],
-            "name": "Delaware Reports, Pennewill",
+                "us:de;supreme.court"
+            ], 
+            "name": "Delaware Reports, Pennewill", 
             "variations": {}
         }
-    ],
+    ], 
     "Pennyp.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Pennyp.": {
-                    "end": "1884-12-31T00:00:00",
+                    "end": "1884-12-31T00:00:00", 
                     "start": "1881-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;pa;supreme.court"
-            ],
-            "name": "Pennsylvania State Reports, Pennypacker",
+                "us:pa;supreme.court"
+            ], 
+            "name": "Pennsylvania State Reports, Pennypacker", 
             "variations": {
-                "Penn.": "Pennyp.",
-                "Penny.": "Pennyp.",
+                "Penn.": "Pennyp.", 
+                "Penny.": "Pennyp.", 
                 "Pennyp.(Pa.)": "Pennyp."
             }
         }
-    ],
+    ], 
     "Pet.": [
         {
-            "cite_type": "scotus_early",
+            "cite_type": "scotus_early", 
             "editions": {
                 "Pet.": {
-                    "end": "1842-12-31T00:00:00",
+                    "end": "1842-12-31T00:00:00", 
                     "start": "1828-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;supreme.court"
-            ],
-            "name": "Peters' Supreme Court Reports",
+                "us;supreme.court"
+            ], 
+            "name": "Peters' Supreme Court Reports", 
             "variations": {
-                "Pet.S.C.": "Pet.",
-                "Peters": "Pet.",
+                "Pet.S.C.": "Pet.", 
+                "Peters": "Pet.", 
                 "U.S.(Pet.)": "Pet."
             }
         }
-    ],
+    ], 
     "Phil. Eq.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Phil. Eq.": {
-                    "end": "1868-12-31T00:00:00",
+                    "end": "1868-12-31T00:00:00", 
                     "start": "1866-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nc;supreme.court"
-            ],
-            "name": "North Carolina Reports, Philips' Equity",
+                "us:nc;supreme.court"
+            ], 
+            "name": "North Carolina Reports, Philips' Equity", 
             "variations": {
-                "N.C.(Phil.Eq.)": "Phil. Eq.",
-                "Phil.": "Phil. Eq.",
-                "Phil.Eq.(N.C.)": "Phil. Eq.",
-                "Phill.": "Phil. Eq.",
+                "N.C.(Phil.Eq.)": "Phil. Eq.", 
+                "Phil.": "Phil. Eq.", 
+                "Phil.Eq.(N.C.)": "Phil. Eq.", 
+                "Phill.": "Phil. Eq.", 
                 "Phillips": "Phil. Eq."
             }
         }
-    ],
+    ], 
     "Phil. Law": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Phil. Law": {
-                    "end": "1868-12-31T00:00:00",
+                    "end": "1868-12-31T00:00:00", 
                     "start": "1866-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nc;supreme.court"
-            ],
-            "name": "North Carolina Reports, Philips' Law",
+                "us:nc;supreme.court"
+            ], 
+            "name": "North Carolina Reports, Philips' Law", 
             "variations": {
-                "N.C.(Phil.Law)": "Phil. Law",
-                "Phil.": "Phil. Law",
-                "Phil.N.C.": "Phil. Law",
-                "Phill.": "Phil. Law",
-                "Phill.L.(N.C.)": "Phil. Law",
+                "N.C.(Phil.Law)": "Phil. Law", 
+                "Phil.": "Phil. Law", 
+                "Phil.N.C.": "Phil. Law", 
+                "Phill.": "Phil. Law", 
+                "Phill.L.(N.C.)": "Phil. Law", 
                 "Phillips": "Phil. Law"
             }
         }
-    ],
+    ], 
     "Pick.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Pick.": {
-                    "end": "1839-12-31T00:00:00",
+                    "end": "1839-12-31T00:00:00", 
                     "start": "1822-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ma;appeals.court"
-            ],
-            "name": "Massachusetts Reports, Pickering",
+                "us:ma;appeals.court"
+            ], 
+            "name": "Massachusetts Reports, Pickering", 
             "variations": {
-                "Mass.(Pick.)": "Pick.",
+                "Mass.(Pick.)": "Pick.", 
                 "Pick.(Mass.)": "Pick."
             }
         }
-    ],
+    ], 
     "Pin.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Pin.": {
-                    "end": "1852-12-31T00:00:00",
+                    "end": "1852-12-31T00:00:00", 
                     "start": "1839-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;wi;supreme.court"
-            ],
-            "name": "Wisconsin Reports, Pinney",
+                "us:wi;supreme.court"
+            ], 
+            "name": "Wisconsin Reports, Pinney", 
             "variations": {
                 "Pinn.": "Pin."
             }
         }
-    ],
+    ], 
     "Port.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Port.": {
-                    "end": "1839-12-31T00:00:00",
+                    "end": "1839-12-31T00:00:00", 
                     "start": "1834-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;al;supreme.court"
-            ],
-            "name": "Alabama Reports, Porter",
+                "us:al;supreme.court"
+            ], 
+            "name": "Alabama Reports, Porter", 
             "variations": {
-                "Port.(Ala.)": "Port.",
+                "Port.(Ala.)": "Port.", 
                 "Porter": "Port."
             }
         }
-    ],
+    ], 
     "R.I.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "R.I.": {
-                    "end": "1980-12-31T00:00:00",
+                    "end": "1980-12-31T00:00:00", 
                     "start": "1828-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ri;supreme.court"
-            ],
-            "name": "Rhode Island Reports",
+                "us:ri;supreme.court"
+            ], 
+            "name": "Rhode Island Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Rand.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Rand.": {
-                    "end": "1828-12-31T00:00:00",
+                    "end": "1828-12-31T00:00:00", 
                     "start": "1821-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;va;supreme.court"
-            ],
-            "name": "Virginia Reports, Randolph",
+                "us:va;supreme.court"
+            ], 
+            "name": "Virginia Reports, Randolph", 
             "variations": {
                 "Va.(Rand.)": "Rand."
             }
         }
-    ],
+    ], 
     "Rawle": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Rawle": {
-                    "end": "1835-12-31T00:00:00",
+                    "end": "1835-12-31T00:00:00", 
                     "start": "1828-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;pa;supreme.court"
-            ],
-            "name": "Pennsylvania State Reports, Rawle",
+                "us:pa;supreme.court"
+            ], 
+            "name": "Pennsylvania State Reports, Rawle", 
             "variations": {
-                "Pa. Rawle": "Rawle",
-                "R.": "Rawle",
+                "Pa. Rawle": "Rawle", 
+                "R.": "Rawle", 
                 "Raw.": "Rawle"
             }
         }
-    ],
+    ], 
     "Rice": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Rice": {
-                    "end": "1839-12-31T00:00:00",
+                    "end": "1839-12-31T00:00:00", 
                     "start": "1838-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Rice",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Rice", 
             "variations": {
-                "Rice L.(S.C.)": "Rice",
+                "Rice L.(S.C.)": "Rice", 
                 "S.C.L.(Rice)": "Rice"
             }
         }
-    ],
+    ], 
     "Rice Eq.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Rice Eq.": {
-                    "end": "1839-12-31T00:00:00",
+                    "end": "1839-12-31T00:00:00", 
                     "start": "1838-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Rice's Equity",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Rice's Equity", 
             "variations": {
-                "Rice Ch.": "Rice Eq.",
+                "Rice Ch.": "Rice Eq.", 
                 "S.C.Eq.(Rice.Eq.)": "Rice Eq."
             }
         }
-    ],
+    ], 
     "Rich.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Rich.": {
-                    "end": "1868-12-31T00:00:00",
+                    "end": "1868-12-31T00:00:00", 
                     "start": "1846-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Richardson",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Richardson", 
             "variations": {
-                "Rich.L.(S.C.)": "Rich.",
-                "Rich.Law(S.C.)": "Rich.",
+                "Rich.L.(S.C.)": "Rich.", 
+                "Rich.Law(S.C.)": "Rich.", 
                 "S.C.L.(Rich.)": "Rich."
             }
         }
-    ],
+    ], 
     "Rich. Cas.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Rich. Cas.": {
-                    "end": "1832-12-31T00:00:00",
+                    "end": "1832-12-31T00:00:00", 
                     "start": "1831-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Richardson's Cases",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Richardson's Cases", 
             "variations": {
                 "Rich.Cas.(S.C.)": "Rich. Cas."
             }
         }
-    ],
+    ], 
     "Rich. Eq.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Rich. Eq.": {
-                    "end": "1868-12-31T00:00:00",
+                    "end": "1868-12-31T00:00:00", 
                     "start": "1844-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Richardson's Equity",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Richardson's Equity", 
             "variations": {
-                "Rich.Eq.Ch.": "Rich. Eq.",
+                "Rich.Eq.Ch.": "Rich. Eq.", 
                 "S.C.Eq.(Rich.Eq.)": "Rich. Eq."
             }
         }
-    ],
+    ], 
     "Ril.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ril.": {
-                    "end": "1837-12-31T00:00:00",
+                    "end": "1837-12-31T00:00:00", 
                     "start": "1836-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Riley",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Riley", 
             "variations": {
-                "Riley": "Ril.",
-                "Riley L.(S.C.)": "Ril.",
+                "Riley": "Ril.", 
+                "Riley L.(S.C.)": "Ril.", 
                 "S.C.L.(Riley)": "Ril."
             }
         }
-    ],
+    ], 
     "Ril. Eq.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Ril. Eq.": {
-                    "end": "1837-12-31T00:00:00",
+                    "end": "1837-12-31T00:00:00", 
                     "start": "1836-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Riley's Chancery",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Riley's Chancery", 
             "variations": {
-                "Ril.": "Ril. Eq.",
-                "Riley": "Ril. Eq.",
-                "Riley Ch.": "Ril. Eq.",
-                "Riley Eq.": "Ril. Eq.",
-                "Riley Eq.(S.C.)": "Ril. Eq.",
+                "Ril.": "Ril. Eq.", 
+                "Riley": "Ril. Eq.", 
+                "Riley Ch.": "Ril. Eq.", 
+                "Riley Eq.": "Ril. Eq.", 
+                "Riley Eq.(S.C.)": "Ril. Eq.", 
                 "S.C.Eq.(Ril.)": "Ril. Eq."
             }
         }
-    ],
+    ], 
     "Rob.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Rob.": {
-                    "end": "1846-12-31T00:00:00",
+                    "end": "1846-12-31T00:00:00", 
                     "start": "1841-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;la;supreme.court"
-            ],
-            "name": "Louisiana Reports, Robinson",
+                "us:la;supreme.court"
+            ], 
+            "name": "Louisiana Reports, Robinson", 
             "variations": {
-                "Rob.La.": "Rob.",
+                "Rob.La.": "Rob.", 
                 "Robinson": "Rob."
             }
-        },
+        }, 
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Rob.": {
-                    "end": "1844-12-31T00:00:00",
+                    "end": "1844-12-31T00:00:00", 
                     "start": "1842-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;va;supreme.court"
-            ],
-            "name": "Virginia Reports, Robinson",
+                "us:va;supreme.court"
+            ], 
+            "name": "Virginia Reports, Robinson", 
             "variations": {
-                "Rob.Va.": "Rob.",
-                "Robinson": "Rob.",
+                "Rob.Va.": "Rob.", 
+                "Robinson": "Rob.", 
                 "Va.(Rob.)": "Rob."
             }
         }
-    ],
+    ], 
     "Robards": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Robards": {
-                    "end": "1865-12-31T00:00:00",
+                    "end": "1865-12-31T00:00:00", 
                     "start": "1862-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tx;supreme.court"
-            ],
-            "name": "Synopses of the Decisions of the Supreme Court of Texas Arising from Restraints by Conscript and Other Military Authorities (Robards)",
+                "us:tx;supreme.court"
+            ], 
+            "name": "Synopses of the Decisions of the Supreme Court of Texas Arising from Restraints by Conscript and Other Military Authorities (Robards)", 
             "variations": {
-                "Rob.": "Robards",
-                "Rob.Cons.Cas.(Tex.)": "Robards",
-                "Rob.Consc.Cas.": "Robards",
+                "Rob.": "Robards", 
+                "Rob.Cons.Cas.(Tex.)": "Robards", 
+                "Rob.Consc.Cas.": "Robards", 
                 "Robard": "Robards"
             }
         }
-    ],
+    ], 
     "Root": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Root": {
-                    "end": "1798-12-31T00:00:00",
+                    "end": "1798-12-31T00:00:00", 
                     "start": "1789-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ct;supreme.court"
-            ],
-            "name": "Root's Connecticut Reports",
+                "us:ct;supreme.court"
+            ], 
+            "name": "Root's Connecticut Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "S. & M.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "S. & M.": {
-                    "end": "1850-12-31T00:00:00",
+                    "end": "1850-12-31T00:00:00", 
                     "start": "1843-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ms;supreme.court"
-            ],
-            "name": "Mississippi Reports, Smedes and Marshall",
+                "us:ms;supreme.court"
+            ], 
+            "name": "Mississippi Reports, Smedes and Marshall", 
             "variations": {
-                "Miss.(S.& M.)": "S. & M.",
-                "S.& Mar.": "S. & M.",
-                "Sm.& M.": "S. & M.",
-                "Smed.& M.": "S. & M.",
+                "Miss.(S.& M.)": "S. & M.", 
+                "S.& Mar.": "S. & M.", 
+                "Sm.& M.": "S. & M.", 
+                "Smed.& M.": "S. & M.", 
                 "Smedes & M.(Miss.)": "S. & M."
             }
         }
-    ],
+    ], 
     "S. Ct.": [
         {
-            "cite_type": "federal",
+            "cite_type": "federal", 
             "editions": {
                 "S. Ct.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1882-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;supreme.court"
-            ],
-            "name": "West's Supreme Court Reporter",
+                "us;supreme.court"
+            ], 
+            "name": "West's Supreme Court Reporter", 
             "variations": {
-                "S Ct": "S. Ct.",
-                "S.C.": "S. Ct.",
-                "S.Ct.": "S. Ct.",
-                "Sup.Ct.": "S. Ct.",
-                "Sup.Ct.Rep.": "S. Ct.",
+                "S Ct": "S. Ct.", 
+                "S.C.": "S. Ct.", 
+                "S.Ct.": "S. Ct.", 
+                "Sup.Ct.": "S. Ct.", 
+                "Sup.Ct.Rep.": "S. Ct.", 
                 "Supr.Ct.Rep.": "S. Ct."
             }
         }
-    ],
+    ], 
     "S.C.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "S.C.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1868-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports", 
             "variations": {
-                "S.C.R.": "S.C.",
-                "S.Car.": "S.C.",
-                "So.C.": "S.C.",
-                "So.Car.": "S.C.",
+                "S.C.R.": "S.C.", 
+                "S.Car.": "S.C.", 
+                "So.C.": "S.C.", 
+                "So.Car.": "S.C.", 
                 "South Car.": "S.C."
             }
         }
-    ],
+    ], 
     "S.D.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "S.D.": {
-                    "end": "1976-12-31T00:00:00",
+                    "end": "1976-12-31T00:00:00", 
                     "start": "1890-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sd;supreme.court"
-            ],
-            "name": "South Dakota Reports",
+                "us:sd;supreme.court"
+            ], 
+            "name": "South Dakota Reports", 
             "variations": {
                 "S.Dak.": "S.D."
             }
         }
-    ],
+    ], 
     "S.E.": [
         {
-            "cite_type": "state_regional",
+            "cite_type": "state_regional", 
             "editions": {
                 "S.E.": {
-                    "end": "1939-12-31T00:00:00",
+                    "end": "1939-12-31T00:00:00", 
                     "start": "1887-01-01T00:00:00"
-                },
+                }, 
                 "S.E.2d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1939-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ga;supreme.court",
-                "us;nc;supreme.court",
-                "us;sc;supreme.court",
-                "us;va;supreme.court",
-                "us;wv;supreme.court"
-            ],
-            "name": "South Eastern Reporter",
+                "us:ga;supreme.court", 
+                "us:nc;supreme.court", 
+                "us:sc;supreme.court", 
+                "us:va;supreme.court", 
+                "us:wv;supreme.court"
+            ], 
+            "name": "South Eastern Reporter", 
             "variations": {
-                "S. E.": "S.E.",
-                "S. E. 2d": "S.E.2d",
-                "S. E.2d": "S.E.2d",
-                "S.E. 2d": "S.E.2d",
-                "SE": "S.E.",
+                "S. E.": "S.E.", 
+                "S. E. 2d": "S.E.2d", 
+                "S. E.2d": "S.E.2d", 
+                "S.E. 2d": "S.E.2d", 
+                "SE": "S.E.", 
                 "SE 2d": "S.E.2d"
             }
         }
-    ],
+    ], 
     "S.W.": [
         {
-            "cite_type": "state_regional",
+            "cite_type": "state_regional", 
             "editions": {
                 "S.W.": {
-                    "end": "1928-12-31T00:00:00",
+                    "end": "1928-12-31T00:00:00", 
                     "start": "1886-01-01T00:00:00"
-                },
+                }, 
                 "S.W.2d": {
-                    "end": "1999-12-31T00:00:00",
+                    "end": "1999-12-31T00:00:00", 
                     "start": "1928-01-01T00:00:00"
-                },
+                }, 
                 "S.W.3d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1999-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ar;supreme.court",
-                "us;ky;supreme.court",
-                "us;mo;supreme.court",
-                "us;tn;supreme.court",
-                "us;tx;supreme.court"
-            ],
-            "name": "South Western Reporter",
+                "us:ar;supreme.court", 
+                "us:ky;supreme.court", 
+                "us:mo;supreme.court", 
+                "us:tn;supreme.court", 
+                "us:tx;supreme.court"
+            ], 
+            "name": "South Western Reporter", 
             "variations": {
-                "S. W.": "S.W.",
-                "S. W. 2d": "S.W.2d",
-                "S. W. 3d": "S.W.3d",
-                "S. W.2d": "S.W.2d",
-                "S. W.3d": "S.W.3d",
-                "S.W. 2d": "S.W.2d",
-                "S.W. 3d": "S.W.3d",
-                "SW": "S.W.",
-                "SW 2d": "S.W.2d",
+                "S. W.": "S.W.", 
+                "S. W. 2d": "S.W.2d", 
+                "S. W. 3d": "S.W.3d", 
+                "S. W.2d": "S.W.2d", 
+                "S. W.3d": "S.W.3d", 
+                "S.W. 2d": "S.W.2d", 
+                "S.W. 3d": "S.W.3d", 
+                "SW": "S.W.", 
+                "SW 2d": "S.W.2d", 
                 "SW 3d": "S.W.3d"
             }
         }
-    ],
+    ], 
     "SD": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "SD": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sd;supreme.court"
-            ],
-            "name": "South Dakota Neutral Citation",
+                "us:sd;supreme.court"
+            ], 
+            "name": "South Dakota Neutral Citation", 
             "variations": {}
         }
-    ],
+    ], 
     "Sadler": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Sadler": {
-                    "end": "1888-12-31T00:00:00",
+                    "end": "1888-12-31T00:00:00", 
                     "start": "1885-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;pa;supreme.court"
-            ],
-            "name": "Pennsylvania State Reports, Sadler",
+                "us:pa;supreme.court"
+            ], 
+            "name": "Pennsylvania State Reports, Sadler", 
             "variations": {
-                "Pa.Cas.": "Sadler",
-                "Sad.Pa.Cas.": "Sadler",
-                "Sad.Pa.Cs.": "Sadler",
-                "Sadl.": "Sadler",
+                "Pa.Cas.": "Sadler", 
+                "Sad.Pa.Cas.": "Sadler", 
+                "Sad.Pa.Cs.": "Sadler", 
+                "Sadl.": "Sadler", 
                 "Sadler(Pa.)": "Sadler"
             }
         }
-    ],
+    ], 
     "Sand. Ch.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Sand. Ch.": {
-                    "end": "1847-12-31T00:00:00",
+                    "end": "1847-12-31T00:00:00", 
                     "start": "1843-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Sandford's Chancery Reports",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Sandford's Chancery Reports", 
             "variations": {
-                "Sand.Chy.": "Sand. Ch.",
-                "Sandf.Ch.": "Sand. Ch.",
-                "Sandf.Ch.(N.Y.)": "Sand. Ch.",
+                "Sand.Chy.": "Sand. Ch.", 
+                "Sandf.Ch.": "Sand. Ch.", 
+                "Sandf.Ch.(N.Y.)": "Sand. Ch.", 
                 "Sandf.Chy.": "Sand. Ch."
             }
         }
-    ],
+    ], 
     "Sarat. Ch. Sent.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Sarat. Ch. Sent.": {
-                    "end": "1847-12-31T00:00:00",
+                    "end": "1847-12-31T00:00:00", 
                     "start": "1841-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Saratoga Chancery Sentinel",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Saratoga Chancery Sentinel", 
             "variations": {
-                "Ch.Sent.": "Sarat. Ch. Sent.",
-                "Ch.Sent.(N.Y.)": "Sarat. Ch. Sent.",
-                "N.Y.Ch.Sent.": "Sarat. Ch. Sent.",
+                "Ch.Sent.": "Sarat. Ch. Sent.", 
+                "Ch.Sent.(N.Y.)": "Sarat. Ch. Sent.", 
+                "N.Y.Ch.Sent.": "Sarat. Ch. Sent.", 
                 "Sar.Ch.Sen.": "Sarat. Ch. Sent."
             }
         }
-    ],
+    ], 
     "Scam.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Scam.": {
-                    "end": "1843-12-31T00:00:00",
+                    "end": "1843-12-31T00:00:00", 
                     "start": "1832-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;il;supreme.court"
-            ],
-            "name": "Illinois Reports, Scammon",
+                "us:il;supreme.court"
+            ], 
+            "name": "Illinois Reports, Scammon", 
             "variations": {
-                "Ill.(Scam.)": "Scam.",
+                "Ill.(Scam.)": "Scam.", 
                 "Sc.": "Scam."
             }
         }
-    ],
+    ], 
     "Serg. & Rawle": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Serg. & Rawle": {
-                    "end": "1828-12-31T00:00:00",
+                    "end": "1828-12-31T00:00:00", 
                     "start": "1814-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;pa;supreme.court"
-            ],
-            "name": "Pennsylvania State Reports, Sergeant and Rawle",
+                "us:pa;supreme.court"
+            ], 
+            "name": "Pennsylvania State Reports, Sergeant and Rawle", 
             "variations": {
-                "Serg.& R.": "Serg. & Rawle",
-                "Serg.& Raw.": "Serg. & Rawle",
+                "Serg.& R.": "Serg. & Rawle", 
+                "Serg.& Raw.": "Serg. & Rawle", 
                 "Serg.& Rawl.": "Serg. & Rawle"
             }
         }
-    ],
+    ], 
     "Sneed": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Sneed": {
-                    "end": "1805-12-31T00:00:00",
+                    "end": "1805-12-31T00:00:00", 
                     "start": "1801-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ky;supreme.court"
-            ],
-            "name": "Kentucky Reports, Sneed",
+                "us:ky;supreme.court"
+            ], 
+            "name": "Kentucky Reports, Sneed", 
             "variations": {
-                "Ken.Dec.": "Sneed",
-                "Ky.(Sneed)": "Sneed",
+                "Ken.Dec.": "Sneed", 
+                "Ky.(Sneed)": "Sneed", 
                 "Sneed Dec.": "Sneed"
             }
-        },
+        }, 
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Sneed": {
-                    "end": "1858-12-31T00:00:00",
+                    "end": "1858-12-31T00:00:00", 
                     "start": "1853-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tn;supreme.court"
-            ],
-            "name": "Tennessee Reports, Sneed",
+                "us:tn;supreme.court"
+            ], 
+            "name": "Tennessee Reports, Sneed", 
             "variations": {
                 "Tenn.(Sneed)": "Sneed"
             }
         }
-    ],
+    ], 
     "So.": [
         {
-            "cite_type": "state_regional",
+            "cite_type": "state_regional", 
             "editions": {
                 "So.": {
-                    "end": "1941-12-31T00:00:00",
+                    "end": "1941-12-31T00:00:00", 
                     "start": "1886-01-01T00:00:00"
-                },
+                }, 
                 "So. 2d": {
-                    "end": "2008-12-31T00:00:00",
+                    "end": "2008-12-31T00:00:00", 
                     "start": "1941-01-01T00:00:00"
-                },
+                }, 
                 "So. 3d": {
-                    "end": null,
+                    "end": null, 
                     "start": "2008-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;al;supreme.court",
-                "us;fl;supreme.court",
-                "us;la;supreme.court",
-                "us;ms;supreme.court"
-            ],
-            "name": "Southern Reporter",
+                "us:al;supreme.court", 
+                "us:fl;supreme.court", 
+                "us:la;supreme.court", 
+                "us:ms;supreme.court"
+            ], 
+            "name": "Southern Reporter", 
             "variations": {
-                "So.2d": "So. 2d",
-                "So.3d": "So. 3d",
-                "South.": "So.",
-                "South.2d": "So. 2d",
+                "So.2d": "So. 2d", 
+                "So.3d": "So. 3d", 
+                "South.": "So.", 
+                "South.2d": "So. 2d", 
                 "South.3d": "So. 3d"
             }
         }
-    ],
+    ], 
     "Speers": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Speers": {
-                    "end": "1844-12-31T00:00:00",
+                    "end": "1844-12-31T00:00:00", 
                     "start": "1842-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Speers",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Speers", 
             "variations": {
-                "S.C.L.(Speers)": "Speers",
-                "Sp.": "Speers",
-                "Spears": "Speers",
+                "S.C.L.(Speers)": "Speers", 
+                "Sp.": "Speers", 
+                "Spears": "Speers", 
                 "Speers L.(S.C.)": "Speers"
             }
         }
-    ],
+    ], 
     "Speers Eq.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Speers Eq.": {
-                    "end": "1844-12-31T00:00:00",
+                    "end": "1844-12-31T00:00:00", 
                     "start": "1842-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Speers' Equity",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Speers' Equity", 
             "variations": {
-                "S.C.Eq.(Speers Eq.)": "Speers Eq.",
-                "Sp.": "Speers Eq.",
-                "Sp.Ch.": "Speers Eq.",
-                "Spear Ch.": "Speers Eq.",
-                "Spear Eq.": "Speers Eq.",
-                "Spears": "Speers Eq.",
-                "Spears Eq.": "Speers Eq.",
-                "Speers": "Speers Eq.",
+                "S.C.Eq.(Speers Eq.)": "Speers Eq.", 
+                "Sp.": "Speers Eq.", 
+                "Sp.Ch.": "Speers Eq.", 
+                "Spear Ch.": "Speers Eq.", 
+                "Spear Eq.": "Speers Eq.", 
+                "Spears": "Speers Eq.", 
+                "Spears Eq.": "Speers Eq.", 
+                "Speers": "Speers Eq.", 
                 "Speers Eq.(S.C.)": "Speers Eq."
             }
         }
-    ],
+    ], 
     "State Rptr.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "State Rptr.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1945-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;mt;supreme.court"
-            ],
-            "name": "State Reporter",
+                "us:mt;supreme.court"
+            ], 
+            "name": "State Reporter", 
             "variations": {}
         }
-    ],
+    ], 
     "Stew.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Stew.": {
-                    "end": "1831-12-31T00:00:00",
+                    "end": "1831-12-31T00:00:00", 
                     "start": "1827-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;al;supreme.court"
-            ],
-            "name": "Alabama Reports, Stewart",
+                "us:al;supreme.court"
+            ], 
+            "name": "Alabama Reports, Stewart", 
             "variations": {
                 "Stewart": "Stew."
             }
         }
-    ],
+    ], 
     "Stew. & P.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Stew. & P.": {
-                    "end": "1834-01-01T00:00:00",
+                    "end": "1834-01-01T00:00:00", 
                     "start": "1831-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;al;supreme.court"
-            ],
-            "name": "Alabama Reports, Stewart and Porter",
+                "us:al;supreme.court"
+            ], 
+            "name": "Alabama Reports, Stewart and Porter", 
             "variations": {}
         }
-    ],
+    ], 
     "Strob.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Strob.": {
-                    "end": "1850-12-31T00:00:00",
+                    "end": "1850-12-31T00:00:00", 
                     "start": "1846-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Strobhart",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Strobhart", 
             "variations": {
-                "S.C.L.(Strob.)": "Strob.",
+                "S.C.L.(Strob.)": "Strob.", 
                 "Strobh.L.(S.C.)": "Strob."
             }
         }
-    ],
+    ], 
     "Strob. Eq.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Strob. Eq.": {
-                    "end": "1850-12-31T00:00:00",
+                    "end": "1850-12-31T00:00:00", 
                     "start": "1846-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Strobhart's Equity",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Strobhart's Equity", 
             "variations": {
-                "S.C.Eq.(Strob.Eq.)": "Strob. Eq.",
+                "S.C.Eq.(Strob.Eq.)": "Strob. Eq.", 
                 "Strob.Eq.(S.C.)": "Strob. Eq."
             }
         }
-    ],
+    ], 
     "Swan": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Swan": {
-                    "end": "1853-12-31T00:00:00",
+                    "end": "1853-12-31T00:00:00", 
                     "start": "1851-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tn;supreme.court"
-            ],
-            "name": "Tennessee Reports, Swan",
+                "us:tn;supreme.court"
+            ], 
+            "name": "Tennessee Reports, Swan", 
             "variations": {
                 "Tenn.(Swan)": "Swan"
             }
         }
-    ],
+    ], 
     "T.B. Mon.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "T.B. Mon.": {
-                    "end": "1828-12-31T00:00:00",
+                    "end": "1828-12-31T00:00:00", 
                     "start": "1824-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ky;supreme.court"
-            ],
-            "name": "Kentucky Reports, Monroe, T.B.",
+                "us:ky;supreme.court"
+            ], 
+            "name": "Kentucky Reports, Monroe, T.B.", 
             "variations": {
-                "Ky.(T.B.Monroe)": "T.B. Mon.",
-                "Mon.": "T.B. Mon.",
-                "Mon.T.B.": "T.B. Mon.",
+                "Ky.(T.B.Monroe)": "T.B. Mon.", 
+                "Mon.": "T.B. Mon.", 
+                "Mon.T.B.": "T.B. Mon.", 
                 "T.B.Mon.(Ky.)": "T.B. Mon."
             }
         }
-    ],
+    ], 
     "T.C.": [
         {
-            "cite_type": "specialty",
+            "cite_type": "specialty", 
             "editions": {
                 "T.C.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1942-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;tax.court"
-            ],
-            "name": "Reports of the United States Tax Court",
+                "us:c;tax.court"
+            ], 
+            "name": "Reports of the United States Tax Court", 
             "variations": {
-                "T. C.": "T.C.",
-                "T.Ct": "T.C.",
+                "T. C.": "T.C.", 
+                "T.Ct": "T.C.", 
                 "T.Ct.": "T.C."
             }
         }
-    ],
+    ], 
     "T.C.M.": [
         {
-            "cite_type": "specialty",
+            "cite_type": "specialty", 
             "editions": {
                 "T.C.M.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1942-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;tax.court"
-            ],
-            "name": "Tax Court Memorandum Decisions",
+                "us:c;tax.court"
+            ], 
+            "name": "Tax Court Memorandum Decisions", 
             "variations": {
-                "T.C.M. (CCH)": "T.C.M.",
-                "T.C.M. (P-H)": "T.C.M.",
+                "T.C.M. (CCH)": "T.C.M.", 
+                "T.C.M. (P-H)": "T.C.M.", 
                 "T.C.M. (RIA)": "T.C.M."
             }
         }
-    ],
+    ], 
     "Tay.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Tay.": {
-                    "end": "1802-12-31T00:00:00",
+                    "end": "1802-12-31T00:00:00", 
                     "start": "1798-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nc;supreme.court"
-            ],
-            "name": "North Carolina Reports, Taylor",
+                "us:nc;supreme.court"
+            ], 
+            "name": "North Carolina Reports, Taylor", 
             "variations": {
-                "N.C.(Tay.)": "Tay.",
-                "Tay.J.L.": "Tay.",
-                "Tay.N.C.": "Tay.",
-                "Tayl.N.C.": "Tay.",
+                "N.C.(Tay.)": "Tay.", 
+                "Tay.J.L.": "Tay.", 
+                "Tay.N.C.": "Tay.", 
+                "Tayl.N.C.": "Tay.", 
                 "Taylor": "Tay."
             }
         }
-    ],
+    ], 
     "Taylor": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Taylor": {
-                    "end": "1818-12-31T00:00:00",
+                    "end": "1818-12-31T00:00:00", 
                     "start": "1816-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nc;supreme.court"
-            ],
-            "name": "Taylor's North Carolina Term Reports",
+                "us:nc;supreme.court"
+            ], 
+            "name": "Taylor's North Carolina Term Reports", 
             "variations": {
-                "N.C.(Taylor)": "Taylor",
-                "N.C.T.Rep.": "Taylor",
-                "N.C.Term.R.": "Taylor",
+                "N.C.(Taylor)": "Taylor", 
+                "N.C.T.Rep.": "Taylor", 
+                "N.C.Term.R.": "Taylor", 
                 "N.C.Term.Rep.": "Taylor"
             }
         }
-    ],
+    ], 
     "Teiss.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Teiss.": {
-                    "end": "1917-12-31T00:00:00",
+                    "end": "1917-12-31T00:00:00", 
                     "start": "1903-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;la;supreme.court"
-            ],
-            "name": "Louisiana Court of Appeals Reports, Teisser",
+                "us:la;supreme.court"
+            ], 
+            "name": "Louisiana Court of Appeals Reports, Teisser", 
             "variations": {
-                "La.App.(Orleans)": "Teiss.",
+                "La.App.(Orleans)": "Teiss.", 
                 "Teissier": "Teiss."
             }
         }
-    ],
+    ], 
     "Tenn.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Tenn.": {
-                    "end": "1971-12-31T00:00:00",
+                    "end": "1971-12-31T00:00:00", 
                     "start": "1870-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tn;supreme.court"
-            ],
-            "name": "Tennessee Reports",
+                "us:tn;supreme.court"
+            ], 
+            "name": "Tennessee Reports", 
             "variations": {
                 "Ten.": "Tenn."
             }
         }
-    ],
+    ], 
     "Tenn. App.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Tenn. App.": {
-                    "end": "1971-12-31T00:00:00",
+                    "end": "1971-12-31T00:00:00", 
                     "start": "1925-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tn;supreme.court"
-            ],
-            "name": "Tennessee Appeals Reports",
+                "us:tn;supreme.court"
+            ], 
+            "name": "Tennessee Appeals Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Tenn. Crim. App.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Tenn. Crim. App.": {
-                    "end": "1971-12-31T00:00:00",
+                    "end": "1971-12-31T00:00:00", 
                     "start": "1967-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tn;supreme.court"
-            ],
-            "name": "Tennessee Criminal Appeals Reports",
+                "us:tn;supreme.court"
+            ], 
+            "name": "Tennessee Criminal Appeals Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Tex.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Tex.": {
-                    "end": "1962-12-31T00:00:00",
+                    "end": "1962-12-31T00:00:00", 
                     "start": "1846-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tx;supreme.court"
-            ],
-            "name": "Texas Reports",
+                "us:tx;supreme.court"
+            ], 
+            "name": "Texas Reports", 
             "variations": {
                 "Tex.S.Ct.": "Tex."
             }
         }
-    ],
+    ], 
     "Tex. Civ. App.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Tex. Civ. App.": {
-                    "end": "1911-12-31T00:00:00",
+                    "end": "1911-12-31T00:00:00", 
                     "start": "1892-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tx;supreme.court"
-            ],
-            "name": "Texas Civil Appeals Reports",
+                "us:tx;supreme.court"
+            ], 
+            "name": "Texas Civil Appeals Reports", 
             "variations": {
                 "Tex.Civ.App.": "Tex. Civ. App."
             }
         }
-    ],
+    ], 
     "Tex. Crim.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Tex. Crim.": {
-                    "end": "1962-12-31T00:00:00",
+                    "end": "1962-12-31T00:00:00", 
                     "start": "1891-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tx;supreme.court"
-            ],
-            "name": "Texas Criminal Reports",
+                "us:tx;supreme.court"
+            ], 
+            "name": "Texas Criminal Reports", 
             "variations": {
-                "Tex.Cr.App.": "Tex. Crim.",
-                "Tex.Cr.R.": "Tex. Crim.",
+                "Tex.Cr.App.": "Tex. Crim.", 
+                "Tex.Cr.R.": "Tex. Crim.", 
                 "Tex.Crim.Rep.": "Tex. Crim."
             }
         }
-    ],
+    ], 
     "Tex. Ct. App.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Tex. Ct. App.": {
-                    "end": "1891-12-31T00:00:00",
+                    "end": "1891-12-31T00:00:00", 
                     "start": "1876-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tx;supreme.court"
-            ],
-            "name": "Texas Court of Appeals Reports",
+                "us:tx;supreme.court"
+            ], 
+            "name": "Texas Court of Appeals Reports", 
             "variations": {
                 "Tex.Ct.App.R.": "Tex. Ct. App."
             }
         }
-    ],
+    ], 
     "Tex. L. Rev.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Tex. L. Rev.": {
-                    "end": "1846-12-31T00:00:00",
+                    "end": "1846-12-31T00:00:00", 
                     "start": "1845-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tx;supreme.court"
-            ],
-            "name": "Texas Law Review",
+                "us:tx;supreme.court"
+            ], 
+            "name": "Texas Law Review", 
             "variations": {
                 "Texas L.Rev.": "Tex. L. Rev."
             }
         }
-    ],
+    ], 
     "Tex. Sup. Ct. J.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Tex. Sup. Ct. J.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1957-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tx;supreme.court"
-            ],
-            "name": "Texas Supreme Court Journal",
+                "us:tx;supreme.court"
+            ], 
+            "name": "Texas Supreme Court Journal", 
             "variations": {}
         }
-    ],
+    ], 
     "Tread.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Tread.": {
-                    "end": "1816-12-31T00:00:00",
+                    "end": "1816-12-31T00:00:00", 
                     "start": "1812-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;sc;supreme.court"
-            ],
-            "name": "South Carolina Reports, Treadway",
+                "us:sc;supreme.court"
+            ], 
+            "name": "South Carolina Reports, Treadway", 
             "variations": {
                 "S.C.L.(Tread.)": "Tread."
             }
         }
-    ],
+    ], 
     "Tuck. & Cl.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Tuck. & Cl.": {
-                    "end": "1893-12-31T00:00:00",
+                    "end": "1893-12-31T00:00:00", 
                     "start": "1892-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;district.columbia.court.appeals"
-            ],
-            "name": "District of Columbia Reports, Tucker and Clephane",
+                "us:dc;court.appeals"
+            ], 
+            "name": "District of Columbia Reports, Tucker and Clephane", 
             "variations": {
-                "D.C.(Tuck.& Cl.)": "Tuck. & Cl.",
-                "Tuck.": "Tuck. & Cl.",
+                "D.C.(Tuck.& Cl.)": "Tuck. & Cl.", 
+                "Tuck.": "Tuck. & Cl.", 
                 "Tuck.& C.": "Tuck. & Cl."
             }
         }
-    ],
+    ], 
     "Tyl.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Tyl.": {
-                    "end": "1803-12-31T00:00:00",
+                    "end": "1803-12-31T00:00:00", 
                     "start": "1800-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;vt;supreme.court"
-            ],
-            "name": "Vermont Reports, Tyler",
+                "us:vt;supreme.court"
+            ], 
+            "name": "Vermont Reports, Tyler", 
             "variations": {
                 "Tyler": "Tyl."
             }
         }
-    ],
+    ], 
     "Tyng": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Tyng": {
-                    "end": "1822-12-31T00:00:00",
+                    "end": "1822-12-31T00:00:00", 
                     "start": "1806-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ma;appeals.court"
-            ],
-            "name": "Massachusetts Reports, Tyng",
+                "us:ma;appeals.court"
+            ], 
+            "name": "Massachusetts Reports, Tyng", 
             "variations": {
                 "Mass.(Tyng)": "Tyng"
             }
         }
-    ],
+    ], 
     "U.S.": [
         {
-            "cite_type": "federal",
+            "cite_type": "federal", 
             "editions": {
                 "U.S.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1790-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;supreme.court"
-            ],
-            "name": "United States Supreme Court Reports",
+                "us;supreme.court"
+            ], 
+            "name": "United States Supreme Court Reports", 
             "variations": {
-                "U. S.": "U.S.",
-                "U.S.S.C.Rep.": "U.S.",
-                "US": "U.S.",
+                "U. S.": "U.S.", 
+                "U.S.S.C.Rep.": "U.S.", 
+                "US": "U.S.", 
                 "USSCR": "U.S."
             }
         }
-    ],
+    ], 
     "U.S. App. D.C.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "U.S. App. D.C.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1941-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;district.columbia.court.appeals"
-            ],
-            "name": "United States Court of Appeals Reports",
+                "us:dc;court.appeals"
+            ], 
+            "name": "United States Court of Appeals Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "U.S. App. LEXIS": [
         {
-            "cite_type": "specialty_lexis",
+            "cite_type": "specialty_lexis", 
             "editions": {
                 "U.S. App. LEXIS": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;court.appeals.1.circuit",
-                "us;federal;court.appeals.10.circuit",
-                "us;federal;court.appeals.11.circuit",
-                "us;federal;court.appeals.2.circuit",
-                "us;federal;court.appeals.3.circuit",
-                "us;federal;court.appeals.4.circuit",
-                "us;federal;court.appeals.5.circuit",
-                "us;federal;court.appeals.6.circuit",
-                "us;federal;court.appeals.7.circuit",
-                "us;federal;court.appeals.8.circuit",
-                "us;federal;court.appeals.9.circuit"
-            ],
-            "name": "LexisNexis U.S. Appeals Citation",
+                "us:c10;court.appeals", 
+                "us:c11;court.appeals", 
+                "us:c1;court.appeals", 
+                "us:c2;court.appeals", 
+                "us:c3;court.appeals", 
+                "us:c4;court.appeals", 
+                "us:c5;court.appeals", 
+                "us:c6;court.appeals", 
+                "us:c7;court.appeals", 
+                "us:c8;court.appeals", 
+                "us:c9;court.appeals"
+            ], 
+            "name": "LexisNexis U.S. Appeals Citation", 
             "variations": {}
         }
-    ],
+    ], 
     "U.S. Dist. LEXIS": [
         {
-            "cite_type": "specialty_lexis",
+            "cite_type": "specialty_lexis", 
             "editions": {
                 "U.S. Dist. LEXIS": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;ak;d;district.court",
-                "us;federal;al;md;district.court",
-                "us;federal;ar;ed;district.court",
-                "us;federal;az;d;district.court",
-                "us;federal;ca;cd;district.court",
-                "us;federal;co;d;district.court",
-                "us;federal;ct;d;district.court",
-                "us;federal;de;d;district.court",
-                "us;federal;district.court.canal.zone",
-                "us;federal;district.court.d.guam",
-                "us;federal;district.court.d.puerto.rico",
-                "us;federal;district.court.district.columbia",
-                "us;federal;district.court.northern.mariana.islands",
-                "us;federal;district.court.virgin.islands",
-                "us;federal;fl;md;district.court",
-                "us;federal;ga;md;district.court",
-                "us;federal;hi;d;district.court",
-                "us;federal;ia;nd;district.court",
-                "us;federal;id;d;district.court",
-                "us;federal;il;cd;district.court",
-                "us;federal;in;d;district.court",
-                "us;federal;ks;d;district.court",
-                "us;federal;ky;ed;district.court",
-                "us;federal;la;ed;district.court",
-                "us;federal;ma;d;district.court",
-                "us;federal;md;d;district.court",
-                "us;federal;me;d;district.court",
-                "us;federal;mi;ed;district.court",
-                "us;federal;mn;d;district.court",
-                "us;federal;mo;cd;district.court",
-                "us;federal;ms;nd;district.court",
-                "us;federal;mt;d;district.court",
-                "us;federal;nc;ed;district.court",
-                "us;federal;nd;d;district.court",
-                "us;federal;ne;d;district.court",
-                "us;federal;nh;d;district.court",
-                "us;federal;nj;d;district.court",
-                "us;federal;nm;d;district.court",
-                "us;federal;nv;d;district.court",
-                "us;federal;ny;ed;district.court",
-                "us;federal;oh;d;district.court",
-                "us;federal;ok;ed;district.court",
-                "us;federal;or;d;district.court",
-                "us;federal;pa;d;district.court",
-                "us;federal;ri;d;district.court",
-                "us;federal;sc;d;district.court",
-                "us;federal;sd;d;district.court",
-                "us;federal;tn;d;district.court",
-                "us;federal;tx;ed;district.court",
-                "us;federal;ut;d;district.court",
-                "us;federal;va;ed;district.court",
-                "us;federal;vt;d;district.court",
-                "us;federal;wa;ed;district.court",
-                "us;federal;wi;ed;district.court",
-                "us;federal;wv;nd;district.court",
-                "us;federal;wy;d;district.court"
-            ],
-            "name": "LexisNexis U.S. District Court Citation",
+                "us:c0:dc.d;district.court", 
+                "us:c10:co.d;district.court", 
+                "us:c10:ks.d;district.court", 
+                "us:c10:nm.d;district.court", 
+                "us:c10:ok.ed;district.court", 
+                "us:c10:ut.d;district.court", 
+                "us:c10:wy.d;district.court", 
+                "us:c11:al.md;district.court", 
+                "us:c11:fl.md;district.court", 
+                "us:c11:ga.md;district.court", 
+                "us:c1:ma.d;district.court", 
+                "us:c1:me.d;district.court", 
+                "us:c1:nh.d;district.court", 
+                "us:c1:pr.d;district.court", 
+                "us:c1:ri.d;district.court", 
+                "us:c2:ct.d;district.court", 
+                "us:c2:ny.ed;district.court", 
+                "us:c2:vt.d;district.court", 
+                "us:c3:de.d;district.court", 
+                "us:c3:nj.d;district.court", 
+                "us:c3:pa.d;district.court", 
+                "us:c3:vi.d;district.court", 
+                "us:c4:md.d;district.court", 
+                "us:c4:nc.ed;district.court", 
+                "us:c4:sc.d;district.court", 
+                "us:c4:sc.ed;district.court", 
+                "us:c4:sc.wd;district.court", 
+                "us:c4:va.ed;district.court", 
+                "us:c4:wv.nd;district.court", 
+                "us:c5:la.ed;district.court", 
+                "us:c5:ms.nd;district.court", 
+                "us:c5:pz.d;district.court", 
+                "us:c5:tx.ed;district.court", 
+                "us:c6:ky.ed;district.court", 
+                "us:c6:mi.ed;district.court", 
+                "us:c6:oh.d;district.court", 
+                "us:c6:tn.d;district.court", 
+                "us:c7:il.cd;district.court", 
+                "us:c7:in.d;district.court", 
+                "us:c7:wi.ed;district.court", 
+                "us:c8:ar.ed;district.court", 
+                "us:c8:ia.nd;district.court", 
+                "us:c8:mn.d;district.court", 
+                "us:c8:mo.cd;district.court", 
+                "us:c8:nd.d;district.court", 
+                "us:c8:ne.d;district.court", 
+                "us:c8:sd.d;district.court", 
+                "us:c9:ak.d;district.court", 
+                "us:c9:az.d;district.court", 
+                "us:c9:ca.cd;district.court", 
+                "us:c9:gu.d;district.court", 
+                "us:c9:hi.d;district.court", 
+                "us:c9:id.d;district.court", 
+                "us:c9:mp.d;district.court", 
+                "us:c9:mt.d;district.court", 
+                "us:c9:nv.d;district.court", 
+                "us:c9:or.d;district.court", 
+                "us:c9:wa.ed;district.court"
+            ], 
+            "name": "LexisNexis U.S. District Court Citation", 
             "variations": {}
         }
-    ],
+    ], 
     "U.S.L.W.": [
         {
-            "cite_type": "specialty",
+            "cite_type": "specialty", 
             "editions": {
                 "U.S.L.W.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1933-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;supreme.court"
-            ],
-            "name": "United States Law Week",
+                "us;supreme.court"
+            ], 
+            "name": "United States Law Week", 
             "variations": {}
         }
-    ],
+    ], 
     "UT": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "UT": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ut;supreme.court"
-            ],
-            "name": "Utah Neutral Citation",
+                "us:ut;supreme.court"
+            ], 
+            "name": "Utah Neutral Citation", 
             "variations": {}
         }
-    ],
+    ], 
     "UT App": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "UT App": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ut;supreme.court"
-            ],
-            "name": "Utah Neutral Citation",
+                "us:ut;court.appeals"
+            ], 
+            "name": "Utah Neutral Citation", 
             "variations": {}
         }
-    ],
+    ], 
     "Utah": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Utah": {
-                    "end": "1974-12-31T00:00:00",
+                    "end": "1974-12-31T00:00:00", 
                     "start": "1851-01-01T00:00:00"
-                },
+                }, 
                 "Utah 2d": {
-                    "end": "1974-12-31T00:00:00",
+                    "end": "1974-12-31T00:00:00", 
                     "start": "1851-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ut;supreme.court"
-            ],
-            "name": "Utah Reports",
+                "us:ut;supreme.court"
+            ], 
+            "name": "Utah Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "V.I.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "V.I.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1917-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;district.court.virgin.islands"
-            ],
-            "name": "Virgin Islands Reports",
+                "us:c3:vi.d;district.court"
+            ], 
+            "name": "Virgin Islands Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "VT": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "VT": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;vt;supreme.court"
-            ],
-            "name": "Vermont Neutral Citation",
+                "us:vt;supreme.court"
+            ], 
+            "name": "Vermont Neutral Citation", 
             "variations": {}
         }
-    ],
+    ], 
     "Va.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Va.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1880-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;va;supreme.court"
-            ],
-            "name": "Virginia Reports",
+                "us:va;supreme.court"
+            ], 
+            "name": "Virginia Reports", 
             "variations": {
-                "V.": "Va.",
+                "V.": "Va.", 
                 "Virg.": "Va."
             }
         }
-    ],
+    ], 
     "Va. App.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Va. App.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1985-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;va;supreme.court"
-            ],
-            "name": "Virginia Court of Appeals Reports",
+                "us:va;supreme.court"
+            ], 
+            "name": "Virginia Court of Appeals Reports", 
             "variations": {}
         }
-    ],
+    ], 
     "Va. Cas.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Va. Cas.": {
-                    "end": "1826-12-31T00:00:00",
+                    "end": "1826-12-31T00:00:00", 
                     "start": "1789-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;va;supreme.court"
-            ],
-            "name": "Virginia Cases, Criminal",
+                "us:va;supreme.court"
+            ], 
+            "name": "Virginia Cases, Criminal", 
             "variations": {}
         }
-    ],
+    ], 
     "Vet. App.": [
         {
-            "cite_type": "specialty",
+            "cite_type": "specialty", 
             "editions": {
                 "Vet. App.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1990-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;board.veterans.appeals"
-            ],
-            "name": "Veterans Appeals Reporter",
+                "us:c;board.veterans.appeals"
+            ], 
+            "name": "Veterans Appeals Reporter", 
             "variations": {
                 "Vet.App.": "Vet. App."
             }
         }
-    ],
+    ], 
     "Vt.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Vt.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1826-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;vt;supreme.court"
-            ],
-            "name": "Vermont Reports",
+                "us:vt;supreme.court"
+            ], 
+            "name": "Vermont Reports", 
             "variations": {
-                "V.R.": "Vt.",
+                "V.R.": "Vt.", 
                 "Verm.": "Vt."
             }
         }
-    ],
+    ], 
     "W. Va.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "W. Va.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1864-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;wv;supreme.court"
-            ],
-            "name": "West Virginia Reports",
+                "us:wv;supreme.court"
+            ], 
+            "name": "West Virginia Reports", 
             "variations": {
-                "W.V.": "W. Va.",
+                "W.V.": "W. Va.", 
                 "West Va.": "W. Va."
             }
         }
-    ],
+    ], 
     "WI": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "WI": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;wi;supreme.court"
-            ],
-            "name": "Wisconsin Neutral Citation",
+                "us:wi;supreme.court"
+            ], 
+            "name": "Wisconsin Neutral Citation", 
             "variations": {}
         }
-    ],
+    ], 
     "WI App": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "WI App": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;wi;supreme.court"
-            ],
-            "name": "Wisconsin Neutral Citation",
+                "us:wi;court.appeals"
+            ], 
+            "name": "Wisconsin Neutral Citation", 
             "variations": {}
         }
-    ],
+    ], 
     "WL": [
         {
-            "cite_type": "specialty_west",
+            "cite_type": "specialty_west", 
             "editions": {
                 "WL": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ak;supreme.court",
-                "us;al;supreme.court",
-                "us;ar;supreme.court",
-                "us;az;supreme.court",
-                "us;ca;supreme.court",
-                "us;co;supreme.court",
-                "us;ct;supreme.court",
-                "us;de;supreme.court",
-                "us;federal;court.appeals.1.circuit",
-                "us;federal;court.appeals.10.circuit",
-                "us;federal;court.appeals.11.circuit",
-                "us;federal;court.appeals.2.circuit",
-                "us;federal;court.appeals.3.circuit",
-                "us;federal;court.appeals.4.circuit",
-                "us;federal;court.appeals.5.circuit",
-                "us;federal;court.appeals.6.circuit",
-                "us;federal;court.appeals.7.circuit",
-                "us;federal;court.appeals.8.circuit",
-                "us;federal;court.appeals.9.circuit",
-                "us;federal;district.columbia.court.appeals",
-                "us;fl;supreme.court",
-                "us;ga;supreme.court",
-                "us;hi;supreme.court",
-                "us;ia;supreme.court",
-                "us;id;supreme.court",
-                "us;il;supreme.court",
-                "us;in;supreme.court",
-                "us;ks;supreme.court",
-                "us;ky;supreme.court",
-                "us;la;supreme.court",
-                "us;ma;appeals.court",
-                "us;me;supreme.judicial.court",
-                "us;mi;supreme.court",
-                "us;mn;supreme.court",
-                "us;mo;supreme.court",
-                "us;ms;supreme.court",
-                "us;mt;supreme.court",
-                "us;nc;supreme.court",
-                "us;nd;supreme.court",
-                "us;ne;supreme.court",
-                "us;nh;supreme.court",
-                "us;nj;supreme.court",
-                "us;nm;supreme.court",
-                "us;nv;supreme.court",
-                "us;ny;court.appeals",
-                "us;oh;supreme.court",
-                "us;ok;supreme.court",
-                "us;or;supreme.court",
-                "us;pa;supreme.court",
-                "us;ri;supreme.court",
-                "us;sc;supreme.court",
-                "us;sd;supreme.court",
-                "us;tn;supreme.court",
-                "us;tx;supreme.court",
-                "us;ut;supreme.court",
-                "us;va;supreme.court",
-                "us;vt;supreme.court",
-                "us;wa;supreme.court",
-                "us;wi;supreme.court",
-                "us;wv;supreme.court",
-                "us;wy;supreme.court"
-            ],
-            "name": "West Law Citation",
+                "us:ak;supreme.court", 
+                "us:al;supreme.court", 
+                "us:ar;supreme.court", 
+                "us:az;supreme.court", 
+                "us:c10;court.appeals", 
+                "us:c11;court.appeals", 
+                "us:c1;court.appeals", 
+                "us:c2;court.appeals", 
+                "us:c3;court.appeals", 
+                "us:c4;court.appeals", 
+                "us:c5;court.appeals", 
+                "us:c6;court.appeals", 
+                "us:c7;court.appeals", 
+                "us:c8;court.appeals", 
+                "us:c9;court.appeals", 
+                "us:ca;supreme.court", 
+                "us:co;supreme.court", 
+                "us:ct;supreme.court", 
+                "us:dc;court.appeals", 
+                "us:de;supreme.court", 
+                "us:fl;supreme.court", 
+                "us:ga;supreme.court", 
+                "us:hi;supreme.court", 
+                "us:ia;supreme.court", 
+                "us:id;supreme.court", 
+                "us:il;supreme.court", 
+                "us:in;supreme.court", 
+                "us:ks;supreme.court", 
+                "us:ky;supreme.court", 
+                "us:la;supreme.court", 
+                "us:ma;appeals.court", 
+                "us:me;supreme.judicial.court", 
+                "us:mi;supreme.court", 
+                "us:mn;supreme.court", 
+                "us:mo;supreme.court", 
+                "us:ms;supreme.court", 
+                "us:mt;supreme.court", 
+                "us:nc;supreme.court", 
+                "us:nd;supreme.court", 
+                "us:ne;supreme.court", 
+                "us:nh;supreme.court", 
+                "us:nj;supreme.court", 
+                "us:nm;supreme.court", 
+                "us:nv;supreme.court", 
+                "us:ny;court.appeals", 
+                "us:oh;supreme.court", 
+                "us:ok;supreme.court", 
+                "us:or;supreme.court", 
+                "us:pa;supreme.court", 
+                "us:ri;supreme.court", 
+                "us:sc;supreme.court", 
+                "us:sd;supreme.court", 
+                "us:tn;supreme.court", 
+                "us:tx;supreme.court", 
+                "us:ut;supreme.court", 
+                "us:va;supreme.court", 
+                "us:vt;supreme.court", 
+                "us:wa;supreme.court", 
+                "us:wi;supreme.court", 
+                "us:wv;supreme.court", 
+                "us:wy;supreme.court"
+            ], 
+            "name": "West Law Citation", 
             "variations": {}
         }
-    ],
+    ], 
     "WY": [
         {
-            "cite_type": "neutral",
+            "cite_type": "neutral", 
             "editions": {
                 "WY": {
-                    "end": null,
+                    "end": null, 
                     "start": "1750-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;wy;supreme.court"
-            ],
-            "name": "Wyoming Neutral Citation",
+                "us:wy;supreme.court"
+            ], 
+            "name": "Wyoming Neutral Citation", 
             "variations": {}
         }
-    ],
+    ], 
     "Walk.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Walk.": {
-                    "end": "1885-12-31T00:00:00",
+                    "end": "1885-12-31T00:00:00", 
                     "start": "1855-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;pa;supreme.court"
-            ],
-            "name": "Pennsylvania State Reports, Walker",
+                "us:pa;supreme.court"
+            ], 
+            "name": "Pennsylvania State Reports, Walker", 
             "variations": {
-                "Walk.Pa.": "Walk.",
+                "Walk.Pa.": "Walk.", 
                 "Walker": "Walk."
             }
         }
-    ],
+    ], 
     "Walker": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Walker": {
-                    "end": "1832-12-31T00:00:00",
+                    "end": "1832-12-31T00:00:00", 
                     "start": "1818-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ms;supreme.court"
-            ],
-            "name": "Mississippi Reports, Walker",
+                "us:ms;supreme.court"
+            ], 
+            "name": "Mississippi Reports, Walker", 
             "variations": {
-                "Miss.(Walker)": "Walker",
-                "Walk.": "Walker",
+                "Miss.(Walker)": "Walker", 
+                "Walk.": "Walker", 
                 "Walk.Miss.": "Walker"
             }
         }
-    ],
+    ], 
     "Wall.": [
         {
-            "cite_type": "scotus_early",
+            "cite_type": "scotus_early", 
             "editions": {
                 "Wall.": {
-                    "end": "1874-12-31T00:00:00",
+                    "end": "1874-12-31T00:00:00", 
                     "start": "1863-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;supreme.court"
-            ],
-            "name": "Wallace's Supreme Court Reports",
+                "us;supreme.court"
+            ], 
+            "name": "Wallace's Supreme Court Reports", 
             "variations": {
-                "U.S.(Wall.)": "Wall.",
-                "Wall.": "Wall.",
-                "Wall.Rep.": "Wall.",
+                "U.S.(Wall.)": "Wall.", 
+                "Wall.": "Wall.", 
+                "Wall.Rep.": "Wall.", 
                 "Wall.S.C.": "Wall."
             }
         }
-    ],
+    ], 
     "Wash.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Wash.": {
-                    "end": "1796-12-31T00:00:00",
+                    "end": "1796-12-31T00:00:00", 
                     "start": "1790-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;va;supreme.court"
-            ],
-            "name": "Virginia Reports, Washington",
+                "us:va;supreme.court"
+            ], 
+            "name": "Virginia Reports, Washington", 
             "variations": {
-                "Va.(Wash.)": "Wash.",
+                "Va.(Wash.)": "Wash.", 
                 "Wash.Va.": "Wash."
             }
-        },
+        }, 
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Wash.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1889-01-01T00:00:00"
-                },
+                }, 
                 "Wash. 2d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1889-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;wa;supreme.court"
-            ],
-            "name": "Washington Reports",
+                "us:wa;supreme.court"
+            ], 
+            "name": "Washington Reports", 
             "variations": {
-                "W.": "Wash.",
-                "W.2d": "Wash. 2d",
-                "W.St.": "Wash.",
-                "WASH": "Wash.",
-                "Wa.": "Wash.",
-                "Wa.2d": "Wash. 2d",
-                "Wash.St.": "Wash.",
-                "Wn": "Wash.",
-                "Wn. 2d": "Wash. 2d",
+                "W.": "Wash.", 
+                "W.2d": "Wash. 2d", 
+                "W.St.": "Wash.", 
+                "WASH": "Wash.", 
+                "Wa.": "Wash.", 
+                "Wa.2d": "Wash. 2d", 
+                "Wash.St.": "Wash.", 
+                "Wn": "Wash.", 
+                "Wn. 2d": "Wash. 2d", 
                 "Wn.2d": "Wash. 2d"
             }
         }
-    ],
+    ], 
     "Wash. App.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Wash. App.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1969-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;wa;supreme.court"
-            ],
-            "name": "Washington Appellate Reports",
+                "us:wa;supreme.court"
+            ], 
+            "name": "Washington Appellate Reports", 
             "variations": {
-                "W.App.": "Wash. App.",
-                "Wa.A.": "Wash. App.",
-                "Wn. App.": "Wash. App.",
+                "W.App.": "Wash. App.", 
+                "Wa.A.": "Wash. App.", 
+                "Wn. App.": "Wash. App.", 
                 "Wn.App.": "Wash. App."
             }
         }
-    ],
+    ], 
     "Wash. Terr.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Wash. Terr.": {
-                    "end": "1888-12-31T00:00:00",
+                    "end": "1888-12-31T00:00:00", 
                     "start": "1854-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;wa;supreme.court"
-            ],
-            "name": "Washington Territory Reports",
+                "us:wa;supreme.court"
+            ], 
+            "name": "Washington Territory Reports", 
             "variations": {
-                "Allen": "Wash. Terr.",
-                "W.T.": "Wash. Terr.",
-                "W.Ty.R.": "Wash. Terr.",
-                "Wash.": "Wash. Terr.",
-                "Wash.T.": "Wash. Terr.",
-                "Wash.Ter.": "Wash. Terr.",
-                "Wash.Ter.N.S.": "Wash. Terr.",
-                "Wash.Ty.": "Wash. Terr.",
+                "Allen": "Wash. Terr.", 
+                "W.T.": "Wash. Terr.", 
+                "W.Ty.R.": "Wash. Terr.", 
+                "Wash.": "Wash. Terr.", 
+                "Wash.T.": "Wash. Terr.", 
+                "Wash.Ter.": "Wash. Terr.", 
+                "Wash.Ter.N.S.": "Wash. Terr.", 
+                "Wash.Ty.": "Wash. Terr.", 
                 "Wn. Terr.": "Wash. Terr."
             }
         }
-    ],
+    ], 
     "Watts": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Watts": {
-                    "end": "1840-12-31T00:00:00",
+                    "end": "1840-12-31T00:00:00", 
                     "start": "1832-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;pa;supreme.court"
-            ],
-            "name": "Pennsylvania State Reports, Watts",
+                "us:pa;supreme.court"
+            ], 
+            "name": "Pennsylvania State Reports, Watts", 
             "variations": {
-                "Wa.": "Watts",
+                "Wa.": "Watts", 
                 "Watts(Pa.)": "Watts"
             }
         }
-    ],
+    ], 
     "Watts & Serg.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Watts & Serg.": {
-                    "end": "1845-12-31T00:00:00",
+                    "end": "1845-12-31T00:00:00", 
                     "start": "1841-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;pa;supreme.court"
-            ],
-            "name": "Pennsylvania State Reports, Watts & Sergeant",
+                "us:pa;supreme.court"
+            ], 
+            "name": "Pennsylvania State Reports, Watts & Sergeant", 
             "variations": {
-                "W.& S.": "Watts & Serg.",
+                "W.& S.": "Watts & Serg.", 
                 "Watts & S.": "Watts & Serg."
             }
         }
-    ],
+    ], 
     "Wend.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Wend.": {
-                    "end": "1841-12-31T00:00:00",
+                    "end": "1841-12-31T00:00:00", 
                     "start": "1828-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Wendell's Reports",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Wendell's Reports", 
             "variations": {
-                "W.": "Wend.",
-                "Wend.(N.Y.)": "Wend.",
+                "W.": "Wend.", 
+                "Wend.(N.Y.)": "Wend.", 
                 "Wendell": "Wend."
             }
         }
-    ],
+    ], 
     "Whart.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Whart.": {
-                    "end": "1841-12-31T00:00:00",
+                    "end": "1841-12-31T00:00:00", 
                     "start": "1835-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;pa;supreme.court"
-            ],
-            "name": "Pennsylvania State Reports, Wharton",
+                "us:pa;supreme.court"
+            ], 
+            "name": "Pennsylvania State Reports, Wharton", 
             "variations": {
-                "Wh.": "Whart.",
-                "Whar.": "Whart.",
-                "Whart.Pa.": "Whart.",
+                "Wh.": "Whart.", 
+                "Whar.": "Whart.", 
+                "Whart.Pa.": "Whart.", 
                 "Wharton": "Whart."
             }
         }
-    ],
+    ], 
     "Wheat.": [
         {
-            "cite_type": "scotus_early",
+            "cite_type": "scotus_early", 
             "editions": {
                 "Wheat.": {
-                    "end": "1827-12-31T00:00:00",
+                    "end": "1827-12-31T00:00:00", 
                     "start": "1816-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;federal;supreme.court"
-            ],
-            "name": "Wheaton's Supreme Court Reports",
+                "us;supreme.court"
+            ], 
+            "name": "Wheaton's Supreme Court Reports", 
             "variations": {
-                "U.S.(Wheat.)": "Wheat.",
+                "U.S.(Wheat.)": "Wheat.", 
                 "Wheaton": "Wheat."
             }
         }
-    ],
+    ], 
     "White & W.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "White & W.": {
-                    "end": "1883-12-31T00:00:00",
+                    "end": "1883-12-31T00:00:00", 
                     "start": "1876-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tx;supreme.court"
-            ],
-            "name": "Condensed Reports of Decisions in Civil Causes in the Court of Appeals of Texas (White & Wilson)",
+                "us:tx;supreme.court"
+            ], 
+            "name": "Condensed Reports of Decisions in Civil Causes in the Court of Appeals of Texas (White & Wilson)", 
             "variations": {
-                "Tex.A.Civ.": "White & W.",
-                "Tex.A.Civ.Cas.": "White & W.",
-                "Tex.App.": "White & W.",
-                "Tex.C.C.": "White & W.",
-                "Tex.Civ.Cas.": "White & W.",
-                "Tex.Ct.App.Dec.Civ.": "White & W.",
-                "W.& W.": "White & W.",
-                "White & W.(Tex.)": "White & W.",
-                "White & W.Civ.Cas.Ct.App.": "White & W.",
+                "Tex.A.Civ.": "White & W.", 
+                "Tex.A.Civ.Cas.": "White & W.", 
+                "Tex.App.": "White & W.", 
+                "Tex.C.C.": "White & W.", 
+                "Tex.Civ.Cas.": "White & W.", 
+                "Tex.Ct.App.Dec.Civ.": "White & W.", 
+                "W.& W.": "White & W.", 
+                "White & W.(Tex.)": "White & W.", 
+                "White & W.Civ.Cas.Ct.App.": "White & W.", 
                 "Wi.& Will.": "White & W."
             }
         }
-    ],
+    ], 
     "Will.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Will.": {
-                    "end": "1805-12-31T00:00:00",
+                    "end": "1805-12-31T00:00:00", 
                     "start": "1804-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ma;appeals.court"
-            ],
-            "name": "Massachusetts Reports, Williams",
+                "us:ma;appeals.court"
+            ], 
+            "name": "Massachusetts Reports, Williams", 
             "variations": {
-                "Mass.(Will.)": "Will.",
-                "Will.Mass.": "Will.",
+                "Mass.(Will.)": "Will.", 
+                "Will.Mass.": "Will.", 
                 "Williams": "Will."
             }
         }
-    ],
+    ], 
     "Wilson": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Wilson": {
-                    "end": "1892-12-31T00:00:00",
+                    "end": "1892-12-31T00:00:00", 
                     "start": "1883-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tx;supreme.court"
-            ],
-            "name": "Condensed Reports of Decisions in Civil Causes in the Court of Appeals of Texas (Wilson)",
+                "us:tx;supreme.court"
+            ], 
+            "name": "Condensed Reports of Decisions in Civil Causes in the Court of Appeals of Texas (Wilson)", 
             "variations": {}
         }
-    ],
+    ], 
     "Win.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Win.": {
-                    "end": "1864-12-31T00:00:00",
+                    "end": "1864-12-31T00:00:00", 
                     "start": "1863-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;nc;supreme.court"
-            ],
-            "name": "North Carolina Reports, Winston",
+                "us:nc;supreme.court"
+            ], 
+            "name": "North Carolina Reports, Winston", 
             "variations": {}
         }
-    ],
+    ], 
     "Wis.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Wis.": {
-                    "end": null,
+                    "end": null, 
                     "start": "1853-01-01T00:00:00"
-                },
+                }, 
                 "Wis. 2d": {
-                    "end": null,
+                    "end": null, 
                     "start": "1853-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;wi;supreme.court"
-            ],
-            "name": "Wisconsin Reports",
+                "us:wi;supreme.court"
+            ], 
+            "name": "Wisconsin Reports", 
             "variations": {
-                "W.": "Wis.",
-                "W.2d": "Wis. 2d",
-                "W.R.": "Wis.",
+                "W.": "Wis.", 
+                "W.2d": "Wis. 2d", 
+                "W.R.": "Wis.", 
                 "Wis.2d": "Wis. 2d"
             }
         }
-    ],
+    ], 
     "Wyo.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Wyo.": {
-                    "end": "1959-12-31T00:00:00",
+                    "end": "1959-12-31T00:00:00", 
                     "start": "1870-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;wy;supreme.court"
-            ],
-            "name": "Wyoming Reports",
+                "us:wy;supreme.court"
+            ], 
+            "name": "Wyoming Reports", 
             "variations": {
-                "W.": "Wyo.",
+                "W.": "Wyo.", 
                 "Wy.": "Wyo."
             }
         }
-    ],
+    ], 
     "Yates Sel. Cas.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Yates Sel. Cas.": {
-                    "end": "1809-12-31T00:00:00",
+                    "end": "1809-12-31T00:00:00", 
                     "start": "1809-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;ny;court.appeals"
-            ],
-            "name": "Yates' Select Cases",
+                "us:ny;court.appeals"
+            ], 
+            "name": "Yates' Select Cases", 
             "variations": {
-                "Yates": "Yates Sel. Cas.",
+                "Yates": "Yates Sel. Cas.", 
                 "Yates Sel.Cas.(N.Y.)": "Yates Sel. Cas."
             }
         }
-    ],
+    ], 
     "Yeates": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Yeates": {
-                    "end": "1808-12-31T00:00:00",
+                    "end": "1808-12-31T00:00:00", 
                     "start": "1791-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;pa;supreme.court"
-            ],
-            "name": "Pennsylvania State Reports, Yeates",
+                "us:pa;supreme.court"
+            ], 
+            "name": "Pennsylvania State Reports, Yeates", 
             "variations": {
-                "Y.": "Yeates",
+                "Y.": "Yeates", 
                 "Yea.": "Yeates"
             }
         }
-    ],
+    ], 
     "Yer.": [
         {
-            "cite_type": "state",
+            "cite_type": "state", 
             "editions": {
                 "Yer.": {
-                    "end": "1837-12-31T00:00:00",
+                    "end": "1837-12-31T00:00:00", 
                     "start": "1828-01-01T00:00:00"
                 }
-            },
+            }, 
             "mlz_jurisdiction": [
-                "us;tn;supreme.court"
-            ],
-            "name": "Tennessee Reports, Yerger",
+                "us:tn;supreme.court"
+            ], 
+            "name": "Tennessee Reports, Yerger", 
             "variations": {
-                "Tenn.(Yer.)": "Yer.",
-                "Yerg.": "Yer.",
+                "Tenn.(Yer.)": "Yer.", 
+                "Yerg.": "Yer.", 
                 "Yerg.(Tenn.)": "Yer."
             }
         }


### PR DESCRIPTION
* ID schema has changed, but is now stable, with:
  - jurisdiction element delimited with a colon; and
  - court appended to jurisdiction with a semicolon

* The only changes to reporters.json with this checkin are
  in the mlz_jurisdiction identifiers.

* The PR restores the following entries to the B.R. reporter
  (both are present in a report of CL data, but had gone
  missing when the previous reporters.json was generated)
  - txwb / us:c5:tx.wd;bankruptcy.court
  - wvnb / us:c4:wv.nd;bankruptcy.court

* The PR restores the following entries to the U.S. Dist. LEXIS
  reporter (again, both are present in a report of CL data, but had
  gone missing when the previous version of reporters.json was
  generated)
  - southcarolinaed / us:c4:sc.ed;district.court
  - southcarolinawd / us:c4:sc.wd;district.court