### PR TITLE
Add laws.json

### DIFF
--- a/reporters_db/__init__.py
+++ b/reporters_db/__init__.py
@@ -1,7 +1,6 @@
 import datetime
 import json
 import os
-import six
 from .utils import (
     suck_out_editions,
     names_to_abbreviations,
@@ -11,14 +10,10 @@ from .utils import (
 )
 
 
-# noinspection PyBroadException
 def datetime_parser(dct):
     for k, v in dct.items():
-        if isinstance(v, six.string_types):
-            try:
-                dct[k] = datetime.datetime.strptime(v, "%Y-%m-%dT%H:%M:%S")
-            except:
-                pass
+        if k in ("start", "end") and v is not None:
+            dct[k] = datetime.datetime.strptime(v, "%Y-%m-%dT%H:%M:%S")
     return dct
 
 
@@ -33,6 +28,10 @@ with open(os.path.join(db_root, "data", "state_abbreviations.json")) as f:
 
 with open(os.path.join(db_root, "data", "case_name_abbreviations.json")) as f:
     CASE_NAME_ABBREVIATIONS = json.load(f)
+
+
+with open(os.path.join(db_root, "data", "laws.json")) as f:
+    LAWS = json.load(f, object_hook=datetime_parser)
 
 
 with open(os.path.join(db_root, "data", "regexes.json")) as f:

--- a/reporters_db/data/laws.json
+++ b/reporters_db/data/laws.json
@@ -1,0 +1,6118 @@
+{
+    "Ala. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Ala. Admin. Code r. 218"
+            ],
+            "jurisdiction": "Alabama",
+            "name": "Alabama Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition r\\. $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ala. Admin. Monthly": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "607 Ala. Admin. Monthly 8"
+            ],
+            "jurisdiction": "Alabama",
+            "name": "Alabama Administrative Monthly",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ala. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-7 Ala. Adv. Legis. Serv. 0"
+            ],
+            "jurisdiction": "Alabama",
+            "name": "Michie's Alabama Code <year> Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ala. Code": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Ala. Code § 92.979"
+            ],
+            "jurisdiction": "Alabama",
+            "name": "Code of Alabama, 1975 (West); Michie's Alabama Code, 1975 (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ala. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ala. Laws 94"
+            ],
+            "jurisdiction": "Alabama",
+            "name": "Alabama Laws",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ala. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ala. Legis. Serv. 3"
+            ],
+            "jurisdiction": "Alabama",
+            "name": "West's Alabama Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Alaska Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Alaska Admin. Code tit. 000, § 41-3-545"
+            ],
+            "jurisdiction": "Alaska",
+            "name": "Alaska Administrative Code (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Alaska Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-83 Alaska Adv. Legis. Serv. 8"
+            ],
+            "jurisdiction": "Alaska",
+            "name": "Alaska Statutes <year> Advance Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Alaska Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Alaska Legis. Serv. 8"
+            ],
+            "jurisdiction": "Alaska",
+            "name": "West's Alaska Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Alaska Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Alaska Sess. Laws 59"
+            ],
+            "jurisdiction": "Alaska",
+            "name": "Session Laws of Alaska",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Alaska Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Alaska Stat. § 240"
+            ],
+            "jurisdiction": "Alaska",
+            "name": "Alaska Statutes (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Alaska Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Alaska Stat. Ann. § 95"
+            ],
+            "jurisdiction": "Alaska",
+            "name": "West's Alaska Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Am. Samoa Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Am. Samoa Admin. Code § 930-054-0"
+            ],
+            "jurisdiction": "American Samoa",
+            "name": "American Samoa Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Am. Samoa Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Am. Samoa Code Ann. § 15.4"
+            ],
+            "jurisdiction": "American Samoa",
+            "name": "American Samoa Code Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ariz. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Ariz. Admin. Code § 709"
+            ],
+            "jurisdiction": "Arizona",
+            "name": "Arizona Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ariz. Admin. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "7 Ariz. Admin. Reg. 4"
+            ],
+            "jurisdiction": "Arizona",
+            "name": "Arizona Administrative Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ariz. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ariz. Legis. Serv. 9"
+            ],
+            "jurisdiction": "Arizona",
+            "name": "Arizona Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ariz. Rev. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Ariz. Rev. Stat. § 495:11"
+            ],
+            "jurisdiction": "Arizona",
+            "name": "Arizona Revised Statutes (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ariz. Rev. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Ariz. Rev. Stat. Ann. § 667"
+            ],
+            "jurisdiction": "Arizona",
+            "name": "Arizona Revised Statutes Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ariz. Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ariz. Sess. Laws 95"
+            ],
+            "jurisdiction": "Arizona",
+            "name": "Session Laws, Arizona",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ark. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ark. Acts 1"
+            ],
+            "jurisdiction": "Arkansas",
+            "name": "Acts of Arkansas (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ark. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-44 Ark. Adv. Legis. Serv. 1"
+            ],
+            "jurisdiction": "Arkansas",
+            "name": "Arkansas Code of 1987 Annotated <year> Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ark. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Ark. Code Ann. § 0:331:5"
+            ],
+            "jurisdiction": "Arkansas",
+            "name": "Arkansas Code of 1987 Annotated (LexisNexis); West's Arkansas Code Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ark. Code R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "0-6-054 Ark. Code R. § 36.2.010"
+            ],
+            "jurisdiction": "Arkansas",
+            "name": "Code of Arkansas Rules (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<chapter>\\d+-\\d+-\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ark. Gov't Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "01 Ark. Gov't Reg. 5"
+            ],
+            "jurisdiction": "Arkansas",
+            "name": "Arkansas Government Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ark. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ark. Legis. Serv. 3"
+            ],
+            "jurisdiction": "Arkansas",
+            "name": "West's Arkansas Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ark. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "043 Ark. Reg. 0"
+            ],
+            "jurisdiction": "Arkansas",
+            "name": "Arkansas Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "C.Z. Code": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "C.Z. Code tit. 699, § 50"
+            ],
+            "jurisdiction": "Canal Zone",
+            "name": "Panama Canal Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cal. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-52 Cal. Adv. Legis. Serv. 8"
+            ],
+            "jurisdiction": "California",
+            "name": "Deering's California Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cal. Code": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Cal. Empl. Code § 8:6:077"
+            ],
+            "jurisdiction": "California",
+            "name": "West's Annotated California Codes; Deering's California Codes, Annotated (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<reporter>Cal\\. $law_subject Code) § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cal. Code Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Cal. Code Regs. tit. 64, § 63:140-867"
+            ],
+            "jurisdiction": "California",
+            "name": "California Code of Regulations (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cal. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Cal. Legis. Serv. 89"
+            ],
+            "jurisdiction": "California",
+            "name": "West's California Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cal. Regulatory Notice Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "35 Cal. Regulatory Notice Reg. 784"
+            ],
+            "jurisdiction": "California",
+            "name": "California Regulatory Notice Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cal. Stat.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Cal. Stat. 2"
+            ],
+            "jurisdiction": "California",
+            "name": "Statutes of California",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colo. Code Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "78 Colo. Code Regs. § 49"
+            ],
+            "jurisdiction": "Colorado",
+            "name": "Colorado Code of Regulations; Code of Colorado Regulations (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colo. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Colo. Legis. Serv. 9"
+            ],
+            "jurisdiction": "Colorado",
+            "name": "Colorado Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colo. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "66 Colo. Reg. 1"
+            ],
+            "jurisdiction": "Colorado",
+            "name": "Colorado Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colo. Rev. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Colo. Rev. Stat. § 4-070-09"
+            ],
+            "jurisdiction": "Colorado",
+            "name": "Colorado Revised Statutes (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colo. Rev. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Colo. Rev. Stat. Ann. § 32.8-514"
+            ],
+            "jurisdiction": "Colorado",
+            "name": "West's Colorado Revised Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colo. Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Colo. Sess. Laws 0888"
+            ],
+            "jurisdiction": "Colorado",
+            "name": "Session Laws of Colorado (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Conn. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Conn. Acts 7 ([Reg. or Spec.] Sess.)"
+            ],
+            "jurisdiction": "Connecticut",
+            "name": "Connecticut Public & Special Acts",
+            "notes": "Automatically generated. Remove this message if replacing with real examples. Indigo Book dates 1972-date.",
+            "regexes": [
+                "$law_year $edition $page_with_commas \\(\\[Reg\\. or Spec\\.\\] Sess\\.\\)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Conn. Agencies Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Conn. Agencies Regs. § 44-999-9"
+            ],
+            "jurisdiction": "Connecticut",
+            "name": "Regulations of Connecticut State Agencies",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Conn. Gen. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Conn. Gen. Stat. § 0:899"
+            ],
+            "jurisdiction": "Connecticut",
+            "name": "General Statutes of Connecticut",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Conn. Gen. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Conn. Gen. Stat. Ann. § 77"
+            ],
+            "jurisdiction": "Connecticut",
+            "name": "Connecticut General Statutes Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Conn. Gov't Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "777 Conn. Gov't Reg. 6330"
+            ],
+            "jurisdiction": "Connecticut",
+            "name": "Connecticut Government Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Conn. L.J.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "44 Conn. L.J. 64"
+            ],
+            "jurisdiction": "Connecticut",
+            "name": "Connecticut Law Journal",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Conn. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Conn. Legis. Serv. 71"
+            ],
+            "jurisdiction": "Connecticut",
+            "name": "Connecticut Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Conn. Pub. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Conn. Pub. Acts 3"
+            ],
+            "jurisdiction": "Connecticut",
+            "name": "Connecticut Public Acts",
+            "notes": "Automatically generated. Remove this message if replacing with real examples. Indigo Book dates 1650-1971.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Conn. Spec. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Conn. Spec. Acts 029"
+            ],
+            "jurisdiction": "Connecticut",
+            "name": "Connecticut Special Acts (Resolves & Private Laws, Private & Special Laws, Special Laws, Resolves & Private Acts, Resolutions & Private Acts, Private Acts & Resolutions, and Special Acts & Resolutions)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples. Indigo Book dates 1789-1971.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "D.C. Code": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "D.C. Code § 65.405.2"
+            ],
+            "jurisdiction": "District of Columbia",
+            "name": "District of Columbia Official Code (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "D.C. Code Adv. Leg. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-69 D.C. Code Adv. Leg. Serv. 4"
+            ],
+            "jurisdiction": "District of Columbia",
+            "name": "District of Columbia Official Code Lexis Advance Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "D.C. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "D.C. Code Ann. § 580-35.58"
+            ],
+            "jurisdiction": "District of Columbia",
+            "name": "West's District of Columbia Code Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "D.C. Code Mun. Regs.": [
+        {
+            "cite_type": "municipal",
+            "end": null,
+            "examples": [
+                "D.C. Code Mun. Regs. tit. 87 § 54-1"
+            ],
+            "jurisdiction": "District of Columbia",
+            "name": "Code of District of Columbia Municipal Regulations (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+) § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "D.C. Mun. Regs.": [
+        {
+            "cite_type": "municipal",
+            "end": null,
+            "examples": [
+                "D.C. Mun. Regs. tit. 935, § 9"
+            ],
+            "jurisdiction": "District of Columbia",
+            "name": "Code of D.C. Municipal Regulations",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "D.C. Reg.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "685 D.C. Reg. 42"
+            ],
+            "jurisdiction": "District of Columbia",
+            "name": "District of Columbia Register; District of Columbia Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "D.C. Sess. L. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 D.C. Sess. L. Serv. 6359"
+            ],
+            "jurisdiction": "District of Columbia",
+            "name": "District of Columbia Session Law Service West",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Del Gov't Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "075 Del Gov't Reg. 3,52"
+            ],
+            "jurisdiction": "Delaware",
+            "name": "Delaware Government Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Del. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "42-8-22 Del. Admin. Code § 4"
+            ],
+            "jurisdiction": "Delaware",
+            "name": "Delaware Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<chapter>\\d+-\\d+-\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Del. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Del. Code Ann. tit. 87, § 6-584:4"
+            ],
+            "jurisdiction": "Delaware",
+            "name": "Delaware Code Annotated (LexisNexis); West's Delaware Code Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Del. Code Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "35-0-67 Del. Code Regs. § 45-025"
+            ],
+            "jurisdiction": "Delaware",
+            "name": "Code of Delaware Regulations (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<chapter>\\d+-\\d+-\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Del. Code. Ann. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-4 Del. Code. Ann. Adv. Legis. Serv. 3"
+            ],
+            "jurisdiction": "Delaware",
+            "name": "Delaware Code Annotated <year> Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Del. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "25 Del. Laws 1"
+            ],
+            "jurisdiction": "Delaware",
+            "name": "Laws of Delaware",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Del. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Del. Legis. Serv. 83"
+            ],
+            "jurisdiction": "Delaware",
+            "name": "West's Delaware Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Del. Reg. Regs.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "7 Del. Reg. Regs. 8349"
+            ],
+            "jurisdiction": "Delaware",
+            "name": "Delaware Register of Regulations",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fla. Admin. Code Ann.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Fla. Admin. Code Ann. r. 39.6-70"
+            ],
+            "jurisdiction": "Florida",
+            "name": "Florida Administrative Code Annotated (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition r\\. $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fla. Admin. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "280 Fla. Admin. Reg. 7"
+            ],
+            "jurisdiction": "Florida",
+            "name": "Florida Administrative Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples. Indigo Book dates 2012-date.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fla. Admin. Weekly": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "454 Fla. Admin. Weekly 86"
+            ],
+            "jurisdiction": "Florida",
+            "name": "Florida Administrative Weekly (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples. Indigo Book dates 1996-2012.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fla. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Fla. Laws 721"
+            ],
+            "jurisdiction": "Florida",
+            "name": "Laws of Florida",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fla. Sess. Law Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Fla. Sess. Law Serv. 045"
+            ],
+            "jurisdiction": "Florida",
+            "name": "West's Florida Session Law Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fla. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Fla. Stat. § 8"
+            ],
+            "jurisdiction": "Florida",
+            "name": "Florida Statutes",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fla. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Fla. Stat. Ann. § 8-3:39"
+            ],
+            "jurisdiction": "Florida",
+            "name": "West's Florida Statutes Annotated; LexisNexis Florida Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ga. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Ga. Code Ann. § 67.508.661"
+            ],
+            "jurisdiction": "Georgia",
+            "name": "Official Code of Georgia Annotated (LexisNexis); West's Code of Georgia Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ga. Code Ann. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-85 Ga. Code Ann. Adv. Legis. Serv. 51"
+            ],
+            "jurisdiction": "Georgia",
+            "name": "Georgia <year> Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        },
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ga. Code Ann. Adv. Legis. Serv. 2"
+            ],
+            "jurisdiction": "Georgia",
+            "name": "West's Georgia Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ga. Comp. R. & Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Ga. Comp. R. & Regs. 708-5.918"
+            ],
+            "jurisdiction": "Georgia",
+            "name": "Official Compilation Rules and Regulations of the State of Georgia",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ga. Gov't Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "121 Ga. Gov't Reg. 50"
+            ],
+            "jurisdiction": "Georgia",
+            "name": "Georgia Government Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ga. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ga. Laws 5"
+            ],
+            "jurisdiction": "Georgia",
+            "name": "Georgia Laws",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Guam Admin. R. & Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "99 Guam Admin. R. & Regs. § 2.9"
+            ],
+            "jurisdiction": "Guam",
+            "name": "Administrative Rules & Regulations of the Government of Guam",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Guam Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "9 Guam Code Ann. § 205"
+            ],
+            "jurisdiction": "Guam",
+            "name": "Guam Code Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Guam Pub. L.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "Guam Pub. L. 579"
+            ],
+            "jurisdiction": "Guam",
+            "name": "Guam Session Laws",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition (?P<law>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Haw. Code R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Haw. Code R. § 6.0"
+            ],
+            "jurisdiction": "Hawaii",
+            "name": "Code of Hawaii Rules (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Haw. Gov't Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "721 Haw. Gov't Reg. 97"
+            ],
+            "jurisdiction": "Hawaii",
+            "name": "Hawaii Government Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Haw. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Haw. Legis. Serv. 369"
+            ],
+            "jurisdiction": "Hawaii",
+            "name": "West's Hawai'i Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Haw. Rev. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Haw. Rev. Stat. § 230:5.265"
+            ],
+            "jurisdiction": "Hawaii",
+            "name": "Hawaii Revised Statutes",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Haw. Rev. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Haw. Rev. Stat. Ann. § 08.68.903"
+            ],
+            "jurisdiction": "Hawaii",
+            "name": "Michie's Hawaii Revised Statutes Annotated (LexisNexis); West's Hawai'i Revised Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Haw. Rev. Stat. Ann. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-100 Haw. Rev. Stat. Ann. Adv. Legis. Serv. 436"
+            ],
+            "jurisdiction": "Hawaii",
+            "name": "Michie's Hawaii Revised Statutes Annotated Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Haw. Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Haw. Sess. Laws 2203"
+            ],
+            "jurisdiction": "Hawaii",
+            "name": "Session Laws of Hawaii",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Idaho Admin. Bull.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "0 Idaho Admin. Bull. 6"
+            ],
+            "jurisdiction": "Idaho",
+            "name": "Idaho Administrative Bulletin",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Idaho Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Idaho Admin. Code r. 2.12"
+            ],
+            "jurisdiction": "Idaho",
+            "name": "Idaho Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition r\\. $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Idaho Code": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Idaho Code § 54:57-2"
+            ],
+            "jurisdiction": "Idaho",
+            "name": "Idaho Code (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Idaho Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Idaho Code Ann. § 160:38:649"
+            ],
+            "jurisdiction": "Idaho",
+            "name": "West's Idaho Code Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Idaho Code Ann. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-2 Idaho Code Ann. Adv. Legis. Serv. 194"
+            ],
+            "jurisdiction": "Idaho",
+            "name": "Idaho Code Annotated Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Idaho Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Idaho Legis. Serv. 2"
+            ],
+            "jurisdiction": "Idaho",
+            "name": "West's Idaho Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Idaho Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Idaho Sess. Laws 9"
+            ],
+            "jurisdiction": "Idaho",
+            "name": "Idaho Session Laws",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ill. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Ill. Admin. Code tit. 2, § 832-85-0"
+            ],
+            "jurisdiction": "Illinois",
+            "name": "Illinois Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ill. Code R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "7 Ill. Code R. 966"
+            ],
+            "jurisdiction": "Illinois",
+            "name": "Code of Illinois Rules (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ill. Comp. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "1 Ill. Comp. Stat. 0 / 462.04"
+            ],
+            "jurisdiction": "Illinois",
+            "name": "Illinois Compiled Statutes",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<chapter>\\d+) $edition (?P<act>\\d+) / $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ill. Comp. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "885 Ill. Comp. Stat. Ann. 132 / 73-757:13"
+            ],
+            "jurisdiction": "Illinois",
+            "name": "West's Smith-Hurd Illinois Compiled Statutes Annotated; Illinois Compiled Statutes Annotated (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<chapter>\\d+) $edition (?P<act>\\d+) / $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ill. Comp. Stat. Ann. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-6 Ill. Comp. Stat. Ann. Adv. Legis. Serv. 2,80"
+            ],
+            "jurisdiction": "Illinois",
+            "name": "Illinois Compiled Statutes Annotated Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ill. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ill. Laws 9"
+            ],
+            "jurisdiction": "Illinois",
+            "name": "Laws of Illinois",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ill. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ill. Legis. Serv. 4"
+            ],
+            "jurisdiction": "Illinois",
+            "name": "Illinois Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ill. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "1 Ill. Reg. 4434"
+            ],
+            "jurisdiction": "Illinois",
+            "name": "Illinois Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ind. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ind. Acts 0"
+            ],
+            "jurisdiction": "Indiana",
+            "name": "Acts, Indiana",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ind. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "884 Ind. Admin. Code 0"
+            ],
+            "jurisdiction": "Indiana",
+            "name": "Indiana Administrative Code; West's Indiana Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ind. Code": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Ind. Code § 79.443"
+            ],
+            "jurisdiction": "Indiana",
+            "name": "Indiana Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ind. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Ind. Code Ann. § 0-922:28"
+            ],
+            "jurisdiction": "Indiana",
+            "name": "West's Annotated Indiana Code; Burns Indiana Statutes Annotated (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ind. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ind. Legis. Serv. 8"
+            ],
+            "jurisdiction": "Indiana",
+            "name": "West's Indiana Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ind. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "8 Ind. Reg. 737"
+            ],
+            "jurisdiction": "Indiana",
+            "name": "Indiana Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ind. Stat. Ann. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-62 Ind. Stat. Ann. Adv. Legis. Serv. 0"
+            ],
+            "jurisdiction": "Indiana",
+            "name": "Burns Indiana Statutes Annotated Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Iowa Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Iowa Acts 0"
+            ],
+            "jurisdiction": "Iowa",
+            "name": "Acts of the State of Iowa",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Iowa Admin. Bull.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "17 Iowa Admin. Bull. 5"
+            ],
+            "jurisdiction": "Iowa",
+            "name": "Iowa Administrative Bulletin",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Iowa Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Iowa Admin. Code r. 39-0-5"
+            ],
+            "jurisdiction": "Iowa",
+            "name": "Iowa Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition r\\. $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Iowa Code": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Iowa Code § 0.780"
+            ],
+            "jurisdiction": "Iowa",
+            "name": "Code of Iowa",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Iowa Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Iowa Code Ann. § 5:77.49"
+            ],
+            "jurisdiction": "Iowa",
+            "name": "West's Iowa Code Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Iowa Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Iowa Legis. Serv. 9057"
+            ],
+            "jurisdiction": "Iowa",
+            "name": "Iowa Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Kan. Admin. Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Kan. Admin. Regs. § 39"
+            ],
+            "jurisdiction": "Kansas",
+            "name": "Kansas Administrative Regulations (updated by supplements)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Kan. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Kan. Legis. Serv. 6731"
+            ],
+            "jurisdiction": "Kansas",
+            "name": "West's Kansas Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Kan. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "9 Kan. Reg. 78"
+            ],
+            "jurisdiction": "Kansas",
+            "name": "Kansas Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Kan. Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Kan. Sess. Laws 0"
+            ],
+            "jurisdiction": "Kansas",
+            "name": "Session Laws of Kansas",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Kan. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Kan. Stat. Ann. § 4"
+            ],
+            "jurisdiction": "Kansas",
+            "name": "Kansas Statutes Annotated; West's Kansas Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ky. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ky. Acts 1083"
+            ],
+            "jurisdiction": "Kentucky",
+            "name": "Acts of Kentucky",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ky. Admin. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "69 Ky. Admin. Reg. 8,6"
+            ],
+            "jurisdiction": "Kentucky",
+            "name": "Administrative Register of Kentucky",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ky. Admin. Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "78 Ky. Admin. Regs. 124"
+            ],
+            "jurisdiction": "Kentucky",
+            "name": "Kentucky Administrative Regulations Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ky. Rev. Stat. & R. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ky. Rev. Stat. & R. Serv. 8297"
+            ],
+            "jurisdiction": "Kentucky",
+            "name": "Kentucky Revised Statutes and Rules Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ky. Rev. Stat. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-39 Ky. Rev. Stat. Adv. Legis. Serv. 809"
+            ],
+            "jurisdiction": "Kentucky",
+            "name": "Michie's Kentucky Revised Statutes Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ky. Rev. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Ky. Rev. Stat. Ann. § 021.48"
+            ],
+            "jurisdiction": "Kentucky",
+            "name": "Baldwin's Kentucky Revised Statutes Annotated (West); Michie's Kentucky Revised Statutes Annotated (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "La. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 La. Acts 4"
+            ],
+            "jurisdiction": "Louisiana",
+            "name": "State of Louisiana: Acts of the Legislature",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "La. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "La. Admin. Code tit. 15, § 6"
+            ],
+            "jurisdiction": "Louisiana",
+            "name": "Louisiana Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "La. Child. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "La. Child. Code Ann. art 4"
+            ],
+            "jurisdiction": "Louisiana",
+            "name": "West's Louisiana Children's Code Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition art (?P<article>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "La. Civ. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "La. Civ. Code Ann. art 51"
+            ],
+            "jurisdiction": "Louisiana",
+            "name": "West's Louisiana Civil Code Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition art (?P<article>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "La. Code Civ. Proc. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "La. Code Civ. Proc. Ann. art 3"
+            ],
+            "jurisdiction": "Louisiana",
+            "name": "West's Louisiana Code of Civil Procedure Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition art (?P<article>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "La. Code Crim. Proc. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "La. Code Crim. Proc. Ann. art 151"
+            ],
+            "jurisdiction": "Louisiana",
+            "name": "West's Louisiana Code of Criminal Procedure Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition art (?P<article>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "La. Code Evid. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "La. Code Evid. Ann. art 410"
+            ],
+            "jurisdiction": "Louisiana",
+            "name": "West's Louisiana Code of Evidence Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition art (?P<article>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "La. Const. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "La. Const. Ann. art 53"
+            ],
+            "jurisdiction": "Louisiana",
+            "name": "West's Louisiana Constitution Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition art (?P<article>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "La. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "620 La. Reg. 1"
+            ],
+            "jurisdiction": "Louisiana",
+            "name": "Louisiana Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "La. Sess. Law Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 La. Sess. Law Serv. 9"
+            ],
+            "jurisdiction": "Louisiana",
+            "name": "West's Louisiana Session Law Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "La. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "La. Stat. Ann. § 5"
+            ],
+            "jurisdiction": "Louisiana",
+            "name": "West's Louisiana Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mass. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Mass. Acts 8"
+            ],
+            "jurisdiction": "Massachusetts",
+            "name": "Acts and Resolves of Massachusetts",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mass. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-8 Mass. Adv. Legis. Serv. 1"
+            ],
+            "jurisdiction": "Massachusetts",
+            "name": "Massachusetts Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mass. Ann. Laws": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Mass. Ann. Laws ch. 334, § 3:54"
+            ],
+            "jurisdiction": "Massachusetts",
+            "name": "Annotated Laws of Massachusetts (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition ch\\. (?P<chapter>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mass. Code Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "177 Mass. Code Regs. 123-10"
+            ],
+            "jurisdiction": "Massachusetts",
+            "name": "Code of Massachusetts Regulations; Code of Massachusetts Regulations (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mass. Gen. Laws": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Mass. Gen. Laws ch. 44, § 0:04.1"
+            ],
+            "jurisdiction": "Massachusetts",
+            "name": "General Laws of Massachusetts (Mass. Bar Ass'n/West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition ch\\. (?P<chapter>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mass. Gen. Laws Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Mass. Gen. Laws Ann. ch. 3, § 3"
+            ],
+            "jurisdiction": "Massachusetts",
+            "name": "Massachusetts General Laws Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition ch\\. (?P<chapter>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mass. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Mass. Legis. Serv. 1"
+            ],
+            "jurisdiction": "Massachusetts",
+            "name": "Massachusetts Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mass. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "217 Mass. Reg. 3"
+            ],
+            "jurisdiction": "Massachusetts",
+            "name": "Massachusetts Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Md. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Md. Code Ann., Empl. § 8-551"
+            ],
+            "jurisdiction": "Maryland",
+            "name": "Michie's Annotated Code of Maryland (LexisNexis); West's Annotated Code of Maryland",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition, $law_subject § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Md. Code Ann. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-366 Md. Code Ann. Adv. Legis. Serv. 6"
+            ],
+            "jurisdiction": "Maryland",
+            "name": "Michie's Annotated Code of Maryland Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Md. Code Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Md. Code Regs. 12"
+            ],
+            "jurisdiction": "Maryland",
+            "name": "Code of Maryland Regulations",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition (?P<reg>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Md. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Md. Laws 1972"
+            ],
+            "jurisdiction": "Maryland",
+            "name": "Laws of Maryland",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Md. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Md. Legis. Serv. 5"
+            ],
+            "jurisdiction": "Maryland",
+            "name": "West's Maryland Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Md. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "3 Md. Reg. 8065"
+            ],
+            "jurisdiction": "Maryland",
+            "name": "Maryland Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Me. Code R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "60-8-7 Me. Code R. § 88-7:4"
+            ],
+            "jurisdiction": "Maine",
+            "name": "Code of Maine Rules (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<chapter>\\d+-\\d+-\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Me. Gov't Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "1 Me. Gov't Reg. 1"
+            ],
+            "jurisdiction": "Maine",
+            "name": "Maine Government Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Me. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Me. Laws 9"
+            ],
+            "jurisdiction": "Maine",
+            "name": "Laws of the State of Maine",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Me. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Me. Legis. Serv. 6"
+            ],
+            "jurisdiction": "Maine",
+            "name": "Maine Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Me. Rev. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Me. Rev. Stat. Ann. tit. 095, § 0:624"
+            ],
+            "jurisdiction": "Maine",
+            "name": "Maine Revised Statutes Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Me. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Me. Stat. tit. 97, § 439"
+            ],
+            "jurisdiction": "Maine",
+            "name": "West's Maine Statutes",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mich. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Mich. Admin. Code ry 74.4:78"
+            ],
+            "jurisdiction": "Michigan",
+            "name": "Michigan Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition r. $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mich. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-669 Mich. Adv. Legis. Serv. 58"
+            ],
+            "jurisdiction": "Michigan",
+            "name": "Michigan Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mich. Comp. Laws": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Mich. Comp. Laws § 525.008:505"
+            ],
+            "jurisdiction": "Michigan",
+            "name": "Michigan Compiled Laws (1979)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mich. Comp. Laws Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Mich. Comp. Laws Ann. § 39:86.3"
+            ],
+            "jurisdiction": "Michigan",
+            "name": "Michigan Compiled Laws Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mich. Comp. Laws Serv.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Mich. Comp. Laws Serv. § 538-221"
+            ],
+            "jurisdiction": "Michigan",
+            "name": "Michigan Compiled Laws Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mich. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Mich. Legis. Serv. 3"
+            ],
+            "jurisdiction": "Michigan",
+            "name": "Michigan Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mich. Pub. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Mich. Pub. Acts 9,1"
+            ],
+            "jurisdiction": "Michigan",
+            "name": "Public and Local Acts of the Legislature of the State of Michigan",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mich. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "953 Mich. Reg. 0"
+            ],
+            "jurisdiction": "Michigan",
+            "name": "Michigan Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Minn. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Minn. Laws 41"
+            ],
+            "jurisdiction": "Minnesota",
+            "name": "Laws of Minnesota",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Minn. R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Minn. R. 6"
+            ],
+            "jurisdiction": "Minnesota",
+            "name": "Minnesota Rules",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Minn. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "5 Minn. Reg. 69"
+            ],
+            "jurisdiction": "Minnesota",
+            "name": "Minnesota State Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Minn. Sess. Law Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Minn. Sess. Law Serv. 8"
+            ],
+            "jurisdiction": "Minnesota",
+            "name": "Minnesota Session Law Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Minn. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Minn. Stat. § 20-72"
+            ],
+            "jurisdiction": "Minnesota",
+            "name": "Minnesota Statutes",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Minn. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Minn. Stat. Ann. § 967-86"
+            ],
+            "jurisdiction": "Minnesota",
+            "name": "Minnesota Statutes Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Miss. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Miss. Code Ann. § 6"
+            ],
+            "jurisdiction": "Mississippi",
+            "name": "Mississippi Code 1972 Annotated (LexisNexis); West's Annotated Mississippi Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Miss. Code R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "3-866 Miss. Code R. § 22.95.78"
+            ],
+            "jurisdiction": "Mississippi",
+            "name": "Code of Mississippi Rules (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+)\\-(?P<chapter>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Miss. Gov't Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "86 Miss. Gov't Reg. 9"
+            ],
+            "jurisdiction": "Mississippi",
+            "name": "Mississippi Government Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Miss. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Miss. Laws 2"
+            ],
+            "jurisdiction": "Mississippi",
+            "name": "General Laws of Mississippi",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Miss. Laws Adv. Sh.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-2 Miss. Laws Adv. Sh. 6"
+            ],
+            "jurisdiction": "Mississippi",
+            "name": "Mississippi General Laws Advance Sheets (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Miss. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Miss. Legis. Serv. 54"
+            ],
+            "jurisdiction": "Mississippi",
+            "name": "West's Mississippi Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mo. Ann. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Mo. Ann. Stat. § 274"
+            ],
+            "jurisdiction": "Missouri",
+            "name": "Vernon's Annotated Missouri Statutes (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mo. Code Regs. Ann.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Mo. Code Regs. Ann. tit. 42, § 1:080:35"
+            ],
+            "jurisdiction": "Missouri",
+            "name": "Missouri Code of State Regulations Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mo. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Mo. Laws 280"
+            ],
+            "jurisdiction": "Missouri",
+            "name": "Session Laws of Missouri",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mo. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Mo. Legis. Serv. 80"
+            ],
+            "jurisdiction": "Missouri",
+            "name": "Missouri Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mo. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "7 Mo. Reg. 1"
+            ],
+            "jurisdiction": "Missouri",
+            "name": "Missouri Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mo. Rev. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Mo. Rev. Stat. § 1.174"
+            ],
+            "jurisdiction": "Missouri",
+            "name": "Missouri Revised Statutes",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mont. Admin. R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Mont. Admin. R. 5"
+            ],
+            "jurisdiction": "Montana",
+            "name": "Administrative Rules of Montana",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mont. Admin. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "452 Mont. Admin. Reg. 85"
+            ],
+            "jurisdiction": "Montana",
+            "name": "Montana Administrative Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mont. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Mont. Code Ann. § 5"
+            ],
+            "jurisdiction": "Montana",
+            "name": "Montana Code Annotated; West's Montana Code Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mont. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Mont. Laws 7"
+            ],
+            "jurisdiction": "Montana",
+            "name": "Laws of Montana",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N. Mar. I. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "0 N. Mar. I. Admin. Code § 77-642-24"
+            ],
+            "jurisdiction": "Northern Mariana Islands",
+            "name": "Northern Mariana Islands Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N. Mar. I. Code": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "500 N. Mar. I. Code § 59-989:8"
+            ],
+            "jurisdiction": "Northern Mariana Islands",
+            "name": "Northern Mariana Islands Commonwealth Code (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N. Mar. I. Pub. L.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N. Mar. I. Pub. L. 24"
+            ],
+            "jurisdiction": "Northern Mariana Islands",
+            "name": "Northern Mariana Islands Session Laws",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition (?P<law>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N. Mar. I. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "566 N. Mar. I. Reg. 126"
+            ],
+            "jurisdiction": "Northern Mariana Islands",
+            "name": "Northern Mariana Islands Commonwealth Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.C. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "338 N.C. Admin. Code 08"
+            ],
+            "jurisdiction": "North Carolina",
+            "name": "North Carolina Administrative Code (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.C. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-174 N.C. Adv. Legis. Serv. 424"
+            ],
+            "jurisdiction": "North Carolina",
+            "name": "North Carolina <year> Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.C. Gen. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "N.C. Gen. Stat. § 50"
+            ],
+            "jurisdiction": "North Carolina",
+            "name": "General Statutes of North Carolina (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.C. Gen. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "N.C. Gen. Stat. Ann. § 17"
+            ],
+            "jurisdiction": "North Carolina",
+            "name": "West's North Carolina General Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.C. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.C. Legis. Serv. 079"
+            ],
+            "jurisdiction": "North Carolina",
+            "name": "North Carolina Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.C. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "744 N.C. Reg. 56"
+            ],
+            "jurisdiction": "North Carolina",
+            "name": "North Carolina Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.C. Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.C. Sess. Laws 728"
+            ],
+            "jurisdiction": "North Carolina",
+            "name": "Session Laws of North Carolina",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.D. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "N.D. Admin. Code 132"
+            ],
+            "jurisdiction": "North Dakota",
+            "name": "North Dakota Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.D. Cent. Code": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "N.D. Cent. Code § 81-831"
+            ],
+            "jurisdiction": "North Dakota",
+            "name": "North Dakota Century Code (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.D. Cent. Code Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-933 N.D. Cent. Code Adv. Legis. Serv. 80,0"
+            ],
+            "jurisdiction": "North Dakota",
+            "name": "North Dakota Century Code <year> Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.D. Cent. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "N.D. Cent. Code Ann. § 18"
+            ],
+            "jurisdiction": "North Dakota",
+            "name": "West's North Dakota Century Code Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.D. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.D. Laws 491"
+            ],
+            "jurisdiction": "North Dakota",
+            "name": "Laws of North Dakota",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.D. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.D. Legis. Serv. 33,5"
+            ],
+            "jurisdiction": "North Dakota",
+            "name": "West's North Dakota Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.H. Code Admin. R. Ann.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "N.H. Code Admin. R. Ann. Empl. 044"
+            ],
+            "jurisdiction": "New Hampshire",
+            "name": "New Hampshire Code of Administrative Rules Annotated (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition $law_subject (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.H. Code R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "N.H. Code R. Empl. 497"
+            ],
+            "jurisdiction": "New Hampshire",
+            "name": "Code of New Hampshire Rules (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition $law_subject (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.H. Gov't Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "87 N.H. Gov't Reg. 91"
+            ],
+            "jurisdiction": "New Hampshire",
+            "name": "New Hampshire Government Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.H. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.H. Laws 833"
+            ],
+            "jurisdiction": "New Hampshire",
+            "name": "Laws of the State of New Hampshire (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.H. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.H. Legis. Serv. 7"
+            ],
+            "jurisdiction": "New Hampshire",
+            "name": "New Hampshire Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.H. Rev. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "N.H. Rev. Stat. Ann. § 5:41"
+            ],
+            "jurisdiction": "New Hampshire",
+            "name": "New Hampshire Revised Statutes Annotated (West); Lexis New Hampshire Revised Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.H. Rev. Stat. Ann. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-063 N.H. Rev. Stat. Ann. Adv. Legis. Serv. 7,48"
+            ],
+            "jurisdiction": "New Hampshire",
+            "name": "Lexis New Hampshire Revised Statutes Annotated <year> Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.H. Rulemaking Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "5 N.H. Rulemaking Reg. 6962"
+            ],
+            "jurisdiction": "New Hampshire",
+            "name": "New Hampshire Rulemaking Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.J. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "N.J. Admin. Code § 1"
+            ],
+            "jurisdiction": "New Jersey",
+            "name": "New Jersey Administrative Code (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.J. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.J. Laws 594"
+            ],
+            "jurisdiction": "New Jersey",
+            "name": "Laws of New Jersey",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.J. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "374 N.J. Reg. 17"
+            ],
+            "jurisdiction": "New Jersey",
+            "name": "New Jersey Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.J. Rev. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "N.J. Rev. Stat. § 9-513:53"
+            ],
+            "jurisdiction": "New Jersey",
+            "name": "New Jersey Revised Statutes (2013)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.J. Sess. Law Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.J. Sess. Law Serv. 00"
+            ],
+            "jurisdiction": "New Jersey",
+            "name": "New Jersey Session Law Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.J. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "N.J. Stat. Ann. § 0.21-05"
+            ],
+            "jurisdiction": "New Jersey",
+            "name": "New Jersey Statutes Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.M. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.M. Adv. Legis. Serv. 31,7"
+            ],
+            "jurisdiction": "New Mexico",
+            "name": "New Mexico Advance Legislative Service (Conway Greene)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.M. Code R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "N.M. Code R. § 4.887.8"
+            ],
+            "jurisdiction": "New Mexico",
+            "name": "Code of New Mexico Rules (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.M. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.M. Laws 76"
+            ],
+            "jurisdiction": "New Mexico",
+            "name": "Laws of the State of New Mexico",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.M. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.M. Legis. Serv. 5"
+            ],
+            "jurisdiction": "New Mexico",
+            "name": "West's New Mexico Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.M. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "19 N.M. Reg. 9"
+            ],
+            "jurisdiction": "New Mexico",
+            "name": "New Mexico Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.M. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "N.M. Stat. Ann. § 641"
+            ],
+            "jurisdiction": "New Mexico",
+            "name": "New Mexico Statutes Annotated 1978 (Conway Greene); West's New Mexico Statutes Annotated; Michie's Annotated Statutes of New Mexico (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y.": [
+        {
+            "cite_type": "leg_act",
+            "end": null,
+            "examples": [
+                "N.Y. Empl. § 85"
+            ],
+            "jurisdiction": "New York",
+            "name": "McKinney's Consolidated Laws; Consolidated Laws Service; LexisNexis New York Consolidated Laws Unannotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition $law_subject § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y. Comp. Codes R. & Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "N.Y. Comp. Codes R. & Regs. tit. 01, § 38-9:0"
+            ],
+            "jurisdiction": "New York",
+            "name": "Official Compilation of Codes, Rules & Regulations of the State of New York (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y. Consol. Laws Adv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-975 N.Y. Consol. Laws Adv."
+            ],
+            "jurisdiction": "New York",
+            "name": "New York Consolidated Laws Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y. Law": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "N.Y. Empl. Law § 24:09"
+            ],
+            "jurisdiction": "New York",
+            "name": "McKinney's Consolidated Laws of New York Annotated (West); New York Consolidated Laws Service (LexisNexis); New York Consolidated Laws Unannotated (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<reporter>N\\.Y\\. $law_subject Law) § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.Y. Laws 19"
+            ],
+            "jurisdiction": "New York",
+            "name": "Laws of New York",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "N.Y. Legis. Serv. 4"
+            ],
+            "jurisdiction": "New York",
+            "name": "Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "6 N.Y. Reg. 9"
+            ],
+            "jurisdiction": "New York",
+            "name": "New York State Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y. Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.Y. Sess. Laws 9"
+            ],
+            "jurisdiction": "New York",
+            "name": "McKinney's Session Laws of New York (West) (McKinney)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Navajo Nation Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Navajo Nation Code Ann. tit. 52, § 4:57.42"
+            ],
+            "jurisdiction": "Navajo Nation",
+            "name": "Navajo Nation Code Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Neb. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "74 Neb. Admin. Code § 9-58.82"
+            ],
+            "jurisdiction": "Nebraska",
+            "name": "Nebraska Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Neb. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Neb. Laws 7"
+            ],
+            "jurisdiction": "Nebraska",
+            "name": "Laws of Nebraska",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Neb. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Neb. Legis. Serv. 3"
+            ],
+            "jurisdiction": "Nebraska",
+            "name": "West's Nebraska Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Neb. Rev. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Neb. Rev. Stat. § 352.853"
+            ],
+            "jurisdiction": "Nebraska",
+            "name": "Revised Statutes of Nebraska",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Neb. Rev. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Neb. Rev. Stat. Ann. § 865.5:868"
+            ],
+            "jurisdiction": "Nebraska",
+            "name": "Revised Statutes of Nebraska Annotated (LexisNexis); West's Revised Statutes of Nebraska Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Nev. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Nev. Admin. Code § 73:9"
+            ],
+            "jurisdiction": "Nevada",
+            "name": "Nevada Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Nev. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Nev. Legis. Serv. 7"
+            ],
+            "jurisdiction": "Nevada",
+            "name": "West's Nevada Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Nev. Reg. Admin. Regs.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "2 Nev. Reg. Admin. Regs. 710"
+            ],
+            "jurisdiction": "Nevada",
+            "name": "Nevada Register of Administrative Regulations",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition (?P<reg>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Nev. Rev. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Nev. Rev. Stat. § 1.616-28"
+            ],
+            "jurisdiction": "Nevada",
+            "name": "Nevada Revised Statutes",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Nev. Rev. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Nev. Rev. Stat. Ann. § 140:737"
+            ],
+            "jurisdiction": "Nevada",
+            "name": "Michie's Nevada Revised Statutes Annotated (LexisNexis); West's Nevada Revised Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Nev. Stat.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Nev. Stat. 3"
+            ],
+            "jurisdiction": "Nevada",
+            "name": "Statutes of Nevada",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ohio Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Ohio Admin. Code 5"
+            ],
+            "jurisdiction": "Ohio",
+            "name": "Baldwin's Ohio Administrative Code (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ohio Dep't": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "Ohio Dep't 39"
+            ],
+            "jurisdiction": "Ohio",
+            "name": "Ohio Department Reports",
+            "notes": "Automatically generated. Remove this message if replacing with real examples. Indigo Book dates 1914-1964.",
+            "regexes": [
+                "$edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ohio Gov't": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "Ohio Gov't 38,7"
+            ],
+            "jurisdiction": "Ohio",
+            "name": "Ohio Government Reports",
+            "notes": "Automatically generated. Remove this message if replacing with real examples. Indigo Book dates 1965-1976.",
+            "regexes": [
+                "$edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ohio Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ohio Laws 4"
+            ],
+            "jurisdiction": "Ohio",
+            "name": "State of Ohio: Legislative Acts Passed and Joint Resolutions Adopted",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ohio Legis. Bull.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ohio Legis. Bull. 6"
+            ],
+            "jurisdiction": "Ohio",
+            "name": "Page's Ohio Legislative Bulletin (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ohio Legis. Serv. Ann.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ohio Legis. Serv. Ann. 4767"
+            ],
+            "jurisdiction": "Ohio",
+            "name": "Baldwin's Ohio Legislative Service Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ohio Monthly Rec.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "Ohio Monthly Rec. 6"
+            ],
+            "jurisdiction": "Ohio",
+            "name": "Baldwin's Ohio Monthly Record",
+            "notes": "Automatically generated. Remove this message if replacing with real examples. Indigo Book dates 1977-date.",
+            "regexes": [
+                "$edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ohio Rev. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Ohio Rev. Code Ann. § 34"
+            ],
+            "jurisdiction": "Ohio",
+            "name": "Page's Ohio Revised Code Annotated (LexisNexis); Baldwin's Ohio Revised Code Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Okla. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Okla. Admin. Code § 21:1:912"
+            ],
+            "jurisdiction": "Oklahoma",
+            "name": "Oklahoma Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Okla. Gaz.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "059 Okla. Gaz. 9275"
+            ],
+            "jurisdiction": "Oklahoma",
+            "name": "Oklahoma Gazette 1962-1983",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Okla. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "87 Okla. Reg. 453"
+            ],
+            "jurisdiction": "Oklahoma",
+            "name": "Oklahoma Register 1983-date",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Okla. Sess. Law Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Okla. Sess. Law Serv. 9"
+            ],
+            "jurisdiction": "Oklahoma",
+            "name": "Oklahoma Session Law Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Okla. Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Okla. Sess. Laws 1"
+            ],
+            "jurisdiction": "Oklahoma",
+            "name": "Oklahoma Session Laws (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Okla. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Okla. Stat. tit. 425, § 838-00-01"
+            ],
+            "jurisdiction": "Oklahoma",
+            "name": "Oklahoma Statutes (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Okla. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Okla. Stat. Ann. tit. 2, § 559"
+            ],
+            "jurisdiction": "Oklahoma",
+            "name": "Oklahoma Statutes Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Or. Admin. R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Or. Admin. R. 454"
+            ],
+            "jurisdiction": "Oregon",
+            "name": "Oregon Administrative Rules",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Or. Bull.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "2 Or. Bull. 8803"
+            ],
+            "jurisdiction": "Oregon",
+            "name": "Oregon Bulletin",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Or. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Or. Laws 2"
+            ],
+            "jurisdiction": "Oregon",
+            "name": "Oregon Laws and Resolutions",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Or. Laws Adv. Sh.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Or. Laws Adv. Sh. No. 801, 0072"
+            ],
+            "jurisdiction": "Oregon",
+            "name": "",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition No\\. (?P<number>\\d+), $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Or. Laws Spec. Sess.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Or. Laws Spec. Sess. 0"
+            ],
+            "jurisdiction": "Oregon",
+            "name": "",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Or. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Or. Legis. Serv. 3"
+            ],
+            "jurisdiction": "Oregon",
+            "name": "West's Oregon Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Or. Rev. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Or. Rev. Stat. § 733"
+            ],
+            "jurisdiction": "Oregon",
+            "name": "Oregon Revised Statutes",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Or. Rev. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Or. Rev. Stat. Ann. § 837-3.93"
+            ],
+            "jurisdiction": "Oregon",
+            "name": "West's Oregon Revised Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "P.R. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 P.R. Laws 8"
+            ],
+            "jurisdiction": "Puerto Rico",
+            "name": "Laws of Puerto Rico",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "P.R. Laws Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "P.R. Laws Ann. tit. 326, § 352-04:737"
+            ],
+            "jurisdiction": "Puerto Rico",
+            "name": "Laws of Puerto Rico Annotated (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "P.R. Leyes": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 P.R. Leyes 0"
+            ],
+            "jurisdiction": "Puerto Rico",
+            "name": "Leyes de Puerto Rico (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "P.R. Leyes An.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "P.R. Leyes An. tit. 861, § 47.8-6"
+            ],
+            "jurisdiction": "Puerto Rico",
+            "name": "Leyes de Puerto Rico Anotadas (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Pa. Bull.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "52 Pa. Bull. 5"
+            ],
+            "jurisdiction": "Pennsylvania",
+            "name": "Pennsylvania Bulletin (Fry Communications)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Pa. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "92 Pa. Code § 7:97"
+            ],
+            "jurisdiction": "Pennsylvania",
+            "name": "Pennsylvania Code (Fry Communications)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Pa. Cons. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "1 Pa. Cons. Stat. § 229:08"
+            ],
+            "jurisdiction": "Pennsylvania",
+            "name": "Pennsylvania Consolidated Statutes",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Pa. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Pa. Laws 9825"
+            ],
+            "jurisdiction": "Pennsylvania",
+            "name": "Laws of Pennsylvania",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Pa. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Pa. Legis. Serv. 9"
+            ],
+            "jurisdiction": "Pennsylvania",
+            "name": "Purdon's Pennsylvania Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Pa. Stat. and Cons. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "8 Pa. Stat. and Cons. Stat. Ann. § 3"
+            ],
+            "jurisdiction": "Pennsylvania",
+            "name": "Purdon's Pennsylvania Statutes and Consolidated Statutes Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "R.I. Acts & Resolves": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 R.I. Acts & Resolves 7"
+            ],
+            "jurisdiction": "Rhode Island",
+            "name": "Acts and Resolves of Rhode Island and Providence Plantations",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "R.I. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-364 R.I. Adv. Legis. Serv. 3"
+            ],
+            "jurisdiction": "Rhode Island",
+            "name": "Rhode Island Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        },
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 R.I. Adv. Legis. Serv. 6479"
+            ],
+            "jurisdiction": "Rhode Island",
+            "name": "West's Rhode Island Advance Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "R.I. Code R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "831-537 R.I. Code R. § 28.72:41"
+            ],
+            "jurisdiction": "Rhode Island",
+            "name": "Code of Rhode Island Rules (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+)\\-(?P<chapter>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "R.I. Gen. Laws": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "0 R.I. Gen. Laws § 56"
+            ],
+            "jurisdiction": "Rhode Island",
+            "name": "General Laws of Rhode Island (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "R.I. Gen. Laws Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "296 R.I. Gen. Laws Ann. § 9:6.918"
+            ],
+            "jurisdiction": "Rhode Island",
+            "name": "West's General Laws of Rhode Island Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "R.I. Gov't Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "41 R.I. Gov't Reg. 66"
+            ],
+            "jurisdiction": "Rhode Island",
+            "name": "Rhode Island Government Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "R.I. Pub. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 R.I. Pub. Laws 1577"
+            ],
+            "jurisdiction": "Rhode Island",
+            "name": "Public Laws of Rhode Island and Providence Plantations",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Repub. Tex. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Repub. Tex. Laws 2"
+            ],
+            "jurisdiction": "Texas",
+            "name": "Laws of the Republic of Texas",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "S.C. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 S.C. Acts 96"
+            ],
+            "jurisdiction": "South Carolina",
+            "name": "Acts and Joint Resolutions, South Carolina",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "S.C. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "S.C. Code Ann. § 07-903"
+            ],
+            "jurisdiction": "South Carolina",
+            "name": "Code of Laws of South Carolina 1976 Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "S.C. Code Ann. Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "S.C. Code Ann. Regs. 09"
+            ],
+            "jurisdiction": "South Carolina",
+            "name": "Code of Laws of South Carolina 1976 Annotated:Code of Regulations (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition (?P<reg>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "S.C. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "571 S.C. Reg. 3514"
+            ],
+            "jurisdiction": "South Carolina",
+            "name": "South Carolina State Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "S.D. Admin. R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "S.D. Admin. R. 4"
+            ],
+            "jurisdiction": "South Dakota",
+            "name": "Administrative Rules of South Dakota",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "S.D. Codified Laws": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "S.D. Codified Laws § 5"
+            ],
+            "jurisdiction": "South Dakota",
+            "name": "South Dakota Codified Laws (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "S.D. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "250 S.D. Reg. 8"
+            ],
+            "jurisdiction": "South Dakota",
+            "name": "South Dakota Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "S.D. Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 S.D. Sess. Laws ch\\w 12 § 40:441 03"
+            ],
+            "jurisdiction": "South Dakota",
+            "name": "Session Laws of South Dakota",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition ch\\\\. (?P<chapter>\\d+) § $law_section $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Stat.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "82 Stat. 6"
+            ],
+            "jurisdiction": "District of Columbia",
+            "name": "United States Statutes at Large",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tenn. Admin. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "81 Tenn. Admin. Reg. 211"
+            ],
+            "jurisdiction": "Tennessee",
+            "name": "Tennessee Administrative Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tenn. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Tenn. Code Ann. § 6"
+            ],
+            "jurisdiction": "Tennessee",
+            "name": "Tennessee Code Annotated (LexisNexis); West's Tennessee Code Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tenn. Code Ann. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-6 Tenn. Code Ann. Adv. Legis. Serv. 0"
+            ],
+            "jurisdiction": "Tennessee",
+            "name": "Tennessee Code Annotated Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tenn. Comp. R. & Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Tenn. Comp. R. & Regs. 522"
+            ],
+            "jurisdiction": "Tennessee",
+            "name": "Official Compilation Rules & Regulations of the State of Tennessee",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tenn. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Tenn. Legis. Serv. 7"
+            ],
+            "jurisdiction": "Tennessee",
+            "name": "West's Tennessee Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tenn. Priv. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Tenn. Priv. Acts 0"
+            ],
+            "jurisdiction": "Tennessee",
+            "name": "Private Acts of the State of Tennessee",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tenn. Pub. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Tenn. Pub. Acts 8"
+            ],
+            "jurisdiction": "Tennessee",
+            "name": "Public Acts of the State of Tennessee",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "30 Tex. Admin. Code § 162-05.0"
+            ],
+            "jurisdiction": "Texas",
+            "name": "Texas Administrative Code (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. Bus. Corp. Act Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Tex. Bus. Corp. Act Ann. art 3"
+            ],
+            "jurisdiction": "Texas",
+            "name": "Vernon's Texas Business Corporation Act Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition art (?P<article>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Tex. Empl. Code Ann. § 025:2-2"
+            ],
+            "jurisdiction": "Texas",
+            "name": "Vernon's Texas Codes Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<reporter>Tex\\. $law_subject Code Ann\\.) § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. Code Crim. Proc. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Tex. Code Crim. Proc. Ann. art 877"
+            ],
+            "jurisdiction": "Texas",
+            "name": "Vernon's Texas Code of Criminal Procedure Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition art (?P<article>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. Gen. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Tex. Gen. Laws 1"
+            ],
+            "jurisdiction": "Texas",
+            "name": "General and Special Laws of the State of Texas",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. Ins. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Tex. Ins. Code Ann. art 288"
+            ],
+            "jurisdiction": "Texas",
+            "name": "Vernon's Texas Insurance Code Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition art (?P<article>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. Prob. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Tex. Prob. Code Ann. § 02:69"
+            ],
+            "jurisdiction": "Texas",
+            "name": "Vernon's Texas Probate Code Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "4 Tex. Reg. 3"
+            ],
+            "jurisdiction": "Texas",
+            "name": "Texas Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. Rev. Civ. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Tex. Rev. Civ. Stat. Ann. art 49, § 61-64-81"
+            ],
+            "jurisdiction": "Texas",
+            "name": "Vernon's Texas Revised Civil Statutes Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition art (?P<article>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. Sess. Law Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Tex. Sess. Law Serv. 0"
+            ],
+            "jurisdiction": "Texas",
+            "name": "Vernon's Texas Session Law Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Utah Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Utah Admin. Code r. 031:409.889"
+            ],
+            "jurisdiction": "Utah",
+            "name": "Utah Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition r\\. $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Utah Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-311 Utah Adv. Legis. Serv. 6"
+            ],
+            "jurisdiction": "Utah",
+            "name": "Utah Code <year> Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Utah Bull.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "630 Utah Bull. 2"
+            ],
+            "jurisdiction": "Utah",
+            "name": "Utah State Bulletin",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Utah Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Utah Code Ann. § 506-41-9"
+            ],
+            "jurisdiction": "Utah",
+            "name": "Utah Code Annotated (LexisNexis); West's Utah Code Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Utah Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Utah Laws 545"
+            ],
+            "jurisdiction": "Utah",
+            "name": "Laws of Utah",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Utah. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Utah. Legis. Serv. 0"
+            ],
+            "jurisdiction": "Utah",
+            "name": "Utah Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "V.I. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "V.I. Code Ann. tit. 24, § 183.04:688 1999"
+            ],
+            "jurisdiction": "Virgin Islands",
+            "name": "Virgin Islands Code Annotated (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples. Indigo Book dates 1962-date.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section $law_year"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "V.I. Code Ann. Adv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-2 V.I. Code Ann. Adv."
+            ],
+            "jurisdiction": "Virgin Islands",
+            "name": "Virgin Islands Code Annotated Advance",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "V.I. Code R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "8-063 V.I. Code R. § 425:846"
+            ],
+            "jurisdiction": "Virgin Islands",
+            "name": "Code of U.S. Virgin Islands Rules (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+)\\-(?P<chapter>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "V.I. Gov't Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "69 V.I. Gov't Reg. 8548"
+            ],
+            "jurisdiction": "Virgin Islands",
+            "name": "Virgin Islands Government Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "V.I. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "V.I. Legis. Serv. 8"
+            ],
+            "jurisdiction": "Virgin Islands",
+            "name": "Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "V.I. Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 V.I. Sess. Laws 8"
+            ],
+            "jurisdiction": "Virgin Islands",
+            "name": "Session Laws of the Virgin Islands",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Va. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Va. Acts 9"
+            ],
+            "jurisdiction": "Virginia",
+            "name": "Acts of the General Assembly of the Commonwealth of Virginia",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Va. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "18 Va. Admin. Code § 79"
+            ],
+            "jurisdiction": "Virginia",
+            "name": "Virginia Administrative Code (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Va. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-258 Va. Adv. Legis. Serv. 9"
+            ],
+            "jurisdiction": "Virginia",
+            "name": "Virginia <year> Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Va. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Va. Code Ann. § 23.1:955"
+            ],
+            "jurisdiction": "Virginia",
+            "name": "Code of Virginia 1950 Annotated (LexisNexis); West's Annotated Code of Virginia",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Va. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Va. Legis. Serv. 9"
+            ],
+            "jurisdiction": "Virginia",
+            "name": "West's Virginia Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Va. Reg. Regs.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "39 Va. Reg. Regs. 3847"
+            ],
+            "jurisdiction": "Virginia",
+            "name": "Virginia Register of Regulations (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Vt. Acts & Resolves": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Vt. Acts & Resolves 2"
+            ],
+            "jurisdiction": "Vermont",
+            "name": "Acts and Resolves of Vermont",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Vt. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-547 Vt. Adv. Legis. Serv. 5"
+            ],
+            "jurisdiction": "Vermont",
+            "name": "Vermont <year> Advance Legislative Service(LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Vt. Code R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "81-597 Vt. Code R. § 238-7.8"
+            ],
+            "jurisdiction": "Vermont",
+            "name": "Code of Vermont Rules (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+)\\-(?P<chapter>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Vt. Gov't Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "34 Vt. Gov't Reg. 70,4"
+            ],
+            "jurisdiction": "Vermont",
+            "name": "Vermont Government Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Vt. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Vt. Legis. Serv. 8446"
+            ],
+            "jurisdiction": "Vermont",
+            "name": "West's Vermont Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Vt. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Vt. Stat. Ann. tit. 99, § 2"
+            ],
+            "jurisdiction": "Vermont",
+            "name": "Vermont Statutes Annotated (LexisNexis); West's Vermont Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "W. Va. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 W. Va. Acts 8"
+            ],
+            "jurisdiction": "West Virginia",
+            "name": "Acts of the Legislature of West Virginia",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "W. Va. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-52 W. Va. Adv. Legis. Serv. 18,7"
+            ],
+            "jurisdiction": "West Virginia",
+            "name": "West Virginia <year> Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "W. Va. Code": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "W. Va. Code § 4-829"
+            ],
+            "jurisdiction": "West Virginia",
+            "name": "West Virginia Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "W. Va. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "W. Va. Code Ann. § 7"
+            ],
+            "jurisdiction": "West Virginia",
+            "name": "Michie's West Virginia Code Annotated (LexisNexis); West's Annotated Code of West Virginia",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "W. Va. Code R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "W. Va. Code R. § 5:3.79"
+            ],
+            "jurisdiction": "West Virginia",
+            "name": "West Virginia Code of State Rules",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "W. Va. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 W. Va. Legis. Serv. 159"
+            ],
+            "jurisdiction": "West Virginia",
+            "name": "West's West Virginia Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "W. Va. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "1 W. Va. Reg. 8939"
+            ],
+            "jurisdiction": "West Virginia",
+            "name": "West Virginia Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wash. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Wash. Admin. Code § 6:945"
+            ],
+            "jurisdiction": "Washington",
+            "name": "Washington Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wash. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Wash. Legis. Serv. 1"
+            ],
+            "jurisdiction": "Washington",
+            "name": "West's Washington Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wash. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "07 Wash. Reg. 946"
+            ],
+            "jurisdiction": "Washington",
+            "name": "Washington State Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wash. Rev. Code": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Wash. Rev. Code § 32:7-703"
+            ],
+            "jurisdiction": "Washington",
+            "name": "Revised Code of Washington",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wash. Rev. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Wash. Rev. Code Ann. § 73"
+            ],
+            "jurisdiction": "Washington",
+            "name": "West's Revised Code of Washington Annotated; Annotated Revised Code of Washington (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wash. Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Wash. Sess. Laws 0"
+            ],
+            "jurisdiction": "Washington",
+            "name": "Session Laws of Washington",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wis. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Wis. Admin. Code SvTr § 4"
+            ],
+            "jurisdiction": "Wisconsin",
+            "name": "Wisconsin Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition (?P<agency>[A-Z][A-Za-z]+) § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wis. Admin. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "95 Wis. Admin. Reg. 0198"
+            ],
+            "jurisdiction": "Wisconsin",
+            "name": "Wisconsin Administrative Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wis. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Wis. Legis. Serv. 0"
+            ],
+            "jurisdiction": "Wisconsin",
+            "name": "West's Wisconsin Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wis. Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Wis. Sess. Laws 741"
+            ],
+            "jurisdiction": "Wisconsin",
+            "name": "Wisconsin Session Laws",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wis. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Wis. Stat. § 8-431-7"
+            ],
+            "jurisdiction": "Wisconsin",
+            "name": "Wisconsin Statutes",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wis. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Wis. Stat. Ann. § 32:6"
+            ],
+            "jurisdiction": "Wisconsin",
+            "name": "West's Wisconsin Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wyo. Code R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "6-61 Wyo. Code R. § 194"
+            ],
+            "jurisdiction": "Wyoming",
+            "name": "Code of Wyoming Rules (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+)\\-(?P<chapter>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wyo. Gov't Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "501 Wyo. Gov't Reg. 1"
+            ],
+            "jurisdiction": "Wyoming",
+            "name": "Wyoming Government Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wyo. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Wyo. Legis. Serv. 3"
+            ],
+            "jurisdiction": "Wyoming",
+            "name": "West's Wyoming Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wyo. Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Wyo. Sess. Laws 305"
+            ],
+            "jurisdiction": "Wyoming",
+            "name": "Session Laws of Wyoming",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wyo. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Wyo. Stat. Ann. § 7-505"
+            ],
+            "jurisdiction": "Wyoming",
+            "name": "Wyoming Statutes Annotated (LexisNexis); West's Wyoming Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ]
+}

