### PR TITLE
Add Illinois format-neutral regexes

### DIFF
--- a/reporters_db/data/regexes.json
+++ b/reporters_db/data/regexes.json
@@ -8,6 +8,10 @@
             "3_4": "$volume_year-$reporter-$page_3_4",
             "3_4#": "Format neutral cite where the page must be 3 or 4 digits, like '2000-NMSC-123'"
         },
+        "illinois_neutral": {
+            "": "$volume_year $reporter (?P<page>\\d{6}(?:-[A-Z])?)",
+            "#": "Illinois format-neutral cite with an optional -letter in page number."
+        },
         "louisiana": {
             "": "(?P<volume>\\d{2,4})[- ](?P<page>\\d{2,5}[A-Z]?) \\($reporter (?P<date_filed>\\d{1,2}\\/\\d{1,2}\\/\\d{2,4})\\)",
             "#": "Format neutral Louisiana cite, like '2009 1359R (La.App. 1 Cir. 05/10/10)'"

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -6350,9 +6350,16 @@
             "editions": {
                 "IL": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite_illinois_neutral"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "2014 IL 115811",
+                "2014 IL 115811-B"
+            ],
             "mlz_jurisdiction": [
                 "us:il;supreme.court"
             ],
@@ -6366,9 +6373,16 @@
             "editions": {
                 "IL App (1st)": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite_illinois_neutral"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "2014 IL App (1st) 120583",
+                "2014 IL App (1st) 120583-U"
+            ],
             "mlz_jurisdiction": [
                 "us:il;court.appeals"
             ],
@@ -6386,9 +6400,16 @@
             "editions": {
                 "IL App (2d)": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite_illinois_neutral"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "2014 IL App (2d) 120583",
+                "2014 IL App (2d) 120583-U"
+            ],
             "mlz_jurisdiction": [
                 "us:il;court.appeals"
             ],
@@ -6407,9 +6428,16 @@
             "editions": {
                 "IL App (3d)": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite_illinois_neutral"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "2014 IL App (3d) 120583",
+                "2014 IL App (3d) 120583-U"
+            ],
             "mlz_jurisdiction": [
                 "us:il;court.appeals"
             ],
@@ -6428,9 +6456,16 @@
             "editions": {
                 "IL App (4th)": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite_illinois_neutral"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "2014 IL App (4th) 120583",
+                "2014 IL App (4th) 120583-U"
+            ],
             "mlz_jurisdiction": [
                 "us:il;court.appeals"
             ],
@@ -6448,9 +6483,16 @@
             "editions": {
                 "IL App (5th)": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite_illinois_neutral"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "2014 IL App (5th) 120583",
+                "2014 IL App (5th) 120583-U"
+            ],
             "mlz_jurisdiction": [
                 "us:il;court.appeals"
             ],


### PR DESCRIPTION
Add a custom regex for Illinois format-neutral cites like `2014 IL App (3d) 120583-U`, so we can drop the generic `r"\d{1,6}[-]?[a-zA-Z]{1,6}",  # CT/IL page` regex from eyecite.

I can't find any evidence of a CT cite format like this, so didn't add it here -- will follow up over in the eyecite repo.