### PR TITLE
Remove extra neutral citation formats

### DIFF
--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -14668,7 +14668,7 @@
             ],
             "name": "Pennsylvania State Reports, Watts & Sergeant",
             "variations": {
-                "W.& S.": "Watts & Serg.",
+                "W. & S.": "Watts & Serg.",
                 "Watts & S.": "Watts & Serg."
             }
         }

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -9921,32 +9921,6 @@
             }
         }
     ],
-    "OH": [
-        {
-            "cite_format": "{volume}-{reporter}-{page}",
-            "cite_type": "neutral",
-            "editions": {
-                "OH": {
-                    "end": null,
-                    "start": "1750-01-01T00:00:00"
-                }
-            },
-            "examples": [
-                "2017-Ohio-5699"
-            ],
-            "mlz_jurisdiction": [
-                "us:oh;supreme.court"
-            ],
-            "name": "Ohio Neutral Citation",
-            "regexes": [
-                "(?P<volume>[12]\\d{3})-(?P<reporter>Ohio)-(?P<page>\\d{1,5})"
-            ],
-            "variations": {
-                "OHIO": "OH",
-                "Ohio": "OH"
-            }
-        }
-    ],
     "OK": [
         {
             "cite_type": "neutral",
@@ -10057,6 +10031,29 @@
             ],
             "name": "Ohio Reports",
             "variations": {}
+        },
+        {
+            "cite_format": "{volume}-{reporter}-{page}",
+            "cite_type": "neutral",
+            "editions": {
+                "Ohio": {
+                    "end": null,
+                    "start": "2002-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "2017-Ohio-5699"
+            ],
+            "mlz_jurisdiction": [
+                "us:oh;supreme.court"
+            ],
+            "name": "Ohio Neutral Citation",
+            "regexes": [
+                "(?P<volume>[12]\\d{3})-(?P<reporter>Ohio)-(?P<page>\\d{1,5})"
+            ],
+            "variations": {
+                "OHIO": "Ohio"
+            }
         }
     ],
     "Ohio App.": [

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -9531,22 +9531,6 @@
             "variations": {}
         }
     ],
-    "NM": [
-        {
-            "cite_type": "neutral",
-            "editions": {
-                "NM": {
-                    "end": null,
-                    "start": "1852-01-01T00:00:00"
-                }
-            },
-            "mlz_jurisdiction": [
-                "us:nm;supreme.court"
-            ],
-            "name": "New Mexico Neutral Citation",
-            "variations": {}
-        }
-    ],
     "NMCA": [
         {
             "cite_format": "{volume}-{reporter}-{page}",


### PR DESCRIPTION
Following up on the questions in #26, this fixes a few things:

* The neutral cite format for NM appears to be only "NMCA", "NMSC", etc., not "NM". Remove "NM".
* The neutral cite format for Ohio appears to only be "Ohio", not "OH". Fixing this involves moving the Ohio definition to a different top-level key, which I hope I did correctly.
* The Watts & Serg. variation "W. & S." is missing a space.

I checked that these three changes are consistent with CAP data -- we didn't extract any cites before that would be lost by these changes. If the formats are used elsewhere of course I'm fine with leaving them in.

Ongoing questions:

* I'm not sure why "NM" and "OH" were there in the first place -- is it possible there's some other source that does use those formats? I only checked citation formats in our published caselaw.
* CAP doesn't have any citations matching the variation "OHIO". That was [added quite recently](https://github.com/freelawproject/reporters-db/commit/734049bc8a7ea74bcafb0fafbb4810261281b6df) so I kept it.