--- a/reporters_db/data/regexes.json
+++ b/reporters_db/data/regexes.json
@@ -44,6 +44,18 @@
         "": "(?P<reporter>$edition)",
         "#": "Standard reporter"
     },
+    "law": {
+        "#": "Regexes used in laws.json",
+        "day": "(?P<day>\\d{1,2}),?",
+        "month": "(?P<month>[A-Z][a-z]+\\.?)",
+        "section": "(?P<section>\\d+(?:[\\-.:]\\d+){,3})",
+        "section#": "Section like 1-2-3, 1.2.3, or 1:2-3.4",
+        "subject": "(?P<subject>$law_subject_word(?: $law_subject_word| &){,4})",
+        "subject#": "One to five word statute subject like 'Parks Rec. & Hist. Preserv.', 'Not-for-Profit Corp.', 'Alt. County Gov’t', 'R.R.'",
+        "subject_word": "[A-Z][.\\-'A-Za-z]*",
+        "subject_word#": "Single word in statute subject, like Rec., Gov't, or Not-for-Profit",
+        "year": "(?P<year>1\\d{3}|20\\d{2})"
+    },
     "volume": {
         "": "(?P<volume>\\d+)",
         "#": "Standard volume number",

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -634,7 +634,7 @@
                 }
             },
             "mlz_jurisdiction": [],
