### PR TITLE
Add new patterns field

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,10 +127,6 @@ Database:
    last opinions in a reporter series have the same dates as the
    database.
 
-7. Some reporters have atypical formatting ``cite_format`` uses
-   standard python formatting to indicate when a citation follows a
-   unique style. This appears most common in tax law.
-
 
 A complete data point has fields like so:
 
@@ -138,20 +134,20 @@ A complete data point has fields like so:
 
     "$citation": [
         {
-            "cite_format": "",
             "cite_type": "state|federal|neutral|specialty|specialty_west|specialty_lexis|state_regional|scotus_early",
             "editions": {
                 "$citation": {
                     "end": null,
+                    "regexes": [],
                     "start": "1750-01-01T00:00:00"
                 },
                 "$citation 2d": {
                     "end": null,
+                    "regexes": [],
                     "start": "1750-01-01T00:00:00"
                 }
             },
             "examples": [],
-            "regexes": [],
             "mlz_jurisdiction": [],
             "name": "",
             "variations": {},
@@ -161,9 +157,23 @@ A complete data point has fields like so:
         }
     ],
 
-Most of those fields should make sense either from their name or by looking at
-a few examples in the data, however, a notes on the ``state_abbreviations`` and
-``case_name_abbreviations`` files:
+The "regexes" field and regexes.json placeholders
+-------------------------------------------------
+
+The "regexes" field can contain raw regular expressions to match a custom citation format,
+or can contain placeholders to be substituted from ``regexes.json`` using
+`python Template formatting <https://docs.python.org/3/library/string.html#template-strings>`__.
+
+If custom regexes are provided, the tests will require that all regexes match at least one
+example in ``examples`` and that all examples match at least one regex.
+
+When adding a new regex it can be useful to ``pip install exrex`` and run the tests *without*
+adding any examples to get a listing of potential citations that would be matched by the new
+regex.
+
+
+``state_abbreviations`` and ``case_name_abbreviations`` files
+-------------------------------------------------------------
 
 1. Abbreviations are based on data from the values in the nineteenth
    edition of the Blue Book supplemented with abbreviations found in our

--- a/reporters_db/__init__.py
+++ b/reporters_db/__init__.py
@@ -35,9 +35,9 @@ with open(os.path.join(db_root, "data", "case_name_abbreviations.json")) as f:
     CASE_NAME_ABBREVIATIONS = json.load(f)
 
 
-with open(os.path.join(db_root, "data", "variables.json")) as f:
-    RAW_VARIABLES = json.load(f)
-    VARIABLES = process_variables(RAW_VARIABLES)
+with open(os.path.join(db_root, "data", "regexes.json")) as f:
+    RAW_REGEX_VARIABLES = json.load(f)
+    REGEX_VARIABLES = process_variables(RAW_REGEX_VARIABLES)
 
 
 VARIATIONS_ONLY = suck_out_variations_only(REPORTERS)

--- a/reporters_db/__init__.py
+++ b/reporters_db/__init__.py
@@ -36,7 +36,8 @@ with open(os.path.join(db_root, "data", "case_name_abbreviations.json")) as f:
 
 
 with open(os.path.join(db_root, "data", "variables.json")) as f:
-    VARIABLES = process_variables(json.load(f))
+    RAW_VARIABLES = json.load(f)
+    VARIABLES = process_variables(RAW_VARIABLES)
 
 
 VARIATIONS_ONLY = suck_out_variations_only(REPORTERS)

--- a/reporters_db/__init__.py
+++ b/reporters_db/__init__.py
@@ -7,6 +7,7 @@ from .utils import (
     names_to_abbreviations,
     suck_out_variations_only,
     suck_out_formats,
+    process_variables,
 )
 
 
@@ -32,6 +33,10 @@ with open(os.path.join(db_root, "data", "state_abbreviations.json")) as f:
 
 with open(os.path.join(db_root, "data", "case_name_abbreviations.json")) as f:
     CASE_NAME_ABBREVIATIONS = json.load(f)
+
+
+with open(os.path.join(db_root, "data", "variables.json")) as f:
+    VARIABLES = process_variables(json.load(f))
 
 
 VARIATIONS_ONLY = suck_out_variations_only(REPORTERS)

--- a/reporters_db/data/regexes.json
+++ b/reporters_db/data/regexes.json
@@ -35,7 +35,7 @@
         "with_periods": "(?P<page>\\d(?:[\\d.]*\\d)?)",
         "with_periods#": "Page number that allows internal periods, like '1234.56'"
     },
