### PR TITLE
Add Conn. Super. Ct. format-neutral cite

### DIFF
--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -3214,7 +3214,7 @@
                 }
             },
             "mlz_jurisdiction": [
-                "us:ct;supreme.court"
+                "us:ct;superior.court"
             ],
             "name": "Connecticut Superior Court Reports",
             "variations": {
@@ -3225,6 +3225,26 @@
                 "Ct. Sup.": "Conn. Super. Ct.",
                 "Ct.Sup.": "Conn. Super. Ct."
             }
+        },
+        {
+            "cite_type": "state",
+            "editions": {
+                "Conn. Super. Ct.": {
+                    "end": null,
+                    "regexes": [
+                        "$volume_year $reporter (?P<page>\\d{1,6}(?:-[A-Z])?)"
+                    ],
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "1999 Conn. Super. Ct. 13301-M"
+            ],
+            "mlz_jurisdiction": [
+                "us:ct;superior.court"
+            ],
+            "name": "Connecticut Superior Court format-neutral citation",
+            "variations": {}
         }
     ],
     "Conn. Supp.": [


### PR DESCRIPTION
I'm not sure if this cite format is cited to, but here's a CourtListener case that lists it as a citation:

Knise v. Knise, No. Fa98 0165989 S (Oct. 4, 1999), 1999 Conn. Super. Ct. 13301-M (Conn. Super. Ct. 1999)
https://www.courtlistener.com/opinion/3347363/knise-v-knise-no-fa98-0165989-s-oct-4-1999/