### PR TITLE
Add format_json script

### DIFF
--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -13051,6 +13051,28 @@
             }
         }
     ],
+    "T.C.M. (RIA)": [
+        {
+            "cite_format": "{reporter} {page}",
+            "cite_type": "specialty",
+            "editions": {
+                "T.C.M. (RIA)": {
+                    "end": null,
+                    "start": "1924-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [
+                "us:c;tax.court"
+            ],
+            "name": "RIA Federal Tax Handbook",
+            "regexes": [
+                "(?P<reporter>(T\\.C\\.M?\\.? \\(RIA\\))|RIA TM) (?P<page>[0-9]{1,})"
+            ],
+            "variations": {
+                "RIA TM": "T.C.M. (RIA)"
+            }
+        }
+    ],
     "TN WC": [
         {
             "cite_type": "neutral",
@@ -13220,28 +13242,6 @@
                 "N.C.T.Rep.": "Taylor",
                 "N.C.Term.R.": "Taylor",
                 "N.C.Term.Rep.": "Taylor"
-            }
-        }
-    ],
-    "T.C.M. (RIA)": [
-        {
-            "cite_format": "{reporter} {page}",
-            "cite_type": "specialty",
-            "editions": {
-                "T.C.M. (RIA)": {
-                    "end": null,
-                    "start": "1924-01-01T00:00:00"
-                }
-            },
-            "mlz_jurisdiction": [
-                "us:c;tax.court"
-            ],
-            "name": "RIA Federal Tax Handbook",
-            "regexes": [
-                "(?P<reporter>(T\\.C\\.M?\\.? \\(RIA\\))|RIA TM) (?P<page>[0-9]{1,})"
-            ],
-            "variations": {
-                "RIA TM": "T.C.M. (RIA)"
             }
         }
     ],

--- a/reporters_db/format_json.py
+++ b/reporters_db/format_json.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+import sys
+
+
+json_path = Path(__file__).parent / "data" / "reporters.json"
+
+
+def get_json():
+    current_json = Path(json_path).read_text()
+    formatted_json = json.dumps(
+        json.loads(current_json),
+        indent=4,
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    formatted_json += "\n"
+    return current_json, formatted_json
+
+
+def check_json():
+    current_json, formatted_json = get_json()
+    return current_json == formatted_json
+
+
+def update_json():
+    current_json, formatted_json = get_json()
+    if current_json != formatted_json:
+        json_path.write_text(formatted_json)
+        return True
+    return False
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "--check":
+        if not check_json():
+            sys.exit("JSON file doesn't match. Run without --check to update.")
+    else:
+        updated = update_json()
+        print("JSON file updated." if updated else "No changes needed.")


### PR DESCRIPTION
Per discussion in #28, here's a quick script to alphabetize reporters.json as well as correct other formatting issues like indentation. The basic idea is to pass it through `json.dumps(json.loads(), sort_keys=True)` to standardize everything. This is Python3 only which I figured was OK for a dev tool.

This PR includes the result of running the script, which is just to reorder the `"T.C.M. (RIA)"` key.

Usage:

* `python reporters_db/format_json.py` to update the file. This would make sense to run before sending a PR.
* `python reporters_db/format_json.py --check` will return exit code 0 if no changes are needed, exit code 1 if changes are needed, and a python exception if the file doesn't parse. This would make sense to run on pull requests and require success.