-    "paragraph_marker": "(?:P|¶|para?\\.) ?",
+    "paragraph_marker": "(?:P|¶|para?\\.)",
     "reporter": {
         "": "(?P<reporter>$edition)",
         "#": "Standard reporter"

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -1401,15 +1401,22 @@
             "editions": {
                 "Bankr. L. Rep.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite_paragraph"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "Bankr. L. Rep. P12,345",
+                "Bankr. L. Rep. P 80679",
+                "Bankr. L. Rep. (CCH) ¶ 67,488",
+                "Bankr. L. Rep. (C.C.H.) ¶67,049"
+            ],
             "mlz_jurisdiction": [],
             "name": "Bankruptcy Law Reporter",
-            "regexes": [
-                "(?P<reporter>Bankr\\. L\\. Rep\\. \\(CCH\\)) (?P<page>P((\\d){1,3})+([,]?[\\d]{3}))"
-            ],
             "variations": {
+                "Bankr. L. Rep. (C.C.H.)": "Bankr. L. Rep.",
                 "Bankr. L. Rep. (CCH)": "Bankr. L. Rep."
             }
         }
@@ -3260,6 +3267,9 @@
             "editions": {
                 "Cont. Cas. Fed.": {
                     "end": null,
+                    "regexes": [
+                        "$volume $reporter $paragraph_marker_optional$page_with_commas"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
@@ -3268,9 +3278,6 @@
             ],
             "mlz_jurisdiction": [],
             "name": "Contract Cases, Federal",
-            "regexes": [
-                "(?P<volume>\\d{1,4}(-\\d{1,})?) (?P<reporter>Cont. Cas. Fed. \\(CCH\\)) (?P<page>P((\\d){1,3})+([,]?[\\d]{3}))"
-            ],
             "variations": {
                 "Cont. Cas. Fed. (CCH)": "Cont. Cas. Fed.",
                 "Cont.Cas.Fed. (CCH)": "Cont. Cas. Fed."
@@ -4251,16 +4258,23 @@
             "editions": {
                 "Empl. Prac. Dec. (CCH)": {
                     "end": null,
+                    "regexes": [
+                        "$volume $reporter $paragraph_marker_optional$page_with_commas"
+                    ],
                     "start": "1971-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "42 Empl. Prac. Dec. (CCH) par. 36,973",
+                "65 Empl. Prac. Dec. (CCH) P 43,243",
+                "23 Empl. Prac. Dec. (CCH) ¶30986",
+                "53 Empl Prac Dec [CCH] ¶ 39,911"
+            ],
             "mlz_jurisdiction": [],
             "name": "Employment Practices Decisions",
             "publisher": "Commerce Clearing House",
-            "regexes": [
-                "(?P<volume>\\d{1,4}) (?P<reporter>Empl\\. Prac\\. Dec\\. \\(CCH\\)) (?P<page>P((\\d){1,3})+([,]?[\\d]{3}))"
-            ],
             "variations": {
+                "Empl Prac Dec [CCH]": "Empl. Prac. Dec. (CCH)",
                 "Empl. Prac. Dec.": "Empl. Prac. Dec. (CCH)",
                 "Empl. Prac.Dec.": "Empl. Prac. Dec. (CCH)"
             }
@@ -4667,6 +4681,9 @@
             "editions": {
                 "FED App.": {
                     "end": null,
+                    "regexes": [
+                        "$volume_year $reporter (?P<page>\\d{4}[nNpP]) \\(6th Cir\\.?\\)"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
@@ -4688,9 +4705,6 @@
             ],
             "name": "United States (US) Court of Appeals for the Sixth Circuit",
             "notes": "This is the only circuit known to us that uses this format.",
-            "regexes": [
-                "(?P<volume>\\d{4})\\s+(?P<reporter>FED App\\.)\\s+(?P<page>\\d{4}(N|P|n|p))\\s+\\(6th Cir\\.?\\)"
-            ],
             "variations": {}
         }
     ],
@@ -4996,15 +5010,21 @@
             "editions": {
                 "Fed. Sec. L. Rep. (CCH)": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite_paragraph_with_suffix"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "Fed. Sec. L. Rep. (CCH) par. 78,056",
+                "Fed. Sec. L. Rep. (CCH) ¶ 77,526",
+                "Fed Sec L Rep (CCH) ¶ 80,715"
+            ],
             "mlz_jurisdiction": [],
             "name": "Federal Securities Law Reporter (CCH)",
-            "regexes": [
-                "(?P<reporter>Fed\\. Sec\\. L\\. Rep\\. \\(CCH\\)) (?P<page>P((\\d){1,3})+([,]?[\\d]{3})([A-Z])?)"
-            ],
             "variations": {
+                "Fed Sec L Rep (CCH)": "Fed. Sec. L. Rep. (CCH)",
                 "Fed. Sec. L. Rep.": "Fed. Sec. L. Rep. (CCH)"
             }
         }
@@ -7386,20 +7406,20 @@
             "editions": {
                 "La.App. 1 Cir.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite_louisiana"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
             "examples": [
-                "2009 1359R (La.App. 1 Cir. 05/10/10);"
+                "2009 1359R (La.App. 1 Cir. 05/10/10)"
             ],
             "mlz_jurisdiction": [
                 "us:la;supreme.court"
             ],
             "name": "Court of Appeal of Louisiana, First Circuit",
             "notes": "Occasionally the citation can have a letter at the end of the second string of numbers.",
-            "regexes": [
-                "(?P<volume>\\d{2,4})( |-)(?P<page>\\d{2,5}) (?P<reporter>\\(La.App. 1 Cir.) (?P<date_filed>\\d{1,2}\\/\\d{1,2}\\/\\d{2,4})\\)"
-            ],
             "variations": {}
         }
     ],
@@ -7409,16 +7429,19 @@
             "editions": {
                 "La.App. 2 Cir.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite_louisiana"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "2009 1359R (La.App. 2 Cir. 05/10/10)"
+            ],
             "mlz_jurisdiction": [
                 "us:la;supreme.court"
             ],
             "name": "Court of Appeal of Louisiana, Second Circuit",
-            "regexes": [
-                "(?P<volume>\\d{2,4})( |-)(?P<page>\\d{2,5}) (?P<reporter>\\(La.App. 2 Cir.) (?P<date_filed>\\d{1,2}\\/\\d{1,2}\\/\\d{2,4})\\)"
-            ],
             "variations": {}
         }
     ],
