### PR TITLE
Add test to check json is sorted and otherwise normally formatted

### DIFF
--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -13051,6 +13051,28 @@
             }
         }
     ],
+    "T.C.M. (RIA)": [
+        {
+            "cite_format": "{reporter} {page}",
+            "cite_type": "specialty",
+            "editions": {
+                "T.C.M. (RIA)": {
+                    "end": null,
+                    "start": "1924-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [
+                "us:c;tax.court"
+            ],
+            "name": "RIA Federal Tax Handbook",
+            "regexes": [
+                "(?P<reporter>(T\\.C\\.M?\\.? \\(RIA\\))|RIA TM) (?P<page>[0-9]{1,})"
+            ],
+            "variations": {
+                "RIA TM": "T.C.M. (RIA)"
+            }
+        }
+    ],
     "TN WC": [
         {
             "cite_type": "neutral",
@@ -13220,28 +13242,6 @@
                 "N.C.T.Rep.": "Taylor",
                 "N.C.Term.R.": "Taylor",
                 "N.C.Term.Rep.": "Taylor"
-            }
-        }
-    ],
-    "T.C.M. (RIA)": [
-        {
-            "cite_format": "{reporter} {page}",
-            "cite_type": "specialty",
-            "editions": {
-                "T.C.M. (RIA)": {
-                    "end": null,
-                    "start": "1924-01-01T00:00:00"
-                }
-            },
-            "mlz_jurisdiction": [
-                "us:c;tax.court"
-            ],
-            "name": "RIA Federal Tax Handbook",
-            "regexes": [
-                "(?P<reporter>(T\\.C\\.M?\\.? \\(RIA\\))|RIA TM) (?P<page>[0-9]{1,})"
-            ],
-            "variations": {
-                "RIA TM": "T.C.M. (RIA)"
             }
         }
     ],


### PR DESCRIPTION
Per the suggestion in #29, here's a json formatting check as a test. The one little oddity is you can call it as `FIX_JSON=1 python tests.py` to get formatting automatically applied. That's clunky but less clunky than having to read the diff and apply alphabetizing by hand.