-            "name": "Americans with  Disabilities Decisions",
+            "name": "Americans with Disabilities Decisions",
             "variations": {}
         }
     ],
@@ -5596,7 +5596,7 @@
                 "us:nj;supreme.court"
             ],
             "name": "Gummere's Reports",
-            "notes": "Estimated date range.  https://www.njstatelib.org/research_library/legal_resources/historical_laws/reporters/",
+            "notes": "Estimated date range. https://www.njstatelib.org/research_library/legal_resources/historical_laws/reporters/",
             "variations": {}
         }
     ],
@@ -8055,7 +8055,7 @@
                 }
             },
             "mlz_jurisdiction": [],
-            "name": "Lowell's District  Court Reports (US Mass. Dist.)",
+            "name": "Lowell's District Court Reports (US Mass. Dist.)",
             "variations": {}
         }
     ],
@@ -8125,7 +8125,7 @@
                 "us:md;circuit.court"
             ],
             "name": "Maryland Business and Technology",
-            "notes": "Appears to be a neutral citation, published but not precedential.  See url: https://mdcourts.gov/businesstech/opinions",
+            "notes": "Appears to be a neutral citation, published but not precedential. See url: https://mdcourts.gov/businesstech/opinions",
             "variations": {}
         }
     ],
@@ -10377,7 +10377,7 @@
                 }
             },
             "mlz_jurisdiction": [],