@@ -7428,16 +7451,19 @@
             "editions": {
                 "La.App. 3 Cir.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite_louisiana"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "2009 1359R (La.App. 3 Cir. 05/10/10)"
+            ],
             "mlz_jurisdiction": [
                 "us:la;supreme.court"
             ],
             "name": "Court of Appeal of Louisiana, Third Circuit",
-            "regexes": [
-                "(?P<volume>\\d{2,4})( |-)(?P<page>\\d{2,5}) (?P<reporter>\\(La.App. 3 Cir.) (?P<date_filed>\\d{1,2}\\/\\d{1,2}\\/\\d{2,4})\\)"
-            ],
             "variations": {}
         }
     ],
@@ -7447,16 +7473,19 @@
             "editions": {
                 "La.App. 4 Cir.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite_louisiana"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "2009 1359R (La.App. 4 Cir. 05/10/10)"
+            ],
             "mlz_jurisdiction": [
                 "us:la;supreme.court"
             ],
             "name": "Court of Appeal of Louisiana, Fourth Circuit",
-            "regexes": [
-                "(?P<volume>\\d{2,4})( |-)(?P<page>\\d{2,5}) (?P<reporter>\\(La.App. 4 Cir.) (?P<date_filed>\\d{1,2}\\/\\d{1,2}\\/\\d{2,4})\\)"
-            ],
             "variations": {}
         }
     ],
@@ -7466,16 +7495,19 @@
             "editions": {
                 "La.App. 5 Cir.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite_louisiana"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "2009 1359R (La.App. 5 Cir. 05/10/10)"
+            ],
             "mlz_jurisdiction": [
                 "us:la;supreme.court"
             ],
             "name": "Court of Appeal of Louisiana, Fifth Circuit",
-            "regexes": [
-                "(?P<volume>\\d{2,4})( |-)(?P<page>\\d{2,5}) (?P<reporter>\\(La.App. 5 Cir.) (?P<date_filed>\\d{1,2}\\/\\d{1,2}\\/\\d{2,4})\\)"
-            ],
             "variations": {}
         }
     ],
@@ -7485,16 +7517,19 @@
             "editions": {
                 "La.App. 6 Cir.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite_louisiana"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "2009 1359R (La.App. 6 Cir. 05/10/10)"
+            ],
             "mlz_jurisdiction": [
                 "us:la;supreme.court"
             ],
             "name": "Court of Appeal of Louisiana, Sixth Circuit",
-            "regexes": [
-                "(?P<volume>\\d{2,4})( |-)(?P<page>\\d{2,5}) (?P<reporter>\\(La.App. 6 Cir.) (?P<date_filed>\\d{1,2}\\/\\d{1,2}\\/\\d{2,4})\\)"
-            ],
             "variations": {}
         }
     ],
@@ -9895,6 +9930,9 @@
             "editions": {
                 "NMCA": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite_format_neutral_3_4"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
@@ -9905,9 +9943,6 @@
                 "us:nm;court.appeals"
             ],
             "name": "New Mexico Neutral Citation (Court of Appeals)",
-            "regexes": [
-                "(?P<volume>[12]\\d{3})-(?P<reporter>NMCA)-(?P<page>\\d{3,4})"
-            ],
             "variations": {}
         }
     ],
@@ -9918,6 +9953,9 @@
             "editions": {
                 "NMCERT": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite_format_neutral_3_4"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
@@ -9928,9 +9966,6 @@
                 "us:nm;supreme.court"
             ],
             "name": "New Mexico Neutral Citation",
-            "regexes": [
-                "(?P<volume>[12]\\d{3})-(?P<reporter>NMCERT)-(?P<page>\\d{3,4})"
-            ],
             "variations": {}
         }
     ],
@@ -9941,6 +9976,9 @@
             "editions": {
                 "NMSC": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite_format_neutral_3_4"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
@@ -9951,9 +9989,6 @@
                 "us:nm;supreme.court"
             ],
             "name": "New Mexico Neutral Citation (Supreme Court)",
-            "regexes": [
-                "(?P<volume>[12]\\d{3})-(?P<reporter>NMSC)-(?P<page>\\d{3,4})"
-            ],
             "variations": {}
         }
     ],
@@ -10397,6 +10432,9 @@
             "editions": {
                 "Ohio": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite_format_neutral"
+                    ],
                     "start": "2002-01-01T00:00:00"
                 }
             },
@@ -10407,9 +10445,6 @@
                 "us:oh;supreme.court"
             ],
             "name": "Ohio Neutral Citation",
-            "regexes": [
-                "(?P<volume>[12]\\d{3})-(?P<reporter>Ohio)-(?P<page>\\d{1,5})"
-            ],
             "variations": {
                 "OHIO": "Ohio"
             }
@@ -12815,16 +12850,18 @@
     ],
     "Smith (N. H.)": [
         {
-            "cite_format": "{reporter} {page}",
             "cite_type": "state",
             "editions": {
                 "Smith (N. H.)": {
                     "end": "1815-12-31T00:00:00",
+                    "regexes": [
+                        "$full_cite_single_volume"
+                    ],
                     "start": "1796-01-01T00:00:00"
                 }
             },
             "examples": [
-                "Twombly v. Baker, Smith (N. H.) 123"
+                "Smith (N. H.) 123"
             ],
             "mlz_jurisdiction": [
                 "us:nh;supreme.court",
@@ -13260,11 +13297,13 @@
     ],
     "T.C. Memo.": [
         {
-            "cite_format": "{reporter} {volume}-{page}",
             "cite_type": "neutral",
             "editions": {
                 "T.C. Memo.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite_year_page"
+                    ],
                     "start": "1942-01-01T00:00:00"
                 }
             },
@@ -13276,9 +13315,6 @@
             ],
             "name": "Tax Court Memorandum Opinions",
             "notes": "These documents are non precedential, but known to be persuasive. Atypical format atypical format -> T.C. Memo YYYY-XX",
-            "regexes": [
-                "(?P<reporter>T\\.\\s?C\\.\\s?Memo\\.?)\\s+(?P<volume>\\d{4})-(?P<page>\\d{1,4})"
-            ],
             "variations": {
                 "T. C. Memo.": "T.C. Memo.",
                 "T.C. Memo": "T.C. Memo."
@@ -13306,22 +13342,24 @@
     ],
     "T.C. Summary Opinion": [
         {
-            "cite_format": "{reporter} {volume}-{page}",
             "cite_type": "neutral",
             "editions": {
                 "T.C. Summary Opinion": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite_year_page"
+                    ],
                     "start": "1942-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "T.C. Summary Opinion 2002-43"
+            ],
             "mlz_jurisdiction": [
                 "us:c;tax.court"
             ],
             "name": "Tax Court Summary Opinions",
             "notes": "Neutral Citation for summary opinions of the Tax Court. These opinions are atypical format -> T.C. Summary Opinion YYYY-XX",
-            "regexes": [
-                "(?P<reporter>T\\.\\s?C\\.\\s?Summary Opinion)\\s+(?P<volume>\\d{4})-(?P<page>\\d{1,4})"
-            ],
             "variations": {
                 "T. C. Summary Opinion": "T.C. Summary Opinion"
             }
@@ -13365,21 +13403,26 @@
     ],
     "T.C.M. (RIA)": [
         {
-            "cite_format": "{reporter} {page}",
             "cite_type": "specialty",
             "editions": {
                 "T.C.M. (RIA)": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite_year_page",
+                        "$full_cite_paragraph"
+                    ],
                     "start": "1924-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "T.C.M. (RIA) ¶ 95,342",
+                "T.C.M. (RIA) 92736",
+                "T.C.M. (RIA) 2004-279"
+            ],
             "mlz_jurisdiction": [
                 "us:c;tax.court"
             ],
             "name": "RIA Federal Tax Handbook",
-            "regexes": [
-                "(?P<reporter>(T\\.C\\.M?\\.? \\(RIA\\))|RIA TM) (?P<page>[0-9]{1,})"
-            ],
             "variations": {
                 "RIA TM": "T.C.M. (RIA)"
             }
@@ -13874,15 +13917,21 @@
             "editions": {
                 "Trade Cas. (CCH)": {
                     "end": null,
+                    "regexes": [
+                        "$volume_with_digit_suffix $reporter $paragraph_marker_optional$page_with_commas"
+                    ],
                     "start": "1914-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "1982-1 Trade Cas. (CCH) par. 64,689",
+                "1940-1943 Trade Cas. (CCH) ¶ 56,104",
+                "1975 Trade Cas. (CCH) ¶ 60,219",
+                "1974-2 Trade Cas. (CCH) ¶ 75,282"
+            ],
             "href": "http://w3.nexis.com/sources/scripts/info.pl?168025",
             "mlz_jurisdiction": [],
             "name": "Trade Cases",
-            "regexes": [
-                "(?P<volume>\\d{1,4}(-\\d{1,})?) (?P<reporter>Trade Cas. \\(CCH\\)) (?P<page>P((\\d){1,3})+([,]?[\\d]{3}))"
-            ],
             "variations": {
                 "Trade Cas.": "Trade Cas. (CCH)",
                 "Trade Cases": "Trade Cas. (CCH)"
@@ -14231,6 +14280,9 @@
             "editions": {
                 "U.S. Tax Cas. (CCH)": {
                     "end": null,
+                    "regexes": [
+                        "$volume_with_digit_suffix $reporter $paragraph_marker_optional$page_with_commas"
+                    ],
                     "start": "1900-01-01T00:00:00"
                 }
             },
@@ -14242,9 +14294,6 @@
                 "us:c;tax.court"
             ],
             "name": "United States (US) Tax Cases (CCH)",
-            "regexes": [
-                "(?P<volume>\\d{1,4}(-\\d{1,})?) (?P<reporter>U\\.S\\. Tax Cas\\. \\(CCH\\)) (?P<page>P((\\d){1,3})+([,]?[\\d]{3}))"
-            ],
             "variations": {}
         }
     ],
@@ -14264,7 +14313,6 @@
                 "us:c;tax.court"
             ],
             "name": "United States (US) Tax Cases Lexis",