-            "name": "Newberry's  District Court Admiralty Rep. United States (US)",
+            "name": "Newberry's District Court Admiralty Rep. United States (US)",
             "variations": {}
         }
     ],
@@ -11731,7 +11731,7 @@
                 }
             },
             "mlz_jurisdiction": [],
-            "name": "Paine's United  States (US) Circuit Court Reports",
+            "name": "Paine's United States (US) Circuit Court Reports",
             "variations": {}
         }
     ],
@@ -11967,7 +11967,7 @@
                 }
             },
             "mlz_jurisdiction": [],
-            "name": "Peters' District  Court Admiralty Reports",
+            "name": "Peters' District Court Admiralty Reports",
             "variations": {}
         }
     ],
@@ -13304,7 +13304,7 @@
                 }
             },
             "mlz_jurisdiction": [],
-            "name": "Sprague's United  States (US) District Ct. (Admiralty) Decisions",
+            "name": "Sprague's United States (US) District Ct. (Admiralty) Decisions",
             "variations": {}
         }
     ],
@@ -14935,7 +14935,7 @@
                 "us:c2:ny.sd;district.court",
                 "us:c2:ny.wd;district.court"
             ],
-            "name": "Van Ness' Prize  Cases, United States (US) District Court, District of New York (NY)",
+            "name": "Van Ness' Prize Cases, United States (US) District Court, District of New York (NY)",
             "variations": {}
         }
     ],