-            "regexes": [],
             "variations": {}
         }
     ],
@@ -14366,20 +14414,28 @@
     ],
     "Unemployment Ins. Rep.": [
         {
-            "cite_format": "{reporter} {page}",
             "cite_type": "specialty",
             "editions": {
                 "Unemployment Ins. Rep.": {
                     "end": null,
+                    "regexes": [
+                        "$volume_with_alpha_suffix_optional$reporter,? (?P<jurisdiction>\\(?[A-Z][a-zA-Z .]+\\)? )?$paragraph_marker_optional$page_with_commas_or_periods"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "CCH Unemployment Ins. Rep. ¶ 15,419",
+                "1 CCH Unemployment Ins. Rep. para. 14,387",
+                "8 CCH, Unemployment Ins. Rep. W. Va. par. 8090",
+                "1A CCH, Unemployment Ins. Rep. (Ala.) par. 1950.74",
+                "4 CCH Unemployment Ins. Rep., Me. ¶ 1995.05"
+            ],
             "mlz_jurisdiction": [],
             "name": "Unemployment Insurance Reports (CCH)",
-            "regexes": [
-                "(?P<reporter>Unemployment Ins\\. Rep\\. \\(CCH\\)) (?P<page>P((\\d){1,3})+([,]?[\\d]{3})([A-Z])?)"
-            ],
             "variations": {
+                "CCH Unemployment Ins. Rep.": "Unemployment Ins. Rep.",
+                "CCH, Unemployment Ins. Rep.": "Unemployment Ins. Rep.",
                 "Unempl. Ins. Rep. (CCH)": "Unemployment Ins. Rep.",
                 "Unemployment Ins. Rep. (CCH)": "Unemployment Ins. Rep."
             }

--- a/reporters_db/data/variables.json
+++ b/reporters_db/data/variables.json
@@ -1,0 +1,53 @@
+{
+    "full_cite": {
+        "": "$volume $reporter $page",
+        "#": "Standard citation",
+        "format_neutral": {
+            "": "$volume_year-$reporter-$page",
+            "#": "Format neutral cite, like '2000-Ohio-123'",
+            "3_4": "$volume_year-$reporter-$page_3_4",
+            "3_4#": "Format neutral cite where the page must be 3 or 4 digits, like '2000-NMSC-123'"
+        },
+        "louisiana": {
+            "": "(?P<volume>\\d{2,4})[- ](?P<page>\\d{2,5}[A-Z]?) \\($reporter (?P<date_filed>\\d{1,2}\\/\\d{1,2}\\/\\d{2,4})\\)",
+            "#": "Format neutral Louisiana cite, like '2009 1359R (La.App. 1 Cir. 05/10/10)'"
+        },
+        "paragraph": {
+            "": "$reporter $paragraph_marker_optional$page_with_commas",
+            "#": "Citation to a paragraph instead of a volume, like 'Bankr. L. Rep. ¶12,345'",
+            "with_suffix": "$reporter $paragraph_marker_optional$page_with_commas_and_suffix",
+            "with_suffix#": "Paragraph cite with optional alpha character appended"
+        },
+        "single_volume": "$reporter $page",
+        "year_page": "$reporter $volume_year-$page"
+    },
+    "page": {
+        "": "(?P<page>\\d+)",
+        "#": "Standard page number",
+        "3_4": "(?P<page>\\d{3,4})",
+        "3_4#": "Page number that must be 3 or 4 digits long",
+        "with_commas": "(?P<page>\\d(?:[\\d,]*\\d)?)",
+        "with_commas#": "Page number that allows internal commas, like '12,345,678'. Doesn't enforce 3-digit groups.",
+        "with_commas_and_suffix": "(?P<page>\\d(?:[\\d,]*\\d)?[A-Z]?)",
+        "with_commas_and_suffix#": "Page number that allows internal commas, plus optional alpha character appended",
+        "with_commas_or_periods": "(?P<page>\\d(?:[\\d,.]*\\d)?)",
+        "with_commas_or_periods#": "Page number that allows internal punctuation",
+        "with_periods": "(?P<page>\\d(?:[\\d.]*\\d)?)",
+        "with_periods#": "Page number that allows internal periods, like '1234.56'"
+    },
+    "paragraph_marker": "(?:P|¶|para?\\.) ?",
+    "reporter": {
+        "": "(?P<reporter>$edition)",
+        "#": "Standard reporter"
+    },
+    "volume": {
+        "": "(?P<volume>\\d+)",
+        "#": "Standard volume number",
+        "with_alpha_suffix": "(?P<volume>\\d{1,4}A?)",
+        "with_alpha_suffix#": "Volume number that may have 'A' appended, like '1A'",
+        "with_digit_suffix": "(?P<volume>\\d{1,4}(?:-\\d+)?)",
+        "with_digit_suffix#": "Volume number that may have digits appended, like '123-4'",
+        "year": "(?P<volume>19\\d{2}|20\\d{2})",
+        "year#": "Volume number that must be a year between 1900 and 2099"
+    }
+}

--- a/tests.py
+++ b/tests.py
@@ -47,18 +47,27 @@ def emit_strings(obj):
         yield obj
 
 
+def iter_reporters():
+    for reporter_abbv, reporter_list in REPORTERS.items():
+        for reporter_data in reporter_list:
+            yield reporter_abbv, reporter_list, reporter_data
+
+
+def iter_editions():
+    for reporter_abbv, reporter_list, reporter_data in iter_reporters():
+        for edition_abbv, edition in reporter_data["editions"].items():
+            yield edition_abbv, edition
+
+
 class ConstantsTest(TestCase):
     def test_any_keys_missing_editions(self):
         """Have we added any new reporters that lack a matching edition?"""
-        for r_name, r_items in REPORTERS.items():
-            # For each reporter
-            for item in r_items:
-                # and each book in each reporter
-                self.assertIn(
-                    r_name,
-                    item["editions"],
-                    msg="Could not find edition for key: %s" % r_name,
-                )
+        for reporter_abbv, reporter_list, reporter_data in iter_reporters():
+            self.assertIn(
+                reporter_abbv,
+                reporter_data["editions"],
+                msg="Could not find edition for key: %s" % reporter_abbv,
+            )
 
     def test_for_variations_mapping_to_bad_keys(self):
         """Do we have a variation that maps to a key that doesn't exist in the
@@ -88,54 +97,44 @@ class ConstantsTest(TestCase):
 
     def test_that_all_dates_are_converted_to_dates_not_strings(self):
         """Do we properly make the ISO-8601 date strings into Python dates?"""
-        for reporter_name, reporter_list in six.iteritems(REPORTERS):
-            # reporter_name == "A."
-            # reporter_list == [
-            # {'name': 'Atlantic Reporter', 'editions': ...},
-            # {'name': 'Aldo's Reporter', 'editions': ...}
-            # ]
-            for reporter_dict in reporter_list:
-                # reporter_dict == {'name': 'Atlantic Reporter'}
-                for e_name, e_dates in six.iteritems(
-                    reporter_dict["editions"]
-                ):
-                    # e_name == "A. 2d"
-                    # e_dates == {
-                    #     "end": "1938-12-31T00:00:00",
-                    #     "start": "1885-01-01T00:00:00"
-                    # }
-                    for key in ["start", "end"]:
-                        is_date_or_none = (
-                            isinstance(e_dates[key], datetime.datetime)
-                            or e_dates[key] is None
-                        )
-                        self.assertTrue(
-                            is_date_or_none,
-                            msg=(
-                                "%s dates in the reporter '%s' appear to be "
-                                "coming through as '%s'"
-                                % (key, e_name, type(e_dates[key]))
-                            ),
-                        )
-                        if key == "start":
-                            start_is_not_none = e_dates[key] is not None
-                            self.assertTrue(
-                                start_is_not_none,
-                                msg=(
-                                    "Start date in reporter '%s' appears to "
-                                    "be None, not 1750" % e_name
-                                ),
-                            )
+        # for reporter_abbv, reporter_list, reporter_data in iter_reporters():
+        for e_name, e_dates in iter_editions():
+            # e_name == "A. 2d"
+            # e_dates == {
+            #     "end": "1938-12-31T00:00:00",
+            #     "start": "1885-01-01T00:00:00"
+            # }
+            for key in ["start", "end"]:
+                is_date_or_none = (
+                    isinstance(e_dates[key], datetime.datetime)
+                    or e_dates[key] is None
+                )
+                self.assertTrue(
+                    is_date_or_none,
+                    msg=(
+                        "%s dates in the reporter '%s' appear to be "
+                        "coming through as '%s'"
+                        % (key, e_name, type(e_dates[key]))
+                    ),
+                )
+                if key == "start":
+                    start_is_not_none = e_dates[key] is not None
+                    self.assertTrue(
+                        start_is_not_none,
+                        msg=(
+                            "Start date in reporter '%s' appears to "
+                            "be None, not 1750" % e_name
+                        ),
+                    )
 
     def test_all_reporters_have_valid_cite_type(self):
         """Do all reporters have valid cite_type values?"""
-        for reporter_abbv, reporter_list in REPORTERS.items():
-            for reporter_data in reporter_list:
-                self.assertIn(
-                    reporter_data["cite_type"],
-                    VALID_CITE_TYPES,
-                    "%s did not have a valid cite_type value" % reporter_abbv,
-                )
+        for reporter_abbv, reporter_list, reporter_data in iter_reporters():
+            self.assertIn(
+                reporter_data["cite_type"],
+                VALID_CITE_TYPES,
+                "%s did not have a valid cite_type value" % reporter_abbv,
+            )
 
     def test_all_required_keys_no_extra_keys(self):
         """Are all required keys present? Are there any keys present that
@@ -157,36 +156,35 @@ class ConstantsTest(TestCase):
             "examples",
         ]
         all_fields = required_fields + optional_fields
-        for reporter_abbv, reporter_list in REPORTERS.items():
-            for reporter_data in reporter_list:
+        for reporter_abbv, reporter_list, reporter_data in iter_reporters():
 
-                # All required fields present?
-                for required_field in required_fields:
-                    try:
-                        reporter_data[required_field]
-                    except KeyError:
-                        self.fail(
-                            "Reporter '%s' lacks required field '%s'"
-                            % (reporter_abbv, required_field)
-                        )
-
-                # No extra fields?
-                for k in reporter_data.keys():
-                    self.assertIn(
-                        k,
-                        all_fields,
-                        "Reporter '%s' has an unknown field '%s'"
-                        % (reporter_abbv, k),
+            # All required fields present?
+            for required_field in required_fields:
+                try:
+                    reporter_data[required_field]
+                except KeyError:
+                    self.fail(
+                        "Reporter '%s' lacks required field '%s'"
+                        % (reporter_abbv, required_field)
                     )
 
-                # No empty string values?
-                for k, v in reporter_data.items():
-                    if isinstance(v, str):
-                        self.assertTrue(
-                            v != "",
-                            msg="Field '%s' is empty in reporter '%s'"
-                            % (k, reporter_abbv),
-                        )
+            # No extra fields?
+            for k in reporter_data.keys():
+                self.assertIn(
+                    k,
+                    all_fields,
+                    "Reporter '%s' has an unknown field '%s'"
+                    % (reporter_abbv, k),
+                )
+
+            # No empty string values?
+            for k, v in reporter_data.items():
+                if isinstance(v, str):
+                    self.assertTrue(
+                        v != "",
+                        msg="Field '%s' is empty in reporter '%s'"
+                        % (k, reporter_abbv),
+                    )
 
     def test_no_variation_is_same_as_key(self):
         """Are any variations identical to the keys they're supposed to be
@@ -213,16 +211,15 @@ class ConstantsTest(TestCase):
             return re.sub(r"[^ 0-9a-zA-Z.,\-'&()\[\]]", "", s.strip())
 
         msg = "Got bad punctuation in: %s"
-        for reporter_abbv, reporter_list in REPORTERS.items():
+        for reporter_abbv, reporter_list, reporter_data in iter_reporters():
             self.assertEqual(
                 reporter_abbv, cleaner(reporter_abbv), msg=msg % reporter_abbv
             )
-            for reporter_data in reporter_list:
-                for k in reporter_data["editions"].keys():
-                    self.assertEqual(cleaner(k), k, msg=msg % k)
-                for k, v in reporter_data["variations"].items():
-                    self.assertEqual(cleaner(k), k, msg=msg % k)
-                    self.assertEqual(cleaner(v), v, msg=msg % v)
+            for k in reporter_data["editions"].keys():
+                self.assertEqual(cleaner(k), k, msg=msg % k)
+            for k, v in reporter_data["variations"].items():
+                self.assertEqual(cleaner(k), k, msg=msg % k)
+                self.assertEqual(cleaner(v), v, msg=msg % v)
 
         for s in emit_strings(REPORTERS):
             self.assertEqual(
@@ -231,18 +228,14 @@ class ConstantsTest(TestCase):
 
     def test_nothing_ends_before_it_starts(self):
         """Do any editions have end dates before their start dates?"""
-        for reporter_dicts in REPORTERS.values():
-            # Each value is a list of reporter dictionaries
-            for reporter in reporter_dicts:
-                # Each edition is a dict of keys that go to more dicts!
-                for k, edition in reporter["editions"].items():
-                    if edition["start"] and edition["end"]:
-                        self.assertLessEqual(
-                            edition["start"],
-                            edition["end"],
-                            msg="It appears that edition %s ends before it "
-                            "starts." % k,
-                        )
+        for k, edition in iter_editions():
+            if edition["start"] and edition["end"]:
+                self.assertLessEqual(
+                    edition["start"],
+                    edition["end"],
+                    msg="It appears that edition %s ends before it "
+                    "starts." % k,
+                )
 
     def test_json_format(self):
         """Does format of reporters.json match json.dumps(json.loads(), sort_keys=True)? """

--- a/tests.py
+++ b/tests.py
@@ -10,7 +10,7 @@ from reporters_db import (
     VARIATIONS_ONLY,
     EDITIONS,
     NAMES_TO_EDITIONS,
-    VARIABLES,
+    REGEX_VARIABLES,
 )
 from unittest import TestCase
 
@@ -242,7 +242,7 @@ class ConstantsTest(TestCase):
 
     def test_json_format(self):
         """Does format of reporters.json match json.dumps(json.loads(), sort_keys=True)? """
-        for file_name in ("reporters.json", "variables.json"):
+        for file_name in ("reporters.json", "regexes.json"):
             with self.subTest(file_name=file_name):
                 json_path = (
                     Path(__file__).parent / "reporters_db" / "data" / file_name
@@ -288,7 +288,7 @@ class ConstantsTest(TestCase):
                 ):
                     for edition_regex in edition["regexes"]:
                         full_regex = recursive_substitute(
-                            edition_regex, VARIABLES
+                            edition_regex, REGEX_VARIABLES
                         )
                         regexes = substitute_editions(
                             full_regex,
@@ -307,14 +307,14 @@ class ConstantsTest(TestCase):
                             try:
                                 import exrex
 
-                                candidate = (
-                                    'Possible example: "%s"'
-                                    % exrex.getone(regexes[0])
-                                )
+                                candidate = "Possible examples: %s" % [
+                                    exrex.getone(regexes[0], limit=3)
+                                    for _ in range(10)
+                                ]
                             except ImportError:
                                 candidate = "Run 'pip install exrex' to generate a candidate example"
                             self.fail(
-                                "Reporter '%s' has no match in 'examples' for custom regex '%s'. Expanded regexes: %s. %s"
+                                "Reporter '%s' has no match in 'examples' for custom regex '%s'.\nExpanded regexes: %s.\n%s"
                                 % (
                                     reporter_abbv,
                                     edition_regex,


### PR DESCRIPTION
Following up on the discussion [over here](https://github.com/freelawproject/eyecite/pull/31), this adds a proposed new field under each edition called `"patterns"` that specifies regexes mapping to that edition. I'm filing this now for comment before getting too far into implementation.

To simplify the regexes, this follows the example of courts-db by expanding placeholders from variables.json, but with the addition of recursive resolution and some additional special-case expansion for "$edition". Here's the intended expansion of the first entry, for example:

```
"Bankr. L. Rep.": [
        {
            "editions": {
                "Bankr. L. Rep.": {
                    "patterns": [
                        "$paragraph_cite"
                    ],
                }
            },
            "variations": {
                "Bankr. L. Rep. (CCH)": "Bankr. L. Rep."
            }
        }
```

Expansion steps:

* Recursive expansion from variables.json:
  * `"$paragraph_cite"` -> 
  * `"$reporter $paragraph_marker_optional$page_with_commas"` ->
  * `"(?P<reporter>$edition) (?:[P¶] ?)?(?P<page>\d(?:[\d,]*\d)?)"` ->
* Then fanout by replacing `$edition` (if any) with the edition key and variations:
  * `"(?P<reporter>Bankr\. L\. Rep\.) (?:[P¶] ?)?(?P<page>\d(?:[\d,]*\d)?)"`
  * `"(?P<reporter>Bankr\. L\. Rep\. \(CCH\)) (?:[P¶] ?)?(?P<page>\d(?:[\d,]*\d)?)"`

This seems a little complicated when it's all spelled out, but I'm hoping that it makes things both DRY and easy to express -- the underlying reality is that `Bankr. L. Rep.` is cited as a reporter string or variation, sometimes a paragraph marker, and then a paragraph number, as are a number of other reporters, and this hopefully expresses that pretty clearly and with minimal redundancy.

Other comments:

* Naming the things in variables.json is hard and I'm open to improvements!
* I kept both "cite_format" and "regexes" keys in for now in case those are in use elsewhere, though this could potentially replace both.
* I called this "patterns" instead of "regexes" to make clear to anyone transitioning that it's a different thing from those other fields. If that's unhelpful I could switch it back to "regexes" though.
* I didn't yet include any code to do the expansion. Probably some helpers want to live here in reporters-db, but I thought maybe it would be best to add those while integrating with `eyecite`. There'll need to be flexibility to do stuff like patching in a more complicated regex for "$page" so I'm not quite sure what the API wants to be yet.
* It would probably be a good idea for the tests to require that each edition with `"patterns"` also have a string under `"examples"` that is matched by each pattern, which would go a long way to detecting typos. I didn't do that yet though.