@@ -15389,7 +15389,7 @@
                 }
             },
             "mlz_jurisdiction": [],
-            "name": "Ware's United  States (US) District Court Reports",
+            "name": "Ware's United States (US) District Court Reports",
             "variations": {}
         }
     ],

--- a/tests.py
+++ b/tests.py
@@ -4,6 +4,8 @@ import re
 import datetime
 from difflib import context_diff
 from pathlib import Path
+from string import Template
+
 import six
 from reporters_db import (
     REPORTERS,
@@ -11,6 +13,7 @@ from reporters_db import (
     EDITIONS,
     NAMES_TO_EDITIONS,
     REGEX_VARIABLES,
+    LAWS,
 )
 from unittest import TestCase
 
@@ -62,7 +65,125 @@ def iter_editions():
             yield edition_abbv, edition
 
 
-class ConstantsTest(TestCase):
+class BaseTestCase(TestCase):
+    def check_regexes(self, regexes, examples):
+        """Check that each regex matches at least one example, and each example matches at least one regex.
+        regexes should be a list of [(regex_template, regex)]."""
+        matched_examples = set()
+
+        # check that each regex matches at least one example
+        for regex_template, regex in regexes:
+            has_match = False
+            for example in examples:
+                if re.match(regex + "$", example):
+                    has_match = True
+                    matched_examples.add(example)
+            if not has_match:
+                try:
+                    import exrex
+
+                    candidate = "Possible examples: %s" % [
+                        exrex.getone(regex, limit=3) for _ in range(10)
+                    ]
+                except ImportError:
+                    candidate = "Run 'pip install exrex' to generate a candidate example"
+                self.fail(
+                    "No match in 'examples' for custom regex '%s'.\n"
+                    "Expanded regex: %s.\n"
+                    "Provided examples: %s.\n"
+                    "%s"
+                    % (
+                        regex_template,
+                        regex,
+                        examples,
+                        candidate,
+                    )
+                )
+
+        # check that each example is matched by at least one regex
+        self.assertEqual(
+            set(examples),
+            matched_examples,
+            "Not all examples matched. If custom regexes are provided, all examples should match."
+            "Unmatched examples: %s. Regexes tried: %s"
+            % (set(examples) - matched_examples, regexes),
+        )
+
+    def check_json_format(self, file_name):
+        """Does format of json file match json.dumps(json.loads(), sort_keys=True)?"""
+        json_path = Path(__file__).parent / "reporters_db" / "data" / file_name
+        json_str = json_path.read_text()
+        reformatted = json.dumps(
+            json.loads(json_str),
+            indent=4,
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+        reformatted += "\n"
+        if json_str != reformatted:
+            if os.environ.get("FIX_JSON"):
+                json_path.write_text(reformatted)
+            else:
+                diff = context_diff(
+                    json_str.splitlines(),
+                    reformatted.splitlines(),
+                    fromfile="reporters.json",
+                    tofile="expected.json",
+                )
+                self.fail(
+                    ("%s needs reformatting. " % file_name)
+                    + "Run with env var FIX_JSON=1 to update the file automatically. "
+                    + "Diff of actual vs. expected:\n"
+                    + "\n".join(diff)
+                )
+
+    def check_dates(self, start, end):
+        """Check that start and end dates are valid."""
+        if start is not None:
+            self.assertTrue(
+                isinstance(start, datetime.datetime),
+                f"{repr(start)} should be imported as a date.",
+            )
+        if end is not None:
+            self.assertTrue(
+                isinstance(end, datetime.datetime),
+                f"{repr(end)} should be imported as a date.",
+            )
+        if start is not None and end is not None:
+            self.assertLessEqual(start, end)
+
+    def check_ascii(self, obj):
+        """Check that all strings in obj match a list of expected ascii characters."""
+        allowed_chars = r"[ 0-9a-zA-Z.,\-'&(){}\[\]\\$§_?<>+:/]"
+        for s in emit_strings(obj):
+            remaining_chars = re.sub(allowed_chars, "", s)
+            self.assertFalse(
+                remaining_chars,
+                f"Unexpected characters in {repr(s)}: {repr(remaining_chars)}.",
+            )
+
+    def check_whitespace(self, obj):
+        for s in emit_strings(obj):
+            self.assertEqual(
+                s.strip(), s, msg="Field needs whitespace stripped: '%s'" % s
+            )
+            non_space_whitespace = any(w != " " for w in re.findall(r"\s+", s))
+            self.assertFalse(
+                non_space_whitespace,
+                f"Field has unexpected whitespace: {repr(s)}",
+            )
+
+
+class RegexesTest(BaseTestCase):
+    """Tests for regexes.json"""
+
+    def text_json_format(self):
+        self.check_json_format("regexes.json")
+
+
+class ReportersTest(BaseTestCase):
+    """Tests for reporters.json"""
+
     def test_any_keys_missing_editions(self):
         """Have we added any new reporters that lack a matching edition?"""
         for reporter_abbv, reporter_list, reporter_data in iter_reporters():
@@ -98,37 +219,11 @@ class ConstantsTest(TestCase):
             NAMES_TO_EDITIONS["Illinois Appellate Court Reports"],
         )
 
-    def test_that_all_dates_are_converted_to_dates_not_strings(self):
+    def test_dates(self):
         """Do we properly make the ISO-8601 date strings into Python dates?"""
         # for reporter_abbv, reporter_list, reporter_data in iter_reporters():
-        for e_name, e_dates in iter_editions():
-            # e_name == "A. 2d"
-            # e_dates == {
-            #     "end": "1938-12-31T00:00:00",
-            #     "start": "1885-01-01T00:00:00"
-            # }
-            for key in ["start", "end"]:
-                is_date_or_none = (
-                    isinstance(e_dates[key], datetime.datetime)
-                    or e_dates[key] is None
-                )
-                self.assertTrue(
-                    is_date_or_none,
-                    msg=(
-                        "%s dates in the reporter '%s' appear to be "
-                        "coming through as '%s'"
-                        % (key, e_name, type(e_dates[key]))
-                    ),
-                )
-                if key == "start":
-                    start_is_not_none = e_dates[key] is not None
-                    self.assertTrue(
-                        start_is_not_none,
-                        msg=(
-                            "Start date in reporter '%s' appears to "
-                            "be None, not 1750" % e_name
-                        ),
-                    )
+        for edition_name, edition in iter_editions():
+            self.check_dates(edition["start"], edition["end"])
 
     def test_all_reporters_have_valid_cite_type(self):
         """Do all reporters have valid cite_type values?"""
@@ -203,138 +298,89 @@ class ConstantsTest(TestCase):
                 )
 
     def test_fields_tidy(self):
-        """Do fields have any messiness?
-
-        For example:
-         - some punctuation is not allowed in some keys
-         - spaces at beginning/end not allowed
-        """
-
-        def cleaner(s):
-            return re.sub(r"[^ 0-9a-zA-Z.,\-'&()\[\]]", "", s.strip())
-
-        msg = "Got bad punctuation in: %s"
+        """Check that fields don't have unexpected characters or whitespace."""
         for reporter_abbv, reporter_list, reporter_data in iter_reporters():
-            self.assertEqual(
-                reporter_abbv, cleaner(reporter_abbv), msg=msg % reporter_abbv
-            )
-            for k in reporter_data["editions"].keys():
-                self.assertEqual(cleaner(k), k, msg=msg % k)
-            for k, v in reporter_data["variations"].items():
-                self.assertEqual(cleaner(k), k, msg=msg % k)
-                self.assertEqual(cleaner(v), v, msg=msg % v)
+            self.check_ascii(reporter_abbv)
+            self.check_ascii(list(reporter_data["editions"].keys()))
+            self.check_ascii(reporter_data["variations"])
 
-        for s in emit_strings(REPORTERS):
-            self.assertEqual(
-                s.strip(), s, msg="Fields needs whitespace stripped: '%s'" % s
-            )
-
-    def test_nothing_ends_before_it_starts(self):
-        """Do any editions have end dates before their start dates?"""
-        for k, edition in iter_editions():
-            if edition["start"] and edition["end"]:
-                self.assertLessEqual(
-                    edition["start"],
-                    edition["end"],
-                    msg="It appears that edition %s ends before it "
-                    "starts." % k,
-                )
-
-    def test_json_format(self):
-        """Does format of reporters.json match json.dumps(json.loads(), sort_keys=True)?"""
-        for file_name in ("reporters.json", "regexes.json"):
-            with self.subTest(file_name=file_name):
-                json_path = (
-                    Path(__file__).parent / "reporters_db" / "data" / file_name
-                )
-                json_str = json_path.read_text()
-                reformatted = json.dumps(
-                    json.loads(json_str),
-                    indent=4,
-                    ensure_ascii=False,
-                    sort_keys=True,
-                )
-                reformatted += "\n"
-                if json_str != reformatted:
-                    if os.environ.get("FIX_JSON"):
-                        json_path.write_text(reformatted)
-                    else:
-                        diff = context_diff(
-                            json_str.splitlines(),
-                            reformatted.splitlines(),
-                            fromfile="reporters.json",
-                            tofile="expected.json",
-                        )
-                        self.fail(
-                            ("%s needs reformatting. " % file_name)
-                            + "Run with env var FIX_JSON=1 to update the file automatically. "
-                            + "Diff of actual vs. expected:\n"
-                            + "\n".join(diff)
-                        )
+        self.check_whitespace(REPORTERS)
 
     def test_regexes(self):
         """Do custom regexes and examples match up?"""
         for reporter_abbv, reporter_list, reporter_data in iter_reporters():
-            examples = reporter_data.get("examples", [])
-            matched_examples = set()
-            custom_regexes = {}
 
-            # check that each custom regex matches at least one example
+            # get list of expanded regexes and examples for this reporter
+            examples = reporter_data.get("examples", [])
+            regexes = []
             for edition_abbv, edition in reporter_data["editions"].items():
                 if not edition.get("regexes"):
                     continue
-                with self.subTest(
-                    "Check edition regexes", edition=edition_abbv
-                ):
-                    for edition_regex in edition["regexes"]:
-                        full_regex = recursive_substitute(
-                            edition_regex, REGEX_VARIABLES
-                        )
-                        regexes = substitute_editions(
-                            full_regex,
-                            edition_abbv,
-                            reporter_data["variations"],
-                        )
-                        custom_regexes[edition_regex] = regexes
-                        has_match = False
-                        for example in examples:
-                            for regex in regexes:
-                                if re.match(regex + "$", example):
-                                    has_match = True
-                                    matched_examples.add(example)
-                                    break
-                        if not has_match:
-                            try:
-                                import exrex
-
-                                candidate = "Possible examples: %s" % [
-                                    exrex.getone(regexes[0], limit=3)
-                                    for _ in range(10)
-                                ]
-                            except ImportError:
-                                candidate = "Run 'pip install exrex' to generate a candidate example"
-                            self.fail(
-                                "Reporter '%s' has no match in 'examples' for custom regex '%s'.\nExpanded regexes: %s.\n%s"
-                                % (
-                                    reporter_abbv,
-                                    edition_regex,
-                                    regexes,
-                                    candidate,
-                                )
-                            )
-
-            # check that each example is matched by at least one regex
-            if custom_regexes:
-                with self.subTest(
-                    "Check all examples matched by custom regex",
-                    reporter=reporter_abbv,
-                ):
-                    self.assertEqual(
-                        set(examples),
-                        matched_examples,
-                        "Not all examples matched. If custom regexes are provided, all examples should match. Regexes tried: %s"
-                        % custom_regexes,
+                for regex_template in edition["regexes"]:
+                    edition_strings = [edition_abbv] + [
+                        k
+                        for k, v in reporter_data["variations"].items()
+                        if v == edition_abbv
+                    ]
+                    regex = recursive_substitute(
+                        regex_template, REGEX_VARIABLES
                     )
+                    regex = Template(regex).safe_substitute(
+                        edition="(?:%s)"
+                        % "|".join(re.escape(e) for e in edition_strings)
+                    )
+                    regexes.append((regex_template, regex))
+
+            if not regexes:
+                continue
+
+            with self.subTest(
+                "Check reporter regexes", reporter=reporter_abbv
+            ):
+                self.check_regexes(regexes, examples)
+
+    def text_json_format(self):
+        self.check_json_format("reporters.json")
+
+
+class LawsTest(BaseTestCase):
+    """Tests for laws.json"""
+
+    @staticmethod
+    def iter_laws():
+        for law_key, law_list in LAWS.items():
+            yield from ((law_key, law) for law in law_list)
+
+    def test_regexes(self):
+        """Do custom regexes and examples match up?"""
+        for law_key, law in self.iter_laws():
+            regexes = []
+            # expand regex and substitute $edition value
+            series_strings = [law_key] + law["variations"]
+            for regex_template in law["regexes"]:
+                regex = recursive_substitute(regex_template, REGEX_VARIABLES)
+                regex = Template(regex).safe_substitute(
+                    edition="(?:%s)"
+                    % "|".join(re.escape(e) for e in series_strings)
+                )
+                regexes.append((regex_template, regex))
+            with self.subTest("Check law regexes", name=law["name"]):
+                self.check_regexes(regexes, law["examples"])
+
+    def text_json_format(self):
+        self.check_json_format("laws.json")
+
+    def test_dates(self):
+        for law_key, law in self.iter_laws():
+            self.check_dates(law["start"], law["end"])
+
+    def test_fields_tidy(self):
+        """Check that fields don't have unexpected characters or whitespace."""
+        for law_key, law in self.iter_laws():
+            self.check_ascii(law["regexes"])
+            self.check_ascii(law["examples"])
+
+        self.check_whitespace(REPORTERS)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Here's a first pass at adding `laws.json` based on the state-by-state rules from the [Indigo Book](https://law.resource.org/pub/us/code/blue/IndigoBook.html#T3). Offering for discussion!

See below for the full file, but this initial proposal is basically a few hundred entries that look like this:

```
    {
        "cite_type": "leg_statute",
        "end": null,
        "examples": [
            "Ala. Code § 92.979 (1999)"
        ],
        "jurisdiction": "Alabama",
        "name": "Code of Alabama, 1975 (West)",
        "notes": "Automatically generated on 2021-04-30. Remove this message if replacing with real examples.",
        "regexes": [
            "Ala\\. Code § $statute_section \\($statute_year\\)"
        ],
        "start": null
    }
```

Open questions:

* Do we like putting all the non-court legislative and executive stuff in "laws.json"?
* Top level structure: this is a list of dicts, with no top-level keys. It could have a structure like `jurisdiction` or `jurisdiction -> cite_type` or something else? Is there anything analogous to the reporters.json structure that's useful here?
* JSON keys:
  * `cite_type`: currently has this totally arbitrary mapping from the Indigo Book categories:
    ```
    "Statutory compilation": "leg_statute",
    "Session laws": "leg_session",
    "Uncompiled law": "leg_act",
    "Administrative compilation": "admin_compilation",
    "Administrative register": "admin_register",
    "Administrative and executive register": "admin_register",
    "Municipal regulations": "municipal",
    ```
  * `start` and `end`: currently `null`. I'm not interpreting the occasional date ranges from the Indigo Book as being restrictive, since those might just be the preferred citation date range, so only adding them to the notes field. Probably valid date ranges are still useful though?
  * `jurisdiction`: currently the full state name, rather than e.g. an `mlz_jurisdiction` value.
  * `regexes` and `examples`: should work the same way as reporters.json, with placeholders from regexes.json. There's nothing analogous to `$edition` substitution, so each entry results in one regex. Examples are automatically generated for now.
  * Missing fields?
* Choices in converting citation forms to regular expressions:
  * Here's the substitutions I made to generate the regular expressions, followed by some thoughts:
  ```
    # agency/subject/department-name
    "<agency abbreviation>": r"(?P<agency>\w+)",  # wisconsin agency
    "<subject>": "$statute_subject",
    "<Subject>": "$statute_subject",
    "<law>": "$statute_subject",
    "<dep't name as abbreviated in Rules>": "$statute_subject",

    # title/article/chapter/number/page/volume/...
    "tit. x": r"tit\. (?P<title>\d+)",
    "art. x": r"art (?P<article>\d+)",
    "ch. x,": r"ch\. (?P<chapter>\d+),",
    "x-x-x Me.": r"(?P<chapter>\d+-\d+-\d+) Me\.",
    "x-x-x Del.": r"(?P<chapter>\d+-\d+-\d+) Del\.",
    "x-x-x Ark.": r"(?P<chapter>\d+-\d+-\d+) Ark\.",
    "<ch. x § x>": r"ch\\. (?P<chapter>\d+) § $statute_section",
    "<ch. no.>": r"(?P<chapter>\d+)",
    "<page no.>": "$page_with_commas",
    "<vol. no.>": "$volume",
    "<pamph. no.>": r"(?P<pamphlet>\d+)",
    "<tit. no.>": r"(?P<title>\d+)",
    "<act no.>": r"(?P<act>\d+)",
    "<iss. no.>": r"(?P<issue>\d+)",
    "<law no.>": r"(?P<law>\d+)",
    "<rule no.>": r"(?P<rule>\d+)",
    "<reg. no.>": r"(?P<reg>\d+)",
    "<reg no.>": r"(?P<reg>\d+)",
    "No. x": r"No\. (?P<number>\d+)",

    # section
    "§ x:x-x.x": "§ $statute_section",
    "§ x:x-x-x": "§ $statute_section",
    "§ x.x.x.x": "§ $statute_section",
    "§ x-x-x-x": "§ $statute_section",
    "§ x.x.x": "§ $statute_section",
    "§ x-x-x": "§ $statute_section",
    "§ x-x.x": "§ $statute_section",
    "§ x.x": "§ $statute_section",
    "§ x-x": "§ $statute_section",
    "§ x:x": "§ $statute_section",
    "§ x": "§ $statute_section",
    "Regs. x-x-x.x": r"Regs\. $statute_section",
    "r. x-x-x.x": r"r\. $statute_section",
    "r. x.x.x.x": r"r\. $statute_section",
    "r. x-x.x": r"r\. $statute_section",
    "r. x-x-x": r"r\. $statute_section",
    "r. x.x": "r. $statute_section",
    "<sec. no.>": "$statute_section",

    # dates
    "<year>": "$statute_year",
    "<month year>": "$statute_month $statute_year",
    "<month day, year>": "$statute_month $statute_day $statute_year",
    ```
  * Thoughts:
    * There isn't consistency in capture group naming here like "volume", "reporter", "year" that we have in reporters.json. I'm not sure how these want to be used downstream, but maybe there could be more consolidated naming for groups like number, reg, rule, law, issue, act, title, pamphlet.
    * I didn't match all the `section` groups with their own pattern, but used one pattern with up to four digit groups separated by one of `:-.`.
    * I didn't look into whether all of these that say `\d` are actually `\d`. Acts could be roman numerals, for example; others could have commas or other formatting. I'm thinking when we get this running we could then do a report for regexes that have the fewest matches and see what's broken.

Known incomplete in this demo, but could be fixed before pulling or done later:

* No imports or helpers yet, just the raw json.
* No tests yet (e.g. to ensure regexes match).
* No federal law yet. This is just the state-level data from section T3.