### PR TITLE
Ingest journals spreadsheet

### DIFF
--- a/reporters_db/__init__.py
+++ b/reporters_db/__init__.py
@@ -34,6 +34,10 @@ with open(os.path.join(db_root, "data", "laws.json")) as f:
     LAWS = json.load(f, object_hook=datetime_parser)
 
 
+with open(os.path.join(db_root, "data", "journals.json")) as f:
+    JOURNALS = json.load(f, object_hook=datetime_parser)
+
+
 with open(os.path.join(db_root, "data", "regexes.json")) as f:
     RAW_REGEX_VARIABLES = json.load(f)
     REGEX_VARIABLES = process_variables(RAW_REGEX_VARIABLES)

--- a/reporters_db/__init__.py
+++ b/reporters_db/__init__.py
@@ -1,7 +1,6 @@
 import datetime
 import json
 import os
-import six
 from .utils import (
     suck_out_editions,
     names_to_abbreviations,
@@ -11,14 +10,10 @@ from .utils import (
 )
 
 
-# noinspection PyBroadException
 def datetime_parser(dct):
     for k, v in dct.items():
-        if isinstance(v, six.string_types):
-            try:
-                dct[k] = datetime.datetime.strptime(v, "%Y-%m-%dT%H:%M:%S")
-            except:
-                pass
+        if k in ("start", "end") and v is not None:
+            dct[k] = datetime.datetime.strptime(v, "%Y-%m-%dT%H:%M:%S")
     return dct
 
 
@@ -33,6 +28,10 @@ with open(os.path.join(db_root, "data", "state_abbreviations.json")) as f:
 
 with open(os.path.join(db_root, "data", "case_name_abbreviations.json")) as f:
     CASE_NAME_ABBREVIATIONS = json.load(f)
+
+
+with open(os.path.join(db_root, "data", "laws.json")) as f:
+    LAWS = json.load(f, object_hook=datetime_parser)
 
 
 with open(os.path.join(db_root, "data", "regexes.json")) as f:

--- a/reporters_db/data/journals.json
+++ b/reporters_db/data/journals.json
@@ -1,0 +1,9584 @@
+{
+    "A.B.A. J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "ABA Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "A.F. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Air Force Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "AIDS L. & Litig. Rep.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "AIDS Law & Litigation Reporter",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "AIPLA Q.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "American Intellectual Property Law Association Quarterly",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Adel. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Adelaide Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Admin. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Administrative Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Admin. L. Rev. Am. U.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Administrative Law Review of American University",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Admin. L.3d": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Administrative Law Third Series for Federal Contractors",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Aff. Action Compl. Man.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Affirmative Action Compliance Manual for Federal Contractors",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Akron L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Akron Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Akron Tax J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Akron Tax Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ala. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Alabama Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Alaska L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Alaska Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Alb. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Albany Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Alb. L.J. Sci. & Tech.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Albany Law Journal of Science and Technology",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "All St. Tax Guide": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "All States Tax Guide",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Am. B. Found. Res. J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "American Bar Foundation Research Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Am. Bankr. Inst. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "American Bankruptcy Institute Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Am. Bankr. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "American Bankruptcy Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Am. Bus. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "American Business Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Am. Crim. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "American Criminal Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Am. I. Int'l L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "American Journal of International Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Am. Indian L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "American Indian Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Am. J. Comp. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "American Journal of Comparative Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Am. J. Crim. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "American Journal of Criminal Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Am. J. Juris.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "American Journal of Jurisprudence",
+            "notes": "Published by Notre Dame Law School",
+            "regexes": [],
+            "start": "1969-01-01T00:00:00",
+            "variations": {
+                "Am. J. Jurispr": "Am. J. Juris.",
+                "Am. J. Jurisprud": "Am. J. Juris."
+            }
+        }
+    ],
+    "Am. J. Legal Hist.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "American Journal of Legal History",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Am. J. Trial Advoc.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "American Journal of Trial Advocacy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Am. J.L. & Med.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "American Journal of Law & Medicine",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Am. Rev. Int'l Arb.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "American Review of International Arbitration",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Am. Soc'y Int'l L. Proc.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "American Society of International Law Proceedings",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Am. Stock Ex. Guide": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "American Stock Exchange Guide",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Am. U. Int'l L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "American University International Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Am. U. J. Gender Soc. Pol'y & L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "American University Journal of Gender, Social Policy and the Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Am. U. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "American University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Anglo-Am. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Anglo-American Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ann. Rev. Banking & Fin. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Annual Review of Banking & Financial law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ann. Rev. Banking L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Annual Review of Banking Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ann. Surv. Am. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Annual Survey of American Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ann. Surv. Int'l & Comp. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Annual Survey of International and Comparative Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Annals Am. Acad. Pol. & Soc. Sci.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Annals of the American Academy of Political and Social Science",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Annals Health L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Annals of Health Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Antitrust & Trade Reg. Rep.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Antitrust & Trade Regulation Report",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ariz. J. Int'l & Comp. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Arizona Journal of International and Comparative Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ariz. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Arizona Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ariz. St. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Arizona State Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ark. L. Notes": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Arkansas Law Notes",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ark. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Arkansas Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Army Law.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Army Lawyer",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Asian Am. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Asian American Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Asian Pac. Am. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Asian Pacific American Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Asian-Pac. L. & Pol'y J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Asian-Pacific Law and Policy Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Auckland U. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Auckland University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Av. L. Rep.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Aviation Law Reporter",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ave Maria L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Ave Maria Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "B. Examiner": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "The Bar Examiner",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "B.C. Envtl. Aff. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Boston College Environmental Affairs Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "B.C. Int'l & Comp. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Boston College International and Comparative Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "B.C. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Boston College Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "B.C. Third World L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Boston College Third World Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "B.U. Int'l L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Boston University International Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "B.U. J. Sci. & Tech. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Boston University Journal of Science & Technology Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "B.U. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Boston University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "B.U. Pub. Int. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Boston University Public Interest Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "BYU Educ. & L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Brigham Young University Education and Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "BYU J. Pub. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Brigham Young University Journal of Public Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "BYU L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Brigham Young University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Bankr. Dev. J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Bankruptcy Developments Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Baylor L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Baylor Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Behav. Sci. & L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Behavioral Sciences and the Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Berkeley J. Afr.-Am. L. & Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Berkeley Journal of African-American Law & Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Berkeley J. Emp. & Lab. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Berkeley Journal of Employment and Labor Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Berkeley J. Int'l L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Berkeley Journal of International Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Berkeley Tech. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Berkeley Technology Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Berkeley Women's L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Berkeley Women's Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "BioLaw (LexisNexis)": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "BioLaw",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Brandeis L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Brandeis Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Briefcase": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Briefcase",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Brook. J. Int'l L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Brooklyn Journal of International Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Brook. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Brooklyn Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Buff. Crim. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Buffalo Criminal Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Buff. Envtl. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Buffalo Environmental Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Buff. Hum. Rts. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Buffalo Human Rights Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Buff. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Buffalo Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Buff. Pub. Int. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Buffalo Public Interest Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Buff. Women's L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Buffalo Women's Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Bus. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Business Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cal. Bankr. J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "California Bankruptcy Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cal. Crim. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "California Criminal Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cal. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Southern California Law Review &",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cal. Reg. L. Rep.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "California Regulatory Law Reporter",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cal. St. B.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "California State Bar Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cal. W. Int'l L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "California Western International Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cal. W. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "California Western Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Calif. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "California Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cambridge L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Cambridge Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Campbell L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Campbell Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Can.-U.S. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Canada-United States Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cap. Def. Dig.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Capital Defense Digest",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cap. Def. J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Capital Defense Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cap. U. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Capital University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cardozo Arts & Ent. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Cardozo Arts & Entertainment Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cardozo J. Conflict Resol.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Cardozo Journal of Conflict Resolution",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cardozo J. lnt'l & Comp. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Cardozo Journal of International and Comparative Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cardozo L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Cardozo Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cardozo Online J. Conflict Resol.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Cardozo Online Journal of Conflict Resolution",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cardozo Women's L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Cardozo Women's Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Carolina Alumni Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Carolina Alumni Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Case W. Res. J. Int'l L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Case Western Reserve Journal of International Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Case W. Res. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Case Western Reserve Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cath. Law.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Catholic Lawyer",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cath. U. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Catholic University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Chap. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Chapman Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Chi. J. Int'l L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Chicago Journal of International Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Chi.-Kent L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Chicago-Kent Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Chicano-Latino L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Chicano-Latino Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Child. Legal Rts. J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Children's Legal Rights Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Chron. Higher Educ.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Chronicle of Higher Education",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Clearinghouse Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Clearinghouse Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Clev. St. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Cleveland State Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Clev.-Marshall L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Cleveland-Marshall Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Clinical L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Clinical Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colo. J. Int'l Envtl. L. & Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Colorado Journal of International Environmental Law and Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colo. Law.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Colorado Lawyer",
+            "regexes": [],
+            "start": null,
+            "variations": {
+                "Colorado Law.": "Colo. Law."
+            }
+        }
+    ],
+    "Colum. Bus. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Columbia Business Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colum. Hum. Rts. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Columbia Human Rights Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colum. J. Asian L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Columbia Journal of Asian Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colum. J. E. Eur. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Columbia Journal of East European Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colum. J. Envtl. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Columbia Journal of Environmental law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colum. J. Gender & L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Columbia Journal of Gender and Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colum. J. Of Eur. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Columbia Journal of European Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colum. J. Transnat'l L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Columbia Journal of Transnational Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colum. J.L. & Arts": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Columbia Journal of Law & the Arts",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colum. J.L. & Soc. Probs.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Columbia Journal of Law and Social Problems",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colum. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Columbia Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colum. Sci. & Tech. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Columbia Science and Technology Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colum.-VLA J.L. & Arts": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Columbia-VLA journal of Law & the Arts",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "CommLaw Conspectus": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "CommLaw Conspectus: Journal of Communications Law & Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Common Mkt. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Common Market Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Comp. Lab. L. & Pol'y J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Comparative Labor Law & Policy journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Comp. Lab. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Comparative Labor Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Computer L. Rev. & Tech J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Computer Law Review & Technology Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Computer/L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Computer/Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cong. Dig.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Congressional Digest",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Conn. Ins. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Connecticut Insurance Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Conn. J. Int'l L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Connecticut Journal of International Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Conn. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Connecticut Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Conn. Prob. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Connecticut Probate Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Const. Comment.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Constitutional Commentary",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Consumer Fin. L. Q. Rep.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Consumer Finance Law Quarterly Report",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Conv. & Prop. Law. (n.s.)": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Conveyancer and Property Lawyer (new series)",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Copyright L. Symp. (ASCAP)": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Copyright Law Symposium (American Society of Composers, Authors, & Publishers",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cornell Int'l L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Cornell International Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cornell J.L. & Pub. Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Cornell Journal of Law and Public Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cornell L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Cornell Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Corp. Tax'n": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Corporate Taxation",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Creighton L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Creighton Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Crim. Just.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Criminal Justice",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Crim. Just. Ethics": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Criminal Justice Ethics",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Crim. L. Bull.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Criminal Law Bulletin",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Crim. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Criminal Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Crim. L.F.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Criminal Law Forum",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Crime, L. & Soc. Change": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Crime, Law and Social Change",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cumb. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Cumberland Law Review",
+            "regexes": [],
+            "start": null,
+            "variations": {}
+        }
+    ],
+    "Current Med. for Att'ys": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Current Medicine for Attorneys",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Currents: Int'l Trad L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Currents: The International Trade Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "D.C. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "District of Columbia Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Dalhousie L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Dalhousie Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "DePaul Bus. & Com. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "DePaul Business & Commercial Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "DePaul Bus. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "DePaul Business Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "DePaul J. Health Care L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "DePaul Journal of Health Care Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "DePaul L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "DePaul Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Def. Couns. J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Defense Counsel Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Del. J. Corp. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Delaware Journal of Corporate Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Del. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Delaware Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Denv. J. Int'l L. & Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Denver Journal of International Law and Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Denv. U. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Denver University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Dep't St. Bull.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Department of State Bulletin",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Depaul-LCA J. Art & Ent. L. & Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "DePaul-LCA Journal of Art and Entertainment Law and Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Dick. Int'l L. Ann.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Dickinson International Law Annual",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Dick. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Dickinson Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Digest": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "The Digest: The National Italian-American Bar Ass'n Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Drake J. Agric. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Drake Journal of Agricultural Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Drake L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Drake Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Drexel L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Drexel Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Duke J. Comp. & Int'l L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Duke Journal of Comparative & International Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Duke J. Const. L. & Pub. Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Duke Journal of Constitutional Law & Public Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Duke J. Gender L. & Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Duke Journal of Gender Law & Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Duke L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Duke Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Duq. Bus. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Duquesne Business Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Duq. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Duquesne Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Dydke Envtl. L. & Pol'y F.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Duke Environmental Law & Policy Forum",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ecology L.Q.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Ecology Law Quarterly",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Economist": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "The Economist",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Elder L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Elder Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Emory Bankr. Dev. J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Emory Bankruptcy Developments Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Emory Int'l L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Emory International Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Emory L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Emory Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Emp. Rts. & Emp. Pol'y J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Employee Rights and Employment Policy Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Empl. Testing (Univ. Pub. Am.)": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Employment Testing: Law & Policy Reporter",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Energy L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Energy Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Envtl. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Environmental Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Envtl. Law.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Environmental Lawyer",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Est. Plan.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Estate Planning",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Eur. H.R. Rep.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "European Human Rights Reports",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "F.B.I.S.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Foreign Broadcast Information Service",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "FIU L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Florida International University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fam. & Conciliation Cts. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Family and Conciliation Courts Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fam. Ct. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Family Court Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fam. L.Q.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Family Law Quarterly",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fed. Cir. B.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Federal Circuit Bar Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fed. Comm. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Federal Communications Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fed. Probation": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Federal Probation",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fed. Sent'g Rep.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Federal Sentencing Reporter",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fla. B.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Florida Bar Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fla. J. Int'l L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Florida Journal of International Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fla. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Florida Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fla. St. J. Transnat'l L. & Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Florida State Journal of Transnational Law & Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fla. St. U. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Florida State University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fla. Tax Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Florida Tax Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Food & Drug L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Food and Drug Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Food Drug Cosm. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Food Drug Cosmetic Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fordham Envtl. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Fordham Environmental Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fordham Int'l L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Fordham International Law journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fordham Intell. Prop. Media & Ent. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Fordham Intellectual Property, Media & Entertainment Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fordham J. Corp. & Fin. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Fordham Journal of Corporate & Financial Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fordham L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Fordham Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fordham Urb. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Fordham Urban Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Franchise L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Franchise Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ga. J. Int'l & Comp. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Georgia Journal of International and Comparative Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ga. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Georgia Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ga. St. U. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Georgia State University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Geendale L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Glendale Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Geo. Immigr. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Georgetown Immigration Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Geo. Int'l Envtl. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Georgetown International Environmental Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Geo. J. Gender & L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "The Georgetown Journal of Gender and the Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Geo. J. Int'l L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Georgetown Journal of International Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Geo. J. Legal Ethics": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Georgetown Journal of Legal Ethics",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Geo. J. on Poverty L. & Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Georgetown Journal on Poverty Law and Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Geo. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Georgetown Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Geo. Mason L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "George Mason Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Geo. Mason U. C.R. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "George Mason University Civil Rights Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Geo. Wash. Int'l L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "George Washington International Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Geo. Wash. J. Int'l L. & Econ.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "George Washington Journal of International Law and Economics",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Geo. Wash. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "George Washington Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "German L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "German Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Golden Gate U. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Golden Gate University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Gonz. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Gonzaga Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Great Plains Nat. Resources J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Great Plains Natural Resources Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Green Bag": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Green Bag",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Green Bag 2d": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Green Bag 2d",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Green Bag Alm.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Green Bag Almanac",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Guild Prac.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Guild Practitioner",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Hamline J. Pub. L. & Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Hamline Journal of Public Law and Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Hamline L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Hamline Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Harv. C.R.-C.L. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Harvard Civil Rights-Civil Liberties Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Harv. Envtl. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Harvard Environmental Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Harv. Hum. Rts. J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Harvard Human Rights Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Harv. Int'l L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Harvard International Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Harv. J. on Legis.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Harvard Journal on Legislation",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Harv. J. on Racial & Ethnic Just.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Harvard Journal on Racial & Ethnic Justice",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Harv. J.L. & Gender": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Harvard Journal of Law and Gender",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Harv. J.L. & Pub. Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Harvard Journal of Law and Public Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Harv. J.L. & Tech.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Harvard Journal of Law & Technology",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Harv. L. & Pol'y Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Harvard Law & Policy Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Harv. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Harvard Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Harv. Latino L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Harvard Latino Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Harv. Negot. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Harvard Negotiation Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Harv. Women's L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Harvard Women's Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Hastings Comm. & Ent. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Hastings Communications and Entertainment Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Hastings Const. L.Q.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Hastings Constitutional Law Quarterly",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Hastings Int'l & Comp. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Hastings International and Comparative Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Hastings L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Hastings Law Journal",
+            "notes": "University of California, Hastings College of the Law Journal",
+            "regexes": [],
+            "start": "1949-01-01T00:00:00",
+            "variations": {}
+        }
+    ],
+    "Hastings W.-Nw. J. Envtl. L. & Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Hastings West-Northwest Journal of Environmental Law and Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Hastings Women's L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Hastings Women's Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Health L. Persps.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Health Law Perespectives",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Health Matrix": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Health Matrix",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Healthspan": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Healthspan",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "High Tech. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "High Technology Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Hofstra L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Hofstra Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Hofstra Lab. & Emp. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Hofstra Labor & Employment Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Hong Kong L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Hong Kong Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Hous. J. Int'l L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Houston Journal of International Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Hous. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Houston Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "How. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Howard Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Hum. Rts. Q.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Human Rights Quarterly",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Human.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Humanities",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "IDEA": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "IDEA: The Intellectual Property Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "ILSA J. Int'l & Comp. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "ILSA Journal of International & Comparative Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Idaho L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Idaho Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ill. B.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Illinois Bar Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Immigr. & Nat'lity L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Immigration and Nationality Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "In Pub. Interest": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "In the Public Interest",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ind. Int'l & Comp. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Indiana International & Comparative Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ind. J. Global Legal Stud.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Indiana Journal of Global Legal Studies",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ind. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Indiana Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ind. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Indiana Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Indus. & Lab. Rel. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Industrial and Labor Relations Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Inst. on Fed. Tax'n": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Institute on Federal Taxation",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Inst. on Oil & Gas L. & Tax'n": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Institute on Oil and Gas Law and Taxation",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Inst. on Plan. Zoning & Eminent Domain": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Institute on Planning, Zoning, and Eminent Domain",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Inst. on Priv. Inv. & Inv. Abroad": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Institute on Private Investments and Investors Abroad",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Inst. on Sec. Reg.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Institute on Securities Regulation",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Int'l & Comp. L.Q.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "International and Comparative Law Quarterly",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Int'l Herald Trib.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "International Herald Tribune",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Int'l J. Pub. Admin.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "International Journal of Public Administration",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Int'l J. Pub. Opinion Res.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "International Journal of Public Opinion Research",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Int'l J.L. & Psychiat Ry": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "International Journal of Law and Psychiatry",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Int'l Law.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "International Lawyer",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Int'l Org.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "International Organization",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Int'l Org. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "International Organization Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Int'l Rev. L. & Econ.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "International Review of Law and Economics",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Iowa L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Iowa Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. ALWD": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of the Association of Legal Writing Directors",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Affordable Housing & Community Dev. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Affordable Housing & Community Development Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Agric. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Agricultural Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Air L. & Com.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Air Law and Commerce",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Am. Acad. Matrim. Law.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of the American Academy of Matrimonial Lawyers",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Am. Soc'y Info. Sci.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of the American Society for Information Science",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. App. Prac. & Process": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Appellate Practice and Process",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Bus. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Business Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Chinese L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Chinese Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Contemp. Health L. & Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Contemporary Health Law and Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Contemp. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Contemporary Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Contemp. Legal Issues": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Contemporary Legal Issues",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Copyright Soc'y U.S.A.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of the Copyright Society of the U.S.A.",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Corp. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Corporation Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Corp. Tax'n": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Corporate Taxation",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Crim. L. & Criminology": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Criminal Law and Criminology",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Disp. Resol.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Dispute Resolution",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Energy Nat. Resources & Envtl. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Energy, Natural Resources & Environmental Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Envtl. L. & Litig.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Environmental Law and Litigation",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Fam. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Family Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Gender Race & Just.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Gender, Race and justice",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Health & Hosp. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Health and Hospital Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Health Care L. & Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Health Care Law & Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Health L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Health Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Health Pol. Pol'y & L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Health Politics, Policy and Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. High Tech. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of High Technology Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Int'l Arb.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of International Arbitration",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Int'l Legal Stud.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of International Legal Studies",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Int'l Wildlife L. & Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of International Wildlife Law and Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Intell. Prop.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Intellectual Property",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Intell. Prop. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Intellectual Property Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Irreproducible Results": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Irreproducible Results",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Land Resources & Envtl. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Land, Resources & Environmental Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Land Use & Envtl. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Land Use and Environmental Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Legal Educ.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Legal Education",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Legal Med.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Legal Medicine",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Legal Prof.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of the Legal Profession",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Legal Stud.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "The Journal of Legal Studies",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Legis.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Legislation",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Mar. L. & Com.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Maritime Law and Commerce",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Marshall J. Computer & Info. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "John Marshall Journal of Computer & Information Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Marshall L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "John Marshall Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Med. & L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Medicine and Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Min. L. & Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Mineral Law & Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Nat. Resources & Envtl. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Natural Resources & Environmental Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Pat. & Trademark Off. Soc'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of the Patent and Trademark Office Society",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Prod. Liab.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Products Liability",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. S. Legal Hist.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Southern Legal History",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Sci. & Tech. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Science & Technology Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Small & Emerging Bus. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Small and Emerging Business Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Space L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Space Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Suffolk Acad. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of the Suffolk Academy of Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Sup. Ct. Hist.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Supreme Court History",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Tax'n": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Taxation",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Tech. L. & Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Technology Law & Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. Urb. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Urban Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J. World Trade": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of World Trade",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J.C. & U.L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of College and University Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J.L. & Com.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Law and Commerce",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J.L. & Econ.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Law & Economics",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J.L. & Educ.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Law and Education",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J.L. & Fam. Stud.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Law and Family Studies",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J.L. & Health": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Law and Health",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J.L. & Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Law and Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J.L. & Pol.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Law & Politics",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J.L. & Religion": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "The Journal of Law and Religion",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J.L. Econ. & Org.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Law, Economics, & Organization",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J.L. Med. & Ethics": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Law, Medicine & Ethics",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "J.L. Soc'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of Law in Society",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "JAG J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "JAG Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "JAMA": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Journal of the American Medical Association",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Judges J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Judges Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Jurid. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Juridical Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Jurimetrics": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Jurimetrics",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Jurimetrics J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Jurimetrics: The Journal of Law, Science, and Technology",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Juris Mag.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Juris Magazine",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Just. Sys. L": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Justice System Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Kan. J.L. & Pub. Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Kansas Journal of Law and Public Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ky. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Kentucky Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "La Raza L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "La Raza Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "La. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Louisiana Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Lab. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Labor Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Lab. Law.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Labor Lawyer",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Landslide": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Landslide",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Law & Contemp. Probs.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Law and Contemporary Problems",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Law & Hist. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Law and History Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Law & Hum. Behav.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Law and Human Behavior",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Law & Ineq.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Law and Inequality",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Law & Phil.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Law and Philosophy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Law & Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Law and Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Law & Pol'y Int'l Bus.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Law and Policy in International Business",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Law & Soc'y Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Law & Society Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Law & Soc. Inquiry": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Law & Social Inquiry",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Law Libr. J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Law Library Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Law Libr. Lights": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Law Library Lights",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Laws. Man. on Prof. Conduct (ABA/BNA)": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "ABA/BNA Lawyers' Manual on Professional Conduct",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Legal Reference Services Q.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Legal Reference Services Quarterly",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Legal Writing": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Legal Writing: The Journal of the Legal Writing Institute",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Lewis & Clark L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Lewis & Clark Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Libr. J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Library Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Lincoln L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Lincoln Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Litig.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Litigation",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Loy. Consumer L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Loyola Consumer Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Loy. J. Pub. Int. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Loyola Journal of Public Interest Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Loy. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Loyola Law Review (New Orleans)",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Loy. L.A. Ent. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Loyola of Los Angeles Entertainment Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Loy. L.A. Int'l & Comp. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Loyola of Los Angeles International & Comparative Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Loy. L.A. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Loyola of Los Angeles Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Loy. U. Chi. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Loyola University of Chicago Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Major Tax Plan.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Major Tax Planning",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Marq. Intell. Prop. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Marquette Intellectual Property Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Marq. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Marquette Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Marq. Sports L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Marquette Sports Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mass. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Massachusetts Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "McGeorge L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "McGeorge Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "McGill L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "McGill Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Md. J. Contemp. Legal Issues": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Maryland Journal of Contemporary Legal Issues",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Md. J. Int'l L. & Trade": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Maryland Journal of International Law and Trade",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Md. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Maryland Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Me. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Maine Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Melb. U. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Melbourne University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mercer L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Mercer Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mich. Bus. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Michigan Business Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mich. J. Gender & L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Michigan Journal of Gender & Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mich. J. Int'l L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Michigan Journal of International Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mich. J. Race & L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Michigan Journal of Race & Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mich. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Michigan Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mich. St. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Michigan State Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mich. Telecomm. & Tech. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Michigan Telecommunications and Technology Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mil. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Military Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Minn. Intell. Prop. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Minnesota Intellectual Property Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Minn. J. Global Trade": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Minnesota Journal of Global Trade",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Minn. J. Int'l. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "MinnesotaJournal of International Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Minn. J. L. Sci. & Tech.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Minnesota Journal of Law, Science & Technology",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Minn. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Minnesota Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Miss. C. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Mississippi College Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Miss. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Mississippi Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mo. Envtl. L. & Pol'y Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Missouri Environmental Law and Policy Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mo. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Missouri Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mod. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Modern Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Monash U. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Monash University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mont. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Montana Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Monthly Lab. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Monthly Labor Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N. Ill. U. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Northern Illinois University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N. Ky. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Northern Kentucky Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.C. Banking Inst.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "North Carolina Banking Institute",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.C. Cent. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "North Carolina Central Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.C. Cent. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "North Carolina (NC) Central Law Journal",
+            "regexes": [],
+            "start": null,
+            "variations": {
+                "N.C. Cent. L.J.": "Cent. Law J."
+            }
+        }
+    ],
+    "N.C. J. Int'l L. & Com. Reg.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "North Carolina Journal of International Law and Commercial Regulation",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.C. J.L. & Tech.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "North Carolina Journal of Law & Technology",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.C. J.L. & Tech. On.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "North Carolina Journal of Law & Technology (Online)",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.C. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "North Carolina Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.C. St. B.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "North Carolina State Bar Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.D. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "North Dakota Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.M. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "New Mexico Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y. City L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "New York City Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y. Int'l L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "New York International Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "New York Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y. St. B.A. Antitrust L. Symp.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "New York State Bar Association Antitrust Law Symposium",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y. Times": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "New York Times",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y.L. Sch. J. Hum. Rts.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "New York Law School Journal of Human Rights",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y.L. Sch. J. Int'l & Comp. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "New York Law School Journal of International and Comparative Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y.L. Sch. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "New York Law School Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y.U. Ann. Inst. On Fed. Tax'n.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "New York University Annual Institute on Federal Taxation",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y.U. Ann. Surv. Am. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "New York University Annual Survey of American Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y.U. Envtl. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "New York University Environmental Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y.U. J. Int'l L. & Pol.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "New York University Journal of International Law and Politics",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y.U. J. Legis. & Pub. Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "New York University Journal of Legislation and Public Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y.U. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "New York University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y.U. Moot Ct. Casebook": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "New York University School of Law Moot Court Casebook",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y.U. Rev. L. & Soc. Change": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "New York University Review of Law and Social Change",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "NEXUS": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "NEXUS: A Journal of Opinion",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Nat'l Black L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "National Black Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Nat'l L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "National Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Nat'l Lawyers Guild, Civil Rights Litigation and Attorney Fees Annual Handbook": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "National Lawyers Guild, Civil Rights Litigation and Attorney Fees Annual Handbook",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Nat'l Rep. Legal Ethics (Univ. Pub. Am.)": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "National Reporter on Legal Ethics & Professional Responsibility",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Nat. Resources J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Natural Resources Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Naval L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Naval Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Neb. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Nebraska Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Nev. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Nevada Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "New Eng. Int'l & Comp. L. Ann.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "New England International and Comparative Law Annual",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "New Eng. J. Med.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "New England Journal of Medicine",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "New Eng. J. On Crim. & Civ. Confinement": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "New England Journal on Criminal and Civil Confinement",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "New Eng. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "New England Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "New L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "New Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Nota Bene": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Nota Bene",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Notre Dame J.L. Ethics & Pub. Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Notre Dame Journal of Law Ethics & Public Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Notre Dame L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Notre Dame Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Notre Dame Law.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Notre Dame Lawyer",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Nova L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Nova Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Nw. J. Int'l L. & Bus.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Northwestern Journal of International Law & Business",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Nw. U. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Northwestern University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ocean & Coastal L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Ocean and Coastal Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ohio N.U. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Ohio Northern University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ohio St. J. Crim. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Ohio State Journal of Criminal Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ohio St. J. on Disp. Resol.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Ohio State Journal on Dispute Resolution",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ohio St. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Ohio State Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Oil & Gas Tax Q.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Oil and Gas Tax Quarterly",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Oil Gas & Energy Q.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Oil, Gas & Energy Quarterly",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Okla. City U. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Oklahoma City University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Okla. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Oklahoma Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Or. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Oregon Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Or. Rev. Int'l L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Oregon Review of International Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Osgoode Hall L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Osgoode Hall Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Otago L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Otago Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ottawa L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Ottawa Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Pac. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Pacific Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Pac. Rim L. & Pol'y J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Pacific Rim Law & Policy Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Pace Envtl. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Pace Environmental Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Pace Int'l L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Pace International Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Pace L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Pace Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Parker Sch. J. E. Eur. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Parker School Journal of East European Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Pat. L. Ann.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Parent Law Annual",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Penn St. Envtl. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Penn State Environmental Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Penn St. Int'l L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Penn State International Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Penn St. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Penn State Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Pepp. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Pepperdine Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Prac. Law.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Practical Lawyer",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Preview U.S. Sup. Ct. Cas.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Preview of United States Supreme Court Cases",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Prob. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Probate Law Journal (National College of Probate Judges and Boston University School of Law)",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Proc. Nat'l Acad. Sci.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Proceedings of the National Academy of Sciences",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Psychol. Bull.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Psychological Bulletin",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Psychol. Pub. Pol'y & L. Pub.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Psychology Public Policy and Law Public",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Psychol. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Law & Psychology Review LAw &",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Pub. Cont. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Public Contract Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Pub. Ent. Advert. & Allied Fields L.Q.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Publishing, Entertainment, Advertising and Allied Fields Law Quarterly",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Pub. Int. L. Rep.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Public Interest Law Reporter",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Pub. Land & Resources L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Public Land and Resources Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Pub. Util. Rep. (PUR)": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Public Utilities Reports",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Quinnipiac Health L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Quinnipiac Health Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Quinnipiac L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Quinnipiac Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Quinnipiac Prob. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Quinnipiac Probate Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "RAND J. Econ.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "The RAND Journal of Economics",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "RISK": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "RISK: Health, Safety & Environment",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Race & Ethnic Anc. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Race and Ethnic Ancestry Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Real Est. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Real Estate Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Real Prop. Prob. & Tr. J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Real Property Probate and Trust Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Real Prop. Tr. & Est. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Real Property, Trust and Estate Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Regent U. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Regent University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Rev. Der. P.R.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Revista de Derecho Puertorriqueno",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Rev. Jur. U.P.R.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Revista juridica de la Universidad de Puerto Rico",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Rev. Litig.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Review of Litigation",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Rich. J. Global L. & Bus.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Richmond Journal of Global Law & Business",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Rich. J.L. & Pub. Int.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Richmond Journal of Law and the Public Interest",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Rich. J.L. & Tech.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Richmond Journal of Law & Technology",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Rocky Mtn. Min. L. Inst.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Rocky Mountain Mineral Law Institute",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Roger Williams U. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Roger Williams University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Rutgers Computer & Tech. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Rutgers Computer and Technology Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Rutgers L. Rec.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Rutgers Law Record",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Rutgers L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Rutgers Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Rutgers L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Rutgers Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Rutgers Race & L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Rutgers Race & the Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        },
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Rutgers Race and the Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Rutgers-Cam. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Rutgers-Camden Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "S. Cal. Interdisc. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Southern California Interdisciplinary Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "S. Cal. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Southern California Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "S. Cal. Rev. L. & Soc. Just.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Southern California Review of Law & Social justice",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "S. Ill. U. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Southern Illinois University Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "S. Tex. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "South Texas Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "S.C. Envtl. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "South Carolina Environmental Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "S.C. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "South Carolina Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "S.D. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "South Dakota Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "S.U. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Southern University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "SMU L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Southern Methodist University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "San Diego L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "San Diego Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "San Fern. V. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "San Fernando Valley Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Santa Clara Computer & High Tech. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Santa Clam Computer and High Technology Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Santa Clara J. Int'l L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Santa Clara Journal of International Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Santa Clara L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Santa Clara Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Sch. L. Bull.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "School Law Bulletin",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Scholar": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "The Scholar: St. Mary's Law Review on Minority Issues",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "School L. Rep. (Educ. Law Ass'n)": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "School Law Reporter",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Sci. Am.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Scientific American .",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Search & Seizure Bull. (Quinlan)": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Search & Seizure Bulletin",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Seattle U. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Seattle University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Seton Hall Const. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Seton Hall Constitutional Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Seton Hall J. Sport L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Seton Hall Journal of Sport Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Seton Hall J. Sports & Ent. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Seton HallJournal of Sports and Entertainment Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Seton Hall L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Seton Hall Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Seton Hall Legis. J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Seton Hall Legislative Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Soc. Serv. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Social Service Review",
+            "regexes": [],
+            "start": null,
+            "variations": {
+                "Soc. Sec. Rep. Serv.": "Soc. Serv. Rev.",
+                "Soc. Sec. Rep. Service": "Soc. Serv. Rev.",
+                "Soc.Sec.Rep.Serv.": "Soc. Serv. Rev."
+            }
+        }
+    ],
+    "Software L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Software Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Southeastern Envtl. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Southeastern Environmental Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Sports Law. J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Sports Lawyers Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "St. B. Tex. Envtl. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "State Bar of Texas Environmental Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "St. John's J. C.R. & Econ. Dev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "St.]ohn's Journal of Civil Rights and Economic Development",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "St. John's L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "St. John's Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "St. Louis U. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Saint Louis University Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "St. Louis U. Pub. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Saint Louis University Public Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "St. Louis-Warsaw Transatlantic L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Saint Louis-Warsaw Transatlantic Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "St. Mary's L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "St. Mary's Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "St. Thomas L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "St. Thomas Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Stan. Envtl. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Stanford Environmental Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Stan. J. C.R. & C.L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Stanford Journal of Civil Rights and Civil Liberties",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Stan. J. Int'l L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Stanford Journal of International Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Stan. J.L. Bus. & Fin.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Stanford Journal of Law, Business & Finance",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Stan. L. & Pol'y Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Stanford Law & Policy Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Stan. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Stanford Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Stan. Tech. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Stanford Technology Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Stetson L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Stetson Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Stud. L. Pol. & Soc'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Studies in Law, Politics, and Society",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Student Law.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Student Lawyer",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Suffolk J. Trial & App. Advoc.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Suffolk Journal of Trial & Appellate Advocacy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Suffolk Transnat'l L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Suffolk Transnational Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Suffolk U. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Suffolk University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Sup. Ct. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Supreme Court Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Sw. J. Int'l Law": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Southwestern Journal of International Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Sw. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Southwestern Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Sw. U. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Southwestern University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Sydney L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Sydney Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Syracuse J. Int'l L. & Com.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Syracuse Journal of International Law and Commerce",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Syracuse L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Syracuse Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "T. Jefferson L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Thomas Jefferson Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "T. Marshall L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Thurgood Marshall Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "T.M. Cooley J. Prac. & Clinical L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Thomas M. Cooley Journal of Practical and Clinical Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "T.M. Cooley L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Thomas M. Cooley Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tax Adviser": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Tax Adviser",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tax L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Tax Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tax Law.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Tax Lawyer",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tax Mgm't Int'l J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Tax Management International Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tax Notes": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Tax Notes",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Taxes": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Taxes: The Tax Magazine",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Temp. Envtl. L. & Tech. J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Temple Environmental Law & TechnologyJournal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Temp. Int'l & Comp. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Temple International and Comparative Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Temp. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Temple Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Temp. Pol. & C.R. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Temple Political and Civil Rights Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Temp. Pol. & Civ. Rts. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Temple Political & Civil Rights Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tenn. J. Prac. & Proc.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Tennessee Journal of Practice and Procedure",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tenn. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Tennessee Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. F. on C.L. & C.R.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Texas Forum on Civil Liberties and Civil Rights",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. Hisp. J.L. & Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Texas Hispanic Journal of Law and Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. Int'l L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Texas International Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. Intell. Prop. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Texas Intellectual Property Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. J. Bus. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Texas Journal of Business Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. J. C.L. & C.R.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Texas Journal on Civil Liberties and Civil Rights",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. J. Women & L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Texas Journal of Women and the Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": "1846-12-31T00:00:00",
+            "examples": [],
+            "name": "Texas Law Review",
+            "regexes": [],
+            "start": "1845-01-01T00:00:00",
+            "variations": {
+                "Texas L.Rev.": "Tex. L. Rev."
+            }
+        }
+    ],
+    "Tex. Rev. L. & Pol.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Texas Review of Law & Politics",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. Tech L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Texas Tech Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. Wesleyan L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Texas Wesleyan Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Third World Legal Stud.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Third World Legal Studies",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tol. J. Great Lakes, L. Sci. & Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Toledo Journal of Great Lakes' Law, Science & Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tort & Ins. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Tort & Insurance Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tort Trial & Ins. Prac. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Tort Trial & Insurance Practice Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Touro Int'l L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Touro International Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Touro J. Transnat'l L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Touro Journal of Transnational Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Touro L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Touro Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Trademark Rep.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Trademark Reporter",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Transactions: Tenn. J. Bus. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Transactions: The Tennessee Journal of Business Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Transnat'l L. & Contemp. Probs.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Transnational Law & Contemporary Problems",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Transnat'l Law.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "The Transnational Lawyer",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Transp. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Transportation Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Trial Law. Guide": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Trial Lawyers Guide",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tu L. Mar. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Tulane Maritime Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tul. Envtl. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Tulane Environmental Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tul. Eur. & Civ. L.F.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Tulane European and Civil Law Forum",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tul. J. Int'l & Comp. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Tulane Journal of International and Comparative Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tul. J.L. & Sexuality": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Tulane Journal of Law and Sexuality",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tul. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Tulane Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tulsa J. Comp. & Int'l L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Tulsa Journal of Comparative & International Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tulsa L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Tulsa Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tulsa L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Tulsa Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Ark. Little Rock L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Arkansas at Little Rock Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Balt. Intell. Prop. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Baltimore Intellectual Property Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Balt. J. Envtl. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Baltimore Journal of Environmental Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Balt. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Baltimore Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Balt. L.F.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Baltimore Law Forum",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Chi. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Chicago Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Chi. Legal F.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Chicago Legal Forum",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Cin. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Cincinnati Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Colo. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Colorado Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Dayton L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Dayton Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Denv. Water L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Denver Water Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Det. Mercy L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Detroit Mercy Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Fla. J.L. & Pub. Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Florida Journal of Law and Public Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Fla. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Florida Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Haw. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Hawaii Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Ill. J.L. Tech. & Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Illinois Journal of Law, Technology and Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Ill. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Illinois Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Kan. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Kansas Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Md. L.J. Race Religion Gender & Class": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Maryland Law Journal of Race, Religion, Gender and Class",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Mem. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Memphis Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Miami Bus. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Miami Business Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Miami Int'l & Comp. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Miami International and Comparative Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Miami Inter-Am. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Miami Inter-American Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Miami L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Miami Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Miami Y.B. Int'l L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Miami Yearbook of International Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Mich. J.L. Reform": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Michigan Journal of Law Reform",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Pa. J. Bus. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Pennsylvania Journal of Business Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Pa. J. Const. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Pennsylvania Journal of Constitutional Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Pa. J. Int'l Econ. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Pennsylvania Journal of International Economic Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Pa. J. Int'l L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Pennsylvania Journal of International Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Pa. J. Lab. & Emp. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Pennsylvania Journal of Labor and Employment Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Pa. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Pennsylvania Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Pitt. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Pittsburgh Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Puget Sound L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Puget Sound Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Rich. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Richmond Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Seattle L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Seattle Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. St. Thomas L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of St. Thomas Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Tol. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Toledo Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Toronto Fac. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Toronto Faculty of Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U. Toronto L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of Toronto Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U.C. Davis L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of California at Davis Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U.S.-Mex. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "United States-Mexico Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U.S.F. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of San Francisco Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "U.S.F. Mar. L.J": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of San Francisco Maritime Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "UCC L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Uniform Commercial Code Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "UCC Rep.-Dig.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Uniform Commercial Code Reporter-Digest",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "UCLA Bull. L. & Tech.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "UCLA Bulletin of Law and Technology",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "UCLA Ent. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "UCLA Entertainment Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "UCLA J. Envtl. L. & Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "UCLA Journal of Environmental Law & Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "UCLA J. Int'l L. & Foreign Aff.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "UCLA Journal of International Law and Foreign Affairs",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "UCLA J.L. & Tech.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "UCLA Journal of Law and Technology",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "UCLA L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "UCLA Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "UCLA Pac. Basin L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "UCLA Pacific Basin Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "UCLA Women's L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "UCLA Women's Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "UDC/DCSL L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of the District of Coliunbia David Clarke School of Law Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "UMKC L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "UMKC Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "UN Monthly Chron.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "UN Monthly Chronicle",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "UWLA L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "University of West Los Angeles Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Urb. Law.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Urban Lawyer",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Utah L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Utah Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Va. Envtl. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Virginia Environmental Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Va. J. Int'l L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Virginia Journal of International Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Va. J. Soc. Pol'y & L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Virginia Journal of Social Policy & the Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Va. J.L. & Tech.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Virginia Journal of Law and Technology",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Va. L. & Bus. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Virginia Law & Business Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Va. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Virginia Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Va. L.L. & Tech.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Virginia Journal of Law & Technology",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Va. Sports & Ent. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Virginia Sports and Entertainment Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Va. Tax Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Virginia Tax Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Val. U. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Valparaiso University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Vand. J. Ent. & Tech. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Vanderbilt Journal of Entertainment & Technology Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Vand. J. Transnat'l L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Vanderbilt Journal of Transnational Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Vand. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Vanderbilt Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Vill. Envtl. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Villanova Environmental Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Vill. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Villanova Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Vill. Sports & Ent. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Villanova Sports & Entertainment Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Vt. J. Envtl. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Vermont Journal of Environmental Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Vt. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Vermont Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "W. New Eng. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Western New England Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "W. St. U. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Western State University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "W. Va. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "West Virginia Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wake Forest L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Wake Forest Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wall St. J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Wall Street Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wash. & Lee J. C.R. & Soc. Just.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Washington and Lee Journal of Civil Rights and Social Justice",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wash. & Lee L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Washington and Lee Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wash. & Lee Race & Ethnic Anc. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Washington and Lee Race and Ethnic Ancestry Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wash. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Washington Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wash. Monthly": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Washington Monthly",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wash. Post": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Washington Post",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wash. U. Glob. Stud. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Washington University Global Studies Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wash. U. J. Urb. & Contemp. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Washington University Journal of Urban and Contemporary Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wash. U. J.L. & Pol'y": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Washington University Journal of Law and Policy",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wash. U. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Washington University Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wash. U. L.Q.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Washington University Law Quarterly",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Washburn L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Washburn Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wayne L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Wayne Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Whittier L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Whittier Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Widener J. Pub. L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "WidenerJournal of Public Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Widener L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Widener Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Widener L. Symp. J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Widener Law Symposium Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Willamette L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Willamette Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wis. Envtl. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Wisconsin Environmental Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wis. Int'l L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Wisconsin International Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wis. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Wisconsin Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wis. Women's L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Wisconsin Women's Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wm. & Mary Bill Rts. J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "William and Mary Bill of Rights Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wm. & Mary Envtl. L. Pol'y Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "William & Mary Environmental Law and Policy Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wm. & Mary J. Women & L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "William and Mary Journal of Women and the Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wm. & Mary L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "William and Mary Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wm. Mitchell L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "William Mitchell Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Women's Rts. L. Rep.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Women's Rights Law Reporter",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wyo. L. Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Wyoming Law Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wyo. Law.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Wyoming Lawyer",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Yale Hum. Rts. & Dev. L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Yale Human Rights and Development Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Yale J. Health Pol'y L. & Ethics": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Yale Journal of Health Policy, Law, and Ethics",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Yale J. Int'l L.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Yale Journal of International Law",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Yale J. World Pub. Ord.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Yale Journal of World Public Order",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Yale J. on Reg.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Yale Journal on Regulation",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Yale J.L. & Feminism": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Yale Journal of Law and Feminism",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Yale J.L. & Human.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Yale Journal of Law & the Humanities",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Yale J.L. & Tech.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Yale Journal of Law & Technology",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Yale L. & Pol'y Rev.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Yale Law & Policy Review",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Yale L.J.": [
+        {
+            "cite_type": "journal",
+            "end": null,
+            "examples": [],
+            "name": "Yale Law Journal",
+            "notes": "Automatically generated.",
+            "regexes": [],
+            "start": null,
+            "variations": []
+        }
+    ]
+}

--- a/reporters_db/data/laws.json
+++ b/reporters_db/data/laws.json
@@ -1,0 +1,6118 @@
+{
+    "Ala. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Ala. Admin. Code r. 218"
+            ],
+            "jurisdiction": "Alabama",
+            "name": "Alabama Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition r\\. $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ala. Admin. Monthly": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "607 Ala. Admin. Monthly 8"
+            ],
+            "jurisdiction": "Alabama",
+            "name": "Alabama Administrative Monthly",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ala. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-7 Ala. Adv. Legis. Serv. 0"
+            ],
+            "jurisdiction": "Alabama",
+            "name": "Michie's Alabama Code <year> Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ala. Code": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Ala. Code § 92.979"
+            ],
+            "jurisdiction": "Alabama",
+            "name": "Code of Alabama, 1975 (West); Michie's Alabama Code, 1975 (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ala. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ala. Laws 94"
+            ],
+            "jurisdiction": "Alabama",
+            "name": "Alabama Laws",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ala. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ala. Legis. Serv. 3"
+            ],
+            "jurisdiction": "Alabama",
+            "name": "West's Alabama Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Alaska Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Alaska Admin. Code tit. 000, § 41-3-545"
+            ],
+            "jurisdiction": "Alaska",
+            "name": "Alaska Administrative Code (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Alaska Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-83 Alaska Adv. Legis. Serv. 8"
+            ],
+            "jurisdiction": "Alaska",
+            "name": "Alaska Statutes <year> Advance Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Alaska Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Alaska Legis. Serv. 8"
+            ],
+            "jurisdiction": "Alaska",
+            "name": "West's Alaska Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Alaska Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Alaska Sess. Laws 59"
+            ],
+            "jurisdiction": "Alaska",
+            "name": "Session Laws of Alaska",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Alaska Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Alaska Stat. § 240"
+            ],
+            "jurisdiction": "Alaska",
+            "name": "Alaska Statutes (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Alaska Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Alaska Stat. Ann. § 95"
+            ],
+            "jurisdiction": "Alaska",
+            "name": "West's Alaska Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Am. Samoa Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Am. Samoa Admin. Code § 930-054-0"
+            ],
+            "jurisdiction": "American Samoa",
+            "name": "American Samoa Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Am. Samoa Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Am. Samoa Code Ann. § 15.4"
+            ],
+            "jurisdiction": "American Samoa",
+            "name": "American Samoa Code Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ariz. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Ariz. Admin. Code § 709"
+            ],
+            "jurisdiction": "Arizona",
+            "name": "Arizona Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ariz. Admin. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "7 Ariz. Admin. Reg. 4"
+            ],
+            "jurisdiction": "Arizona",
+            "name": "Arizona Administrative Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ariz. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ariz. Legis. Serv. 9"
+            ],
+            "jurisdiction": "Arizona",
+            "name": "Arizona Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ariz. Rev. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Ariz. Rev. Stat. § 495:11"
+            ],
+            "jurisdiction": "Arizona",
+            "name": "Arizona Revised Statutes (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ariz. Rev. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Ariz. Rev. Stat. Ann. § 667"
+            ],
+            "jurisdiction": "Arizona",
+            "name": "Arizona Revised Statutes Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ariz. Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ariz. Sess. Laws 95"
+            ],
+            "jurisdiction": "Arizona",
+            "name": "Session Laws, Arizona",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ark. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ark. Acts 1"
+            ],
+            "jurisdiction": "Arkansas",
+            "name": "Acts of Arkansas (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ark. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-44 Ark. Adv. Legis. Serv. 1"
+            ],
+            "jurisdiction": "Arkansas",
+            "name": "Arkansas Code of 1987 Annotated <year> Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ark. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Ark. Code Ann. § 0:331:5"
+            ],
+            "jurisdiction": "Arkansas",
+            "name": "Arkansas Code of 1987 Annotated (LexisNexis); West's Arkansas Code Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ark. Code R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "0-6-054 Ark. Code R. § 36.2.010"
+            ],
+            "jurisdiction": "Arkansas",
+            "name": "Code of Arkansas Rules (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<chapter>\\d+-\\d+-\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ark. Gov't Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "01 Ark. Gov't Reg. 5"
+            ],
+            "jurisdiction": "Arkansas",
+            "name": "Arkansas Government Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ark. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ark. Legis. Serv. 3"
+            ],
+            "jurisdiction": "Arkansas",
+            "name": "West's Arkansas Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ark. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "043 Ark. Reg. 0"
+            ],
+            "jurisdiction": "Arkansas",
+            "name": "Arkansas Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "C.Z. Code": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "C.Z. Code tit. 699, § 50"
+            ],
+            "jurisdiction": "Canal Zone",
+            "name": "Panama Canal Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cal. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-52 Cal. Adv. Legis. Serv. 8"
+            ],
+            "jurisdiction": "California",
+            "name": "Deering's California Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cal. Code": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Cal. Empl. Code § 8:6:077"
+            ],
+            "jurisdiction": "California",
+            "name": "West's Annotated California Codes; Deering's California Codes, Annotated (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<reporter>Cal\\. $law_subject Code) § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cal. Code Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Cal. Code Regs. tit. 64, § 63:140-867"
+            ],
+            "jurisdiction": "California",
+            "name": "California Code of Regulations (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cal. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Cal. Legis. Serv. 89"
+            ],
+            "jurisdiction": "California",
+            "name": "West's California Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cal. Regulatory Notice Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "35 Cal. Regulatory Notice Reg. 784"
+            ],
+            "jurisdiction": "California",
+            "name": "California Regulatory Notice Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Cal. Stat.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Cal. Stat. 2"
+            ],
+            "jurisdiction": "California",
+            "name": "Statutes of California",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colo. Code Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "78 Colo. Code Regs. § 49"
+            ],
+            "jurisdiction": "Colorado",
+            "name": "Colorado Code of Regulations; Code of Colorado Regulations (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colo. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Colo. Legis. Serv. 9"
+            ],
+            "jurisdiction": "Colorado",
+            "name": "Colorado Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colo. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "66 Colo. Reg. 1"
+            ],
+            "jurisdiction": "Colorado",
+            "name": "Colorado Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colo. Rev. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Colo. Rev. Stat. § 4-070-09"
+            ],
+            "jurisdiction": "Colorado",
+            "name": "Colorado Revised Statutes (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colo. Rev. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Colo. Rev. Stat. Ann. § 32.8-514"
+            ],
+            "jurisdiction": "Colorado",
+            "name": "West's Colorado Revised Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Colo. Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Colo. Sess. Laws 0888"
+            ],
+            "jurisdiction": "Colorado",
+            "name": "Session Laws of Colorado (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Conn. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Conn. Acts 7 ([Reg. or Spec.] Sess.)"
+            ],
+            "jurisdiction": "Connecticut",
+            "name": "Connecticut Public & Special Acts",
+            "notes": "Automatically generated. Remove this message if replacing with real examples. Indigo Book dates 1972-date.",
+            "regexes": [
+                "$law_year $edition $page_with_commas \\(\\[Reg\\. or Spec\\.\\] Sess\\.\\)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Conn. Agencies Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Conn. Agencies Regs. § 44-999-9"
+            ],
+            "jurisdiction": "Connecticut",
+            "name": "Regulations of Connecticut State Agencies",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Conn. Gen. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Conn. Gen. Stat. § 0:899"
+            ],
+            "jurisdiction": "Connecticut",
+            "name": "General Statutes of Connecticut",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Conn. Gen. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Conn. Gen. Stat. Ann. § 77"
+            ],
+            "jurisdiction": "Connecticut",
+            "name": "Connecticut General Statutes Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Conn. Gov't Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "777 Conn. Gov't Reg. 6330"
+            ],
+            "jurisdiction": "Connecticut",
+            "name": "Connecticut Government Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Conn. L.J.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "44 Conn. L.J. 64"
+            ],
+            "jurisdiction": "Connecticut",
+            "name": "Connecticut Law Journal",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Conn. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Conn. Legis. Serv. 71"
+            ],
+            "jurisdiction": "Connecticut",
+            "name": "Connecticut Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Conn. Pub. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Conn. Pub. Acts 3"
+            ],
+            "jurisdiction": "Connecticut",
+            "name": "Connecticut Public Acts",
+            "notes": "Automatically generated. Remove this message if replacing with real examples. Indigo Book dates 1650-1971.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Conn. Spec. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Conn. Spec. Acts 029"
+            ],
+            "jurisdiction": "Connecticut",
+            "name": "Connecticut Special Acts (Resolves & Private Laws, Private & Special Laws, Special Laws, Resolves & Private Acts, Resolutions & Private Acts, Private Acts & Resolutions, and Special Acts & Resolutions)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples. Indigo Book dates 1789-1971.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "D.C. Code": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "D.C. Code § 65.405.2"
+            ],
+            "jurisdiction": "District of Columbia",
+            "name": "District of Columbia Official Code (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "D.C. Code Adv. Leg. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-69 D.C. Code Adv. Leg. Serv. 4"
+            ],
+            "jurisdiction": "District of Columbia",
+            "name": "District of Columbia Official Code Lexis Advance Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "D.C. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "D.C. Code Ann. § 580-35.58"
+            ],
+            "jurisdiction": "District of Columbia",
+            "name": "West's District of Columbia Code Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "D.C. Code Mun. Regs.": [
+        {
+            "cite_type": "municipal",
+            "end": null,
+            "examples": [
+                "D.C. Code Mun. Regs. tit. 87 § 54-1"
+            ],
+            "jurisdiction": "District of Columbia",
+            "name": "Code of District of Columbia Municipal Regulations (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+) § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "D.C. Mun. Regs.": [
+        {
+            "cite_type": "municipal",
+            "end": null,
+            "examples": [
+                "D.C. Mun. Regs. tit. 935, § 9"
+            ],
+            "jurisdiction": "District of Columbia",
+            "name": "Code of D.C. Municipal Regulations",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "D.C. Reg.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "685 D.C. Reg. 42"
+            ],
+            "jurisdiction": "District of Columbia",
+            "name": "District of Columbia Register; District of Columbia Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "D.C. Sess. L. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 D.C. Sess. L. Serv. 6359"
+            ],
+            "jurisdiction": "District of Columbia",
+            "name": "District of Columbia Session Law Service West",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Del Gov't Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "075 Del Gov't Reg. 3,52"
+            ],
+            "jurisdiction": "Delaware",
+            "name": "Delaware Government Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Del. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "42-8-22 Del. Admin. Code § 4"
+            ],
+            "jurisdiction": "Delaware",
+            "name": "Delaware Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<chapter>\\d+-\\d+-\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Del. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Del. Code Ann. tit. 87, § 6-584:4"
+            ],
+            "jurisdiction": "Delaware",
+            "name": "Delaware Code Annotated (LexisNexis); West's Delaware Code Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Del. Code Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "35-0-67 Del. Code Regs. § 45-025"
+            ],
+            "jurisdiction": "Delaware",
+            "name": "Code of Delaware Regulations (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<chapter>\\d+-\\d+-\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Del. Code. Ann. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-4 Del. Code. Ann. Adv. Legis. Serv. 3"
+            ],
+            "jurisdiction": "Delaware",
+            "name": "Delaware Code Annotated <year> Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Del. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "25 Del. Laws 1"
+            ],
+            "jurisdiction": "Delaware",
+            "name": "Laws of Delaware",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Del. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Del. Legis. Serv. 83"
+            ],
+            "jurisdiction": "Delaware",
+            "name": "West's Delaware Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Del. Reg. Regs.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "7 Del. Reg. Regs. 8349"
+            ],
+            "jurisdiction": "Delaware",
+            "name": "Delaware Register of Regulations",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fla. Admin. Code Ann.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Fla. Admin. Code Ann. r. 39.6-70"
+            ],
+            "jurisdiction": "Florida",
+            "name": "Florida Administrative Code Annotated (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition r\\. $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fla. Admin. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "280 Fla. Admin. Reg. 7"
+            ],
+            "jurisdiction": "Florida",
+            "name": "Florida Administrative Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples. Indigo Book dates 2012-date.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fla. Admin. Weekly": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "454 Fla. Admin. Weekly 86"
+            ],
+            "jurisdiction": "Florida",
+            "name": "Florida Administrative Weekly (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples. Indigo Book dates 1996-2012.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fla. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Fla. Laws 721"
+            ],
+            "jurisdiction": "Florida",
+            "name": "Laws of Florida",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fla. Sess. Law Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Fla. Sess. Law Serv. 045"
+            ],
+            "jurisdiction": "Florida",
+            "name": "West's Florida Session Law Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fla. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Fla. Stat. § 8"
+            ],
+            "jurisdiction": "Florida",
+            "name": "Florida Statutes",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Fla. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Fla. Stat. Ann. § 8-3:39"
+            ],
+            "jurisdiction": "Florida",
+            "name": "West's Florida Statutes Annotated; LexisNexis Florida Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ga. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Ga. Code Ann. § 67.508.661"
+            ],
+            "jurisdiction": "Georgia",
+            "name": "Official Code of Georgia Annotated (LexisNexis); West's Code of Georgia Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ga. Code Ann. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-85 Ga. Code Ann. Adv. Legis. Serv. 51"
+            ],
+            "jurisdiction": "Georgia",
+            "name": "Georgia <year> Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        },
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ga. Code Ann. Adv. Legis. Serv. 2"
+            ],
+            "jurisdiction": "Georgia",
+            "name": "West's Georgia Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ga. Comp. R. & Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Ga. Comp. R. & Regs. 708-5.918"
+            ],
+            "jurisdiction": "Georgia",
+            "name": "Official Compilation Rules and Regulations of the State of Georgia",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ga. Gov't Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "121 Ga. Gov't Reg. 50"
+            ],
+            "jurisdiction": "Georgia",
+            "name": "Georgia Government Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ga. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ga. Laws 5"
+            ],
+            "jurisdiction": "Georgia",
+            "name": "Georgia Laws",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Guam Admin. R. & Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "99 Guam Admin. R. & Regs. § 2.9"
+            ],
+            "jurisdiction": "Guam",
+            "name": "Administrative Rules & Regulations of the Government of Guam",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Guam Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "9 Guam Code Ann. § 205"
+            ],
+            "jurisdiction": "Guam",
+            "name": "Guam Code Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Guam Pub. L.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "Guam Pub. L. 579"
+            ],
+            "jurisdiction": "Guam",
+            "name": "Guam Session Laws",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition (?P<law>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Haw. Code R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Haw. Code R. § 6.0"
+            ],
+            "jurisdiction": "Hawaii",
+            "name": "Code of Hawaii Rules (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Haw. Gov't Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "721 Haw. Gov't Reg. 97"
+            ],
+            "jurisdiction": "Hawaii",
+            "name": "Hawaii Government Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Haw. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Haw. Legis. Serv. 369"
+            ],
+            "jurisdiction": "Hawaii",
+            "name": "West's Hawai'i Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Haw. Rev. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Haw. Rev. Stat. § 230:5.265"
+            ],
+            "jurisdiction": "Hawaii",
+            "name": "Hawaii Revised Statutes",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Haw. Rev. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Haw. Rev. Stat. Ann. § 08.68.903"
+            ],
+            "jurisdiction": "Hawaii",
+            "name": "Michie's Hawaii Revised Statutes Annotated (LexisNexis); West's Hawai'i Revised Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Haw. Rev. Stat. Ann. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-100 Haw. Rev. Stat. Ann. Adv. Legis. Serv. 436"
+            ],
+            "jurisdiction": "Hawaii",
+            "name": "Michie's Hawaii Revised Statutes Annotated Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Haw. Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Haw. Sess. Laws 2203"
+            ],
+            "jurisdiction": "Hawaii",
+            "name": "Session Laws of Hawaii",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Idaho Admin. Bull.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "0 Idaho Admin. Bull. 6"
+            ],
+            "jurisdiction": "Idaho",
+            "name": "Idaho Administrative Bulletin",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Idaho Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Idaho Admin. Code r. 2.12"
+            ],
+            "jurisdiction": "Idaho",
+            "name": "Idaho Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition r\\. $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Idaho Code": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Idaho Code § 54:57-2"
+            ],
+            "jurisdiction": "Idaho",
+            "name": "Idaho Code (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Idaho Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Idaho Code Ann. § 160:38:649"
+            ],
+            "jurisdiction": "Idaho",
+            "name": "West's Idaho Code Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Idaho Code Ann. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-2 Idaho Code Ann. Adv. Legis. Serv. 194"
+            ],
+            "jurisdiction": "Idaho",
+            "name": "Idaho Code Annotated Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Idaho Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Idaho Legis. Serv. 2"
+            ],
+            "jurisdiction": "Idaho",
+            "name": "West's Idaho Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Idaho Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Idaho Sess. Laws 9"
+            ],
+            "jurisdiction": "Idaho",
+            "name": "Idaho Session Laws",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ill. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Ill. Admin. Code tit. 2, § 832-85-0"
+            ],
+            "jurisdiction": "Illinois",
+            "name": "Illinois Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ill. Code R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "7 Ill. Code R. 966"
+            ],
+            "jurisdiction": "Illinois",
+            "name": "Code of Illinois Rules (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ill. Comp. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "1 Ill. Comp. Stat. 0 / 462.04"
+            ],
+            "jurisdiction": "Illinois",
+            "name": "Illinois Compiled Statutes",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<chapter>\\d+) $edition (?P<act>\\d+) / $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ill. Comp. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "885 Ill. Comp. Stat. Ann. 132 / 73-757:13"
+            ],
+            "jurisdiction": "Illinois",
+            "name": "West's Smith-Hurd Illinois Compiled Statutes Annotated; Illinois Compiled Statutes Annotated (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<chapter>\\d+) $edition (?P<act>\\d+) / $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ill. Comp. Stat. Ann. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-6 Ill. Comp. Stat. Ann. Adv. Legis. Serv. 2,80"
+            ],
+            "jurisdiction": "Illinois",
+            "name": "Illinois Compiled Statutes Annotated Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ill. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ill. Laws 9"
+            ],
+            "jurisdiction": "Illinois",
+            "name": "Laws of Illinois",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ill. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ill. Legis. Serv. 4"
+            ],
+            "jurisdiction": "Illinois",
+            "name": "Illinois Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ill. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "1 Ill. Reg. 4434"
+            ],
+            "jurisdiction": "Illinois",
+            "name": "Illinois Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ind. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ind. Acts 0"
+            ],
+            "jurisdiction": "Indiana",
+            "name": "Acts, Indiana",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ind. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "884 Ind. Admin. Code 0"
+            ],
+            "jurisdiction": "Indiana",
+            "name": "Indiana Administrative Code; West's Indiana Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ind. Code": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Ind. Code § 79.443"
+            ],
+            "jurisdiction": "Indiana",
+            "name": "Indiana Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ind. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Ind. Code Ann. § 0-922:28"
+            ],
+            "jurisdiction": "Indiana",
+            "name": "West's Annotated Indiana Code; Burns Indiana Statutes Annotated (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ind. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ind. Legis. Serv. 8"
+            ],
+            "jurisdiction": "Indiana",
+            "name": "West's Indiana Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ind. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "8 Ind. Reg. 737"
+            ],
+            "jurisdiction": "Indiana",
+            "name": "Indiana Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ind. Stat. Ann. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-62 Ind. Stat. Ann. Adv. Legis. Serv. 0"
+            ],
+            "jurisdiction": "Indiana",
+            "name": "Burns Indiana Statutes Annotated Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Iowa Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Iowa Acts 0"
+            ],
+            "jurisdiction": "Iowa",
+            "name": "Acts of the State of Iowa",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Iowa Admin. Bull.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "17 Iowa Admin. Bull. 5"
+            ],
+            "jurisdiction": "Iowa",
+            "name": "Iowa Administrative Bulletin",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Iowa Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Iowa Admin. Code r. 39-0-5"
+            ],
+            "jurisdiction": "Iowa",
+            "name": "Iowa Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition r\\. $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Iowa Code": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Iowa Code § 0.780"
+            ],
+            "jurisdiction": "Iowa",
+            "name": "Code of Iowa",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Iowa Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Iowa Code Ann. § 5:77.49"
+            ],
+            "jurisdiction": "Iowa",
+            "name": "West's Iowa Code Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Iowa Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Iowa Legis. Serv. 9057"
+            ],
+            "jurisdiction": "Iowa",
+            "name": "Iowa Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Kan. Admin. Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Kan. Admin. Regs. § 39"
+            ],
+            "jurisdiction": "Kansas",
+            "name": "Kansas Administrative Regulations (updated by supplements)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Kan. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Kan. Legis. Serv. 6731"
+            ],
+            "jurisdiction": "Kansas",
+            "name": "West's Kansas Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Kan. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "9 Kan. Reg. 78"
+            ],
+            "jurisdiction": "Kansas",
+            "name": "Kansas Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Kan. Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Kan. Sess. Laws 0"
+            ],
+            "jurisdiction": "Kansas",
+            "name": "Session Laws of Kansas",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Kan. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Kan. Stat. Ann. § 4"
+            ],
+            "jurisdiction": "Kansas",
+            "name": "Kansas Statutes Annotated; West's Kansas Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ky. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ky. Acts 1083"
+            ],
+            "jurisdiction": "Kentucky",
+            "name": "Acts of Kentucky",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ky. Admin. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "69 Ky. Admin. Reg. 8,6"
+            ],
+            "jurisdiction": "Kentucky",
+            "name": "Administrative Register of Kentucky",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ky. Admin. Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "78 Ky. Admin. Regs. 124"
+            ],
+            "jurisdiction": "Kentucky",
+            "name": "Kentucky Administrative Regulations Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ky. Rev. Stat. & R. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ky. Rev. Stat. & R. Serv. 8297"
+            ],
+            "jurisdiction": "Kentucky",
+            "name": "Kentucky Revised Statutes and Rules Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ky. Rev. Stat. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-39 Ky. Rev. Stat. Adv. Legis. Serv. 809"
+            ],
+            "jurisdiction": "Kentucky",
+            "name": "Michie's Kentucky Revised Statutes Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ky. Rev. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Ky. Rev. Stat. Ann. § 021.48"
+            ],
+            "jurisdiction": "Kentucky",
+            "name": "Baldwin's Kentucky Revised Statutes Annotated (West); Michie's Kentucky Revised Statutes Annotated (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "La. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 La. Acts 4"
+            ],
+            "jurisdiction": "Louisiana",
+            "name": "State of Louisiana: Acts of the Legislature",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "La. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "La. Admin. Code tit. 15, § 6"
+            ],
+            "jurisdiction": "Louisiana",
+            "name": "Louisiana Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "La. Child. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "La. Child. Code Ann. art 4"
+            ],
+            "jurisdiction": "Louisiana",
+            "name": "West's Louisiana Children's Code Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition art (?P<article>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "La. Civ. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "La. Civ. Code Ann. art 51"
+            ],
+            "jurisdiction": "Louisiana",
+            "name": "West's Louisiana Civil Code Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition art (?P<article>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "La. Code Civ. Proc. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "La. Code Civ. Proc. Ann. art 3"
+            ],
+            "jurisdiction": "Louisiana",
+            "name": "West's Louisiana Code of Civil Procedure Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition art (?P<article>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "La. Code Crim. Proc. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "La. Code Crim. Proc. Ann. art 151"
+            ],
+            "jurisdiction": "Louisiana",
+            "name": "West's Louisiana Code of Criminal Procedure Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition art (?P<article>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "La. Code Evid. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "La. Code Evid. Ann. art 410"
+            ],
+            "jurisdiction": "Louisiana",
+            "name": "West's Louisiana Code of Evidence Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition art (?P<article>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "La. Const. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "La. Const. Ann. art 53"
+            ],
+            "jurisdiction": "Louisiana",
+            "name": "West's Louisiana Constitution Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition art (?P<article>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "La. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "620 La. Reg. 1"
+            ],
+            "jurisdiction": "Louisiana",
+            "name": "Louisiana Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "La. Sess. Law Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 La. Sess. Law Serv. 9"
+            ],
+            "jurisdiction": "Louisiana",
+            "name": "West's Louisiana Session Law Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "La. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "La. Stat. Ann. § 5"
+            ],
+            "jurisdiction": "Louisiana",
+            "name": "West's Louisiana Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mass. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Mass. Acts 8"
+            ],
+            "jurisdiction": "Massachusetts",
+            "name": "Acts and Resolves of Massachusetts",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mass. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-8 Mass. Adv. Legis. Serv. 1"
+            ],
+            "jurisdiction": "Massachusetts",
+            "name": "Massachusetts Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mass. Ann. Laws": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Mass. Ann. Laws ch. 334, § 3:54"
+            ],
+            "jurisdiction": "Massachusetts",
+            "name": "Annotated Laws of Massachusetts (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition ch\\. (?P<chapter>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mass. Code Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "177 Mass. Code Regs. 123-10"
+            ],
+            "jurisdiction": "Massachusetts",
+            "name": "Code of Massachusetts Regulations; Code of Massachusetts Regulations (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mass. Gen. Laws": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Mass. Gen. Laws ch. 44, § 0:04.1"
+            ],
+            "jurisdiction": "Massachusetts",
+            "name": "General Laws of Massachusetts (Mass. Bar Ass'n/West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition ch\\. (?P<chapter>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mass. Gen. Laws Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Mass. Gen. Laws Ann. ch. 3, § 3"
+            ],
+            "jurisdiction": "Massachusetts",
+            "name": "Massachusetts General Laws Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition ch\\. (?P<chapter>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mass. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Mass. Legis. Serv. 1"
+            ],
+            "jurisdiction": "Massachusetts",
+            "name": "Massachusetts Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mass. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "217 Mass. Reg. 3"
+            ],
+            "jurisdiction": "Massachusetts",
+            "name": "Massachusetts Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Md. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Md. Code Ann., Empl. § 8-551"
+            ],
+            "jurisdiction": "Maryland",
+            "name": "Michie's Annotated Code of Maryland (LexisNexis); West's Annotated Code of Maryland",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition, $law_subject § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Md. Code Ann. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-366 Md. Code Ann. Adv. Legis. Serv. 6"
+            ],
+            "jurisdiction": "Maryland",
+            "name": "Michie's Annotated Code of Maryland Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Md. Code Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Md. Code Regs. 12"
+            ],
+            "jurisdiction": "Maryland",
+            "name": "Code of Maryland Regulations",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition (?P<reg>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Md. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Md. Laws 1972"
+            ],
+            "jurisdiction": "Maryland",
+            "name": "Laws of Maryland",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Md. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Md. Legis. Serv. 5"
+            ],
+            "jurisdiction": "Maryland",
+            "name": "West's Maryland Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Md. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "3 Md. Reg. 8065"
+            ],
+            "jurisdiction": "Maryland",
+            "name": "Maryland Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Me. Code R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "60-8-7 Me. Code R. § 88-7:4"
+            ],
+            "jurisdiction": "Maine",
+            "name": "Code of Maine Rules (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<chapter>\\d+-\\d+-\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Me. Gov't Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "1 Me. Gov't Reg. 1"
+            ],
+            "jurisdiction": "Maine",
+            "name": "Maine Government Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Me. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Me. Laws 9"
+            ],
+            "jurisdiction": "Maine",
+            "name": "Laws of the State of Maine",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Me. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Me. Legis. Serv. 6"
+            ],
+            "jurisdiction": "Maine",
+            "name": "Maine Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Me. Rev. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Me. Rev. Stat. Ann. tit. 095, § 0:624"
+            ],
+            "jurisdiction": "Maine",
+            "name": "Maine Revised Statutes Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Me. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Me. Stat. tit. 97, § 439"
+            ],
+            "jurisdiction": "Maine",
+            "name": "West's Maine Statutes",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mich. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Mich. Admin. Code ry 74.4:78"
+            ],
+            "jurisdiction": "Michigan",
+            "name": "Michigan Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition r. $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mich. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-669 Mich. Adv. Legis. Serv. 58"
+            ],
+            "jurisdiction": "Michigan",
+            "name": "Michigan Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mich. Comp. Laws": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Mich. Comp. Laws § 525.008:505"
+            ],
+            "jurisdiction": "Michigan",
+            "name": "Michigan Compiled Laws (1979)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mich. Comp. Laws Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Mich. Comp. Laws Ann. § 39:86.3"
+            ],
+            "jurisdiction": "Michigan",
+            "name": "Michigan Compiled Laws Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mich. Comp. Laws Serv.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Mich. Comp. Laws Serv. § 538-221"
+            ],
+            "jurisdiction": "Michigan",
+            "name": "Michigan Compiled Laws Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mich. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Mich. Legis. Serv. 3"
+            ],
+            "jurisdiction": "Michigan",
+            "name": "Michigan Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mich. Pub. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Mich. Pub. Acts 9,1"
+            ],
+            "jurisdiction": "Michigan",
+            "name": "Public and Local Acts of the Legislature of the State of Michigan",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mich. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "953 Mich. Reg. 0"
+            ],
+            "jurisdiction": "Michigan",
+            "name": "Michigan Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Minn. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Minn. Laws 41"
+            ],
+            "jurisdiction": "Minnesota",
+            "name": "Laws of Minnesota",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Minn. R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Minn. R. 6"
+            ],
+            "jurisdiction": "Minnesota",
+            "name": "Minnesota Rules",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Minn. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "5 Minn. Reg. 69"
+            ],
+            "jurisdiction": "Minnesota",
+            "name": "Minnesota State Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Minn. Sess. Law Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Minn. Sess. Law Serv. 8"
+            ],
+            "jurisdiction": "Minnesota",
+            "name": "Minnesota Session Law Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Minn. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Minn. Stat. § 20-72"
+            ],
+            "jurisdiction": "Minnesota",
+            "name": "Minnesota Statutes",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Minn. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Minn. Stat. Ann. § 967-86"
+            ],
+            "jurisdiction": "Minnesota",
+            "name": "Minnesota Statutes Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Miss. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Miss. Code Ann. § 6"
+            ],
+            "jurisdiction": "Mississippi",
+            "name": "Mississippi Code 1972 Annotated (LexisNexis); West's Annotated Mississippi Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Miss. Code R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "3-866 Miss. Code R. § 22.95.78"
+            ],
+            "jurisdiction": "Mississippi",
+            "name": "Code of Mississippi Rules (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+)\\-(?P<chapter>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Miss. Gov't Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "86 Miss. Gov't Reg. 9"
+            ],
+            "jurisdiction": "Mississippi",
+            "name": "Mississippi Government Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Miss. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Miss. Laws 2"
+            ],
+            "jurisdiction": "Mississippi",
+            "name": "General Laws of Mississippi",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Miss. Laws Adv. Sh.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-2 Miss. Laws Adv. Sh. 6"
+            ],
+            "jurisdiction": "Mississippi",
+            "name": "Mississippi General Laws Advance Sheets (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Miss. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Miss. Legis. Serv. 54"
+            ],
+            "jurisdiction": "Mississippi",
+            "name": "West's Mississippi Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mo. Ann. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Mo. Ann. Stat. § 274"
+            ],
+            "jurisdiction": "Missouri",
+            "name": "Vernon's Annotated Missouri Statutes (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mo. Code Regs. Ann.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Mo. Code Regs. Ann. tit. 42, § 1:080:35"
+            ],
+            "jurisdiction": "Missouri",
+            "name": "Missouri Code of State Regulations Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mo. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Mo. Laws 280"
+            ],
+            "jurisdiction": "Missouri",
+            "name": "Session Laws of Missouri",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mo. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Mo. Legis. Serv. 80"
+            ],
+            "jurisdiction": "Missouri",
+            "name": "Missouri Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mo. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "7 Mo. Reg. 1"
+            ],
+            "jurisdiction": "Missouri",
+            "name": "Missouri Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mo. Rev. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Mo. Rev. Stat. § 1.174"
+            ],
+            "jurisdiction": "Missouri",
+            "name": "Missouri Revised Statutes",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mont. Admin. R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Mont. Admin. R. 5"
+            ],
+            "jurisdiction": "Montana",
+            "name": "Administrative Rules of Montana",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mont. Admin. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "452 Mont. Admin. Reg. 85"
+            ],
+            "jurisdiction": "Montana",
+            "name": "Montana Administrative Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mont. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Mont. Code Ann. § 5"
+            ],
+            "jurisdiction": "Montana",
+            "name": "Montana Code Annotated; West's Montana Code Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Mont. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Mont. Laws 7"
+            ],
+            "jurisdiction": "Montana",
+            "name": "Laws of Montana",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N. Mar. I. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "0 N. Mar. I. Admin. Code § 77-642-24"
+            ],
+            "jurisdiction": "Northern Mariana Islands",
+            "name": "Northern Mariana Islands Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N. Mar. I. Code": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "500 N. Mar. I. Code § 59-989:8"
+            ],
+            "jurisdiction": "Northern Mariana Islands",
+            "name": "Northern Mariana Islands Commonwealth Code (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N. Mar. I. Pub. L.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N. Mar. I. Pub. L. 24"
+            ],
+            "jurisdiction": "Northern Mariana Islands",
+            "name": "Northern Mariana Islands Session Laws",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition (?P<law>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N. Mar. I. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "566 N. Mar. I. Reg. 126"
+            ],
+            "jurisdiction": "Northern Mariana Islands",
+            "name": "Northern Mariana Islands Commonwealth Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.C. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "338 N.C. Admin. Code 08"
+            ],
+            "jurisdiction": "North Carolina",
+            "name": "North Carolina Administrative Code (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.C. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-174 N.C. Adv. Legis. Serv. 424"
+            ],
+            "jurisdiction": "North Carolina",
+            "name": "North Carolina <year> Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.C. Gen. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "N.C. Gen. Stat. § 50"
+            ],
+            "jurisdiction": "North Carolina",
+            "name": "General Statutes of North Carolina (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.C. Gen. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "N.C. Gen. Stat. Ann. § 17"
+            ],
+            "jurisdiction": "North Carolina",
+            "name": "West's North Carolina General Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.C. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.C. Legis. Serv. 079"
+            ],
+            "jurisdiction": "North Carolina",
+            "name": "North Carolina Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.C. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "744 N.C. Reg. 56"
+            ],
+            "jurisdiction": "North Carolina",
+            "name": "North Carolina Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.C. Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.C. Sess. Laws 728"
+            ],
+            "jurisdiction": "North Carolina",
+            "name": "Session Laws of North Carolina",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.D. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "N.D. Admin. Code 132"
+            ],
+            "jurisdiction": "North Dakota",
+            "name": "North Dakota Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.D. Cent. Code": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "N.D. Cent. Code § 81-831"
+            ],
+            "jurisdiction": "North Dakota",
+            "name": "North Dakota Century Code (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.D. Cent. Code Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-933 N.D. Cent. Code Adv. Legis. Serv. 80,0"
+            ],
+            "jurisdiction": "North Dakota",
+            "name": "North Dakota Century Code <year> Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.D. Cent. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "N.D. Cent. Code Ann. § 18"
+            ],
+            "jurisdiction": "North Dakota",
+            "name": "West's North Dakota Century Code Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.D. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.D. Laws 491"
+            ],
+            "jurisdiction": "North Dakota",
+            "name": "Laws of North Dakota",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.D. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.D. Legis. Serv. 33,5"
+            ],
+            "jurisdiction": "North Dakota",
+            "name": "West's North Dakota Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.H. Code Admin. R. Ann.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "N.H. Code Admin. R. Ann. Empl. 044"
+            ],
+            "jurisdiction": "New Hampshire",
+            "name": "New Hampshire Code of Administrative Rules Annotated (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition $law_subject (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.H. Code R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "N.H. Code R. Empl. 497"
+            ],
+            "jurisdiction": "New Hampshire",
+            "name": "Code of New Hampshire Rules (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition $law_subject (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.H. Gov't Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "87 N.H. Gov't Reg. 91"
+            ],
+            "jurisdiction": "New Hampshire",
+            "name": "New Hampshire Government Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.H. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.H. Laws 833"
+            ],
+            "jurisdiction": "New Hampshire",
+            "name": "Laws of the State of New Hampshire (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.H. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.H. Legis. Serv. 7"
+            ],
+            "jurisdiction": "New Hampshire",
+            "name": "New Hampshire Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.H. Rev. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "N.H. Rev. Stat. Ann. § 5:41"
+            ],
+            "jurisdiction": "New Hampshire",
+            "name": "New Hampshire Revised Statutes Annotated (West); Lexis New Hampshire Revised Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.H. Rev. Stat. Ann. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-063 N.H. Rev. Stat. Ann. Adv. Legis. Serv. 7,48"
+            ],
+            "jurisdiction": "New Hampshire",
+            "name": "Lexis New Hampshire Revised Statutes Annotated <year> Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.H. Rulemaking Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "5 N.H. Rulemaking Reg. 6962"
+            ],
+            "jurisdiction": "New Hampshire",
+            "name": "New Hampshire Rulemaking Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.J. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "N.J. Admin. Code § 1"
+            ],
+            "jurisdiction": "New Jersey",
+            "name": "New Jersey Administrative Code (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.J. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.J. Laws 594"
+            ],
+            "jurisdiction": "New Jersey",
+            "name": "Laws of New Jersey",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.J. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "374 N.J. Reg. 17"
+            ],
+            "jurisdiction": "New Jersey",
+            "name": "New Jersey Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.J. Rev. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "N.J. Rev. Stat. § 9-513:53"
+            ],
+            "jurisdiction": "New Jersey",
+            "name": "New Jersey Revised Statutes (2013)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.J. Sess. Law Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.J. Sess. Law Serv. 00"
+            ],
+            "jurisdiction": "New Jersey",
+            "name": "New Jersey Session Law Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.J. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "N.J. Stat. Ann. § 0.21-05"
+            ],
+            "jurisdiction": "New Jersey",
+            "name": "New Jersey Statutes Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.M. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.M. Adv. Legis. Serv. 31,7"
+            ],
+            "jurisdiction": "New Mexico",
+            "name": "New Mexico Advance Legislative Service (Conway Greene)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.M. Code R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "N.M. Code R. § 4.887.8"
+            ],
+            "jurisdiction": "New Mexico",
+            "name": "Code of New Mexico Rules (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.M. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.M. Laws 76"
+            ],
+            "jurisdiction": "New Mexico",
+            "name": "Laws of the State of New Mexico",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.M. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.M. Legis. Serv. 5"
+            ],
+            "jurisdiction": "New Mexico",
+            "name": "West's New Mexico Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.M. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "19 N.M. Reg. 9"
+            ],
+            "jurisdiction": "New Mexico",
+            "name": "New Mexico Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.M. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "N.M. Stat. Ann. § 641"
+            ],
+            "jurisdiction": "New Mexico",
+            "name": "New Mexico Statutes Annotated 1978 (Conway Greene); West's New Mexico Statutes Annotated; Michie's Annotated Statutes of New Mexico (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y.": [
+        {
+            "cite_type": "leg_act",
+            "end": null,
+            "examples": [
+                "N.Y. Empl. § 85"
+            ],
+            "jurisdiction": "New York",
+            "name": "McKinney's Consolidated Laws; Consolidated Laws Service; LexisNexis New York Consolidated Laws Unannotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition $law_subject § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y. Comp. Codes R. & Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "N.Y. Comp. Codes R. & Regs. tit. 01, § 38-9:0"
+            ],
+            "jurisdiction": "New York",
+            "name": "Official Compilation of Codes, Rules & Regulations of the State of New York (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y. Consol. Laws Adv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-975 N.Y. Consol. Laws Adv."
+            ],
+            "jurisdiction": "New York",
+            "name": "New York Consolidated Laws Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y. Law": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "N.Y. Empl. Law § 24:09"
+            ],
+            "jurisdiction": "New York",
+            "name": "McKinney's Consolidated Laws of New York Annotated (West); New York Consolidated Laws Service (LexisNexis); New York Consolidated Laws Unannotated (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<reporter>N\\.Y\\. $law_subject Law) § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.Y. Laws 19"
+            ],
+            "jurisdiction": "New York",
+            "name": "Laws of New York",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "N.Y. Legis. Serv. 4"
+            ],
+            "jurisdiction": "New York",
+            "name": "Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "6 N.Y. Reg. 9"
+            ],
+            "jurisdiction": "New York",
+            "name": "New York State Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "N.Y. Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 N.Y. Sess. Laws 9"
+            ],
+            "jurisdiction": "New York",
+            "name": "McKinney's Session Laws of New York (West) (McKinney)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Navajo Nation Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Navajo Nation Code Ann. tit. 52, § 4:57.42"
+            ],
+            "jurisdiction": "Navajo Nation",
+            "name": "Navajo Nation Code Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Neb. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "74 Neb. Admin. Code § 9-58.82"
+            ],
+            "jurisdiction": "Nebraska",
+            "name": "Nebraska Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Neb. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Neb. Laws 7"
+            ],
+            "jurisdiction": "Nebraska",
+            "name": "Laws of Nebraska",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Neb. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Neb. Legis. Serv. 3"
+            ],
+            "jurisdiction": "Nebraska",
+            "name": "West's Nebraska Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Neb. Rev. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Neb. Rev. Stat. § 352.853"
+            ],
+            "jurisdiction": "Nebraska",
+            "name": "Revised Statutes of Nebraska",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Neb. Rev. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Neb. Rev. Stat. Ann. § 865.5:868"
+            ],
+            "jurisdiction": "Nebraska",
+            "name": "Revised Statutes of Nebraska Annotated (LexisNexis); West's Revised Statutes of Nebraska Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Nev. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Nev. Admin. Code § 73:9"
+            ],
+            "jurisdiction": "Nevada",
+            "name": "Nevada Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Nev. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Nev. Legis. Serv. 7"
+            ],
+            "jurisdiction": "Nevada",
+            "name": "West's Nevada Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Nev. Reg. Admin. Regs.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "2 Nev. Reg. Admin. Regs. 710"
+            ],
+            "jurisdiction": "Nevada",
+            "name": "Nevada Register of Administrative Regulations",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition (?P<reg>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Nev. Rev. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Nev. Rev. Stat. § 1.616-28"
+            ],
+            "jurisdiction": "Nevada",
+            "name": "Nevada Revised Statutes",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Nev. Rev. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Nev. Rev. Stat. Ann. § 140:737"
+            ],
+            "jurisdiction": "Nevada",
+            "name": "Michie's Nevada Revised Statutes Annotated (LexisNexis); West's Nevada Revised Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Nev. Stat.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Nev. Stat. 3"
+            ],
+            "jurisdiction": "Nevada",
+            "name": "Statutes of Nevada",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ohio Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Ohio Admin. Code 5"
+            ],
+            "jurisdiction": "Ohio",
+            "name": "Baldwin's Ohio Administrative Code (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ohio Dep't": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "Ohio Dep't 39"
+            ],
+            "jurisdiction": "Ohio",
+            "name": "Ohio Department Reports",
+            "notes": "Automatically generated. Remove this message if replacing with real examples. Indigo Book dates 1914-1964.",
+            "regexes": [
+                "$edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ohio Gov't": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "Ohio Gov't 38,7"
+            ],
+            "jurisdiction": "Ohio",
+            "name": "Ohio Government Reports",
+            "notes": "Automatically generated. Remove this message if replacing with real examples. Indigo Book dates 1965-1976.",
+            "regexes": [
+                "$edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ohio Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ohio Laws 4"
+            ],
+            "jurisdiction": "Ohio",
+            "name": "State of Ohio: Legislative Acts Passed and Joint Resolutions Adopted",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ohio Legis. Bull.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ohio Legis. Bull. 6"
+            ],
+            "jurisdiction": "Ohio",
+            "name": "Page's Ohio Legislative Bulletin (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ohio Legis. Serv. Ann.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Ohio Legis. Serv. Ann. 4767"
+            ],
+            "jurisdiction": "Ohio",
+            "name": "Baldwin's Ohio Legislative Service Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ohio Monthly Rec.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "Ohio Monthly Rec. 6"
+            ],
+            "jurisdiction": "Ohio",
+            "name": "Baldwin's Ohio Monthly Record",
+            "notes": "Automatically generated. Remove this message if replacing with real examples. Indigo Book dates 1977-date.",
+            "regexes": [
+                "$edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Ohio Rev. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Ohio Rev. Code Ann. § 34"
+            ],
+            "jurisdiction": "Ohio",
+            "name": "Page's Ohio Revised Code Annotated (LexisNexis); Baldwin's Ohio Revised Code Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Okla. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Okla. Admin. Code § 21:1:912"
+            ],
+            "jurisdiction": "Oklahoma",
+            "name": "Oklahoma Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Okla. Gaz.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "059 Okla. Gaz. 9275"
+            ],
+            "jurisdiction": "Oklahoma",
+            "name": "Oklahoma Gazette 1962-1983",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Okla. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "87 Okla. Reg. 453"
+            ],
+            "jurisdiction": "Oklahoma",
+            "name": "Oklahoma Register 1983-date",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Okla. Sess. Law Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Okla. Sess. Law Serv. 9"
+            ],
+            "jurisdiction": "Oklahoma",
+            "name": "Oklahoma Session Law Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Okla. Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Okla. Sess. Laws 1"
+            ],
+            "jurisdiction": "Oklahoma",
+            "name": "Oklahoma Session Laws (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Okla. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Okla. Stat. tit. 425, § 838-00-01"
+            ],
+            "jurisdiction": "Oklahoma",
+            "name": "Oklahoma Statutes (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Okla. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Okla. Stat. Ann. tit. 2, § 559"
+            ],
+            "jurisdiction": "Oklahoma",
+            "name": "Oklahoma Statutes Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Or. Admin. R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Or. Admin. R. 454"
+            ],
+            "jurisdiction": "Oregon",
+            "name": "Oregon Administrative Rules",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Or. Bull.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "2 Or. Bull. 8803"
+            ],
+            "jurisdiction": "Oregon",
+            "name": "Oregon Bulletin",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Or. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Or. Laws 2"
+            ],
+            "jurisdiction": "Oregon",
+            "name": "Oregon Laws and Resolutions",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Or. Laws Adv. Sh.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Or. Laws Adv. Sh. No. 801, 0072"
+            ],
+            "jurisdiction": "Oregon",
+            "name": "",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition No\\. (?P<number>\\d+), $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Or. Laws Spec. Sess.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Or. Laws Spec. Sess. 0"
+            ],
+            "jurisdiction": "Oregon",
+            "name": "",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Or. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Or. Legis. Serv. 3"
+            ],
+            "jurisdiction": "Oregon",
+            "name": "West's Oregon Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Or. Rev. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Or. Rev. Stat. § 733"
+            ],
+            "jurisdiction": "Oregon",
+            "name": "Oregon Revised Statutes",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Or. Rev. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Or. Rev. Stat. Ann. § 837-3.93"
+            ],
+            "jurisdiction": "Oregon",
+            "name": "West's Oregon Revised Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "P.R. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 P.R. Laws 8"
+            ],
+            "jurisdiction": "Puerto Rico",
+            "name": "Laws of Puerto Rico",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "P.R. Laws Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "P.R. Laws Ann. tit. 326, § 352-04:737"
+            ],
+            "jurisdiction": "Puerto Rico",
+            "name": "Laws of Puerto Rico Annotated (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "P.R. Leyes": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 P.R. Leyes 0"
+            ],
+            "jurisdiction": "Puerto Rico",
+            "name": "Leyes de Puerto Rico (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "P.R. Leyes An.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "P.R. Leyes An. tit. 861, § 47.8-6"
+            ],
+            "jurisdiction": "Puerto Rico",
+            "name": "Leyes de Puerto Rico Anotadas (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Pa. Bull.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "52 Pa. Bull. 5"
+            ],
+            "jurisdiction": "Pennsylvania",
+            "name": "Pennsylvania Bulletin (Fry Communications)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Pa. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "92 Pa. Code § 7:97"
+            ],
+            "jurisdiction": "Pennsylvania",
+            "name": "Pennsylvania Code (Fry Communications)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Pa. Cons. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "1 Pa. Cons. Stat. § 229:08"
+            ],
+            "jurisdiction": "Pennsylvania",
+            "name": "Pennsylvania Consolidated Statutes",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Pa. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Pa. Laws 9825"
+            ],
+            "jurisdiction": "Pennsylvania",
+            "name": "Laws of Pennsylvania",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Pa. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Pa. Legis. Serv. 9"
+            ],
+            "jurisdiction": "Pennsylvania",
+            "name": "Purdon's Pennsylvania Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Pa. Stat. and Cons. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "8 Pa. Stat. and Cons. Stat. Ann. § 3"
+            ],
+            "jurisdiction": "Pennsylvania",
+            "name": "Purdon's Pennsylvania Statutes and Consolidated Statutes Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "R.I. Acts & Resolves": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 R.I. Acts & Resolves 7"
+            ],
+            "jurisdiction": "Rhode Island",
+            "name": "Acts and Resolves of Rhode Island and Providence Plantations",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "R.I. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-364 R.I. Adv. Legis. Serv. 3"
+            ],
+            "jurisdiction": "Rhode Island",
+            "name": "Rhode Island Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        },
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 R.I. Adv. Legis. Serv. 6479"
+            ],
+            "jurisdiction": "Rhode Island",
+            "name": "West's Rhode Island Advance Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "R.I. Code R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "831-537 R.I. Code R. § 28.72:41"
+            ],
+            "jurisdiction": "Rhode Island",
+            "name": "Code of Rhode Island Rules (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+)\\-(?P<chapter>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "R.I. Gen. Laws": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "0 R.I. Gen. Laws § 56"
+            ],
+            "jurisdiction": "Rhode Island",
+            "name": "General Laws of Rhode Island (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "R.I. Gen. Laws Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "296 R.I. Gen. Laws Ann. § 9:6.918"
+            ],
+            "jurisdiction": "Rhode Island",
+            "name": "West's General Laws of Rhode Island Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "R.I. Gov't Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "41 R.I. Gov't Reg. 66"
+            ],
+            "jurisdiction": "Rhode Island",
+            "name": "Rhode Island Government Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "R.I. Pub. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 R.I. Pub. Laws 1577"
+            ],
+            "jurisdiction": "Rhode Island",
+            "name": "Public Laws of Rhode Island and Providence Plantations",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Repub. Tex. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Repub. Tex. Laws 2"
+            ],
+            "jurisdiction": "Texas",
+            "name": "Laws of the Republic of Texas",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "S.C. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 S.C. Acts 96"
+            ],
+            "jurisdiction": "South Carolina",
+            "name": "Acts and Joint Resolutions, South Carolina",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "S.C. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "S.C. Code Ann. § 07-903"
+            ],
+            "jurisdiction": "South Carolina",
+            "name": "Code of Laws of South Carolina 1976 Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "S.C. Code Ann. Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "S.C. Code Ann. Regs. 09"
+            ],
+            "jurisdiction": "South Carolina",
+            "name": "Code of Laws of South Carolina 1976 Annotated:Code of Regulations (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition (?P<reg>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "S.C. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "571 S.C. Reg. 3514"
+            ],
+            "jurisdiction": "South Carolina",
+            "name": "South Carolina State Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "S.D. Admin. R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "S.D. Admin. R. 4"
+            ],
+            "jurisdiction": "South Dakota",
+            "name": "Administrative Rules of South Dakota",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "S.D. Codified Laws": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "S.D. Codified Laws § 5"
+            ],
+            "jurisdiction": "South Dakota",
+            "name": "South Dakota Codified Laws (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "S.D. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "250 S.D. Reg. 8"
+            ],
+            "jurisdiction": "South Dakota",
+            "name": "South Dakota Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "S.D. Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 S.D. Sess. Laws ch\\w 12 § 40:441 03"
+            ],
+            "jurisdiction": "South Dakota",
+            "name": "Session Laws of South Dakota",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition ch\\\\. (?P<chapter>\\d+) § $law_section $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Stat.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "82 Stat. 6"
+            ],
+            "jurisdiction": "District of Columbia",
+            "name": "United States Statutes at Large",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tenn. Admin. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "81 Tenn. Admin. Reg. 211"
+            ],
+            "jurisdiction": "Tennessee",
+            "name": "Tennessee Administrative Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tenn. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Tenn. Code Ann. § 6"
+            ],
+            "jurisdiction": "Tennessee",
+            "name": "Tennessee Code Annotated (LexisNexis); West's Tennessee Code Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tenn. Code Ann. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-6 Tenn. Code Ann. Adv. Legis. Serv. 0"
+            ],
+            "jurisdiction": "Tennessee",
+            "name": "Tennessee Code Annotated Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tenn. Comp. R. & Regs.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Tenn. Comp. R. & Regs. 522"
+            ],
+            "jurisdiction": "Tennessee",
+            "name": "Official Compilation Rules & Regulations of the State of Tennessee",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition (?P<rule>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tenn. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Tenn. Legis. Serv. 7"
+            ],
+            "jurisdiction": "Tennessee",
+            "name": "West's Tennessee Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tenn. Priv. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Tenn. Priv. Acts 0"
+            ],
+            "jurisdiction": "Tennessee",
+            "name": "Private Acts of the State of Tennessee",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tenn. Pub. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Tenn. Pub. Acts 8"
+            ],
+            "jurisdiction": "Tennessee",
+            "name": "Public Acts of the State of Tennessee",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "30 Tex. Admin. Code § 162-05.0"
+            ],
+            "jurisdiction": "Texas",
+            "name": "Texas Administrative Code (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. Bus. Corp. Act Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Tex. Bus. Corp. Act Ann. art 3"
+            ],
+            "jurisdiction": "Texas",
+            "name": "Vernon's Texas Business Corporation Act Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition art (?P<article>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Tex. Empl. Code Ann. § 025:2-2"
+            ],
+            "jurisdiction": "Texas",
+            "name": "Vernon's Texas Codes Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<reporter>Tex\\. $law_subject Code Ann\\.) § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. Code Crim. Proc. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Tex. Code Crim. Proc. Ann. art 877"
+            ],
+            "jurisdiction": "Texas",
+            "name": "Vernon's Texas Code of Criminal Procedure Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition art (?P<article>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. Gen. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Tex. Gen. Laws 1"
+            ],
+            "jurisdiction": "Texas",
+            "name": "General and Special Laws of the State of Texas",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. Ins. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Tex. Ins. Code Ann. art 288"
+            ],
+            "jurisdiction": "Texas",
+            "name": "Vernon's Texas Insurance Code Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition art (?P<article>\\d+)"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. Prob. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Tex. Prob. Code Ann. § 02:69"
+            ],
+            "jurisdiction": "Texas",
+            "name": "Vernon's Texas Probate Code Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "4 Tex. Reg. 3"
+            ],
+            "jurisdiction": "Texas",
+            "name": "Texas Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. Rev. Civ. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Tex. Rev. Civ. Stat. Ann. art 49, § 61-64-81"
+            ],
+            "jurisdiction": "Texas",
+            "name": "Vernon's Texas Revised Civil Statutes Annotated (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition art (?P<article>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Tex. Sess. Law Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Tex. Sess. Law Serv. 0"
+            ],
+            "jurisdiction": "Texas",
+            "name": "Vernon's Texas Session Law Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Utah Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Utah Admin. Code r. 031:409.889"
+            ],
+            "jurisdiction": "Utah",
+            "name": "Utah Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition r\\. $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Utah Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-311 Utah Adv. Legis. Serv. 6"
+            ],
+            "jurisdiction": "Utah",
+            "name": "Utah Code <year> Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Utah Bull.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "630 Utah Bull. 2"
+            ],
+            "jurisdiction": "Utah",
+            "name": "Utah State Bulletin",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Utah Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Utah Code Ann. § 506-41-9"
+            ],
+            "jurisdiction": "Utah",
+            "name": "Utah Code Annotated (LexisNexis); West's Utah Code Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Utah Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Utah Laws 545"
+            ],
+            "jurisdiction": "Utah",
+            "name": "Laws of Utah",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Utah. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Utah. Legis. Serv. 0"
+            ],
+            "jurisdiction": "Utah",
+            "name": "Utah Legislative Service (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "V.I. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "V.I. Code Ann. tit. 24, § 183.04:688 1999"
+            ],
+            "jurisdiction": "Virgin Islands",
+            "name": "Virgin Islands Code Annotated (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples. Indigo Book dates 1962-date.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section $law_year"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "V.I. Code Ann. Adv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-2 V.I. Code Ann. Adv."
+            ],
+            "jurisdiction": "Virgin Islands",
+            "name": "Virgin Islands Code Annotated Advance",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "V.I. Code R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "8-063 V.I. Code R. § 425:846"
+            ],
+            "jurisdiction": "Virgin Islands",
+            "name": "Code of U.S. Virgin Islands Rules (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+)\\-(?P<chapter>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "V.I. Gov't Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "69 V.I. Gov't Reg. 8548"
+            ],
+            "jurisdiction": "Virgin Islands",
+            "name": "Virgin Islands Government Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "V.I. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "V.I. Legis. Serv. 8"
+            ],
+            "jurisdiction": "Virgin Islands",
+            "name": "Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "V.I. Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 V.I. Sess. Laws 8"
+            ],
+            "jurisdiction": "Virgin Islands",
+            "name": "Session Laws of the Virgin Islands",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Va. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Va. Acts 9"
+            ],
+            "jurisdiction": "Virginia",
+            "name": "Acts of the General Assembly of the Commonwealth of Virginia",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Va. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "18 Va. Admin. Code § 79"
+            ],
+            "jurisdiction": "Virginia",
+            "name": "Virginia Administrative Code (West)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Va. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-258 Va. Adv. Legis. Serv. 9"
+            ],
+            "jurisdiction": "Virginia",
+            "name": "Virginia <year> Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Va. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Va. Code Ann. § 23.1:955"
+            ],
+            "jurisdiction": "Virginia",
+            "name": "Code of Virginia 1950 Annotated (LexisNexis); West's Annotated Code of Virginia",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Va. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Va. Legis. Serv. 9"
+            ],
+            "jurisdiction": "Virginia",
+            "name": "West's Virginia Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Va. Reg. Regs.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "39 Va. Reg. Regs. 3847"
+            ],
+            "jurisdiction": "Virginia",
+            "name": "Virginia Register of Regulations (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Vt. Acts & Resolves": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Vt. Acts & Resolves 2"
+            ],
+            "jurisdiction": "Vermont",
+            "name": "Acts and Resolves of Vermont",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Vt. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-547 Vt. Adv. Legis. Serv. 5"
+            ],
+            "jurisdiction": "Vermont",
+            "name": "Vermont <year> Advance Legislative Service(LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Vt. Code R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "81-597 Vt. Code R. § 238-7.8"
+            ],
+            "jurisdiction": "Vermont",
+            "name": "Code of Vermont Rules (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+)\\-(?P<chapter>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Vt. Gov't Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "34 Vt. Gov't Reg. 70,4"
+            ],
+            "jurisdiction": "Vermont",
+            "name": "Vermont Government Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Vt. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Vt. Legis. Serv. 8446"
+            ],
+            "jurisdiction": "Vermont",
+            "name": "West's Vermont Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Vt. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Vt. Stat. Ann. tit. 99, § 2"
+            ],
+            "jurisdiction": "Vermont",
+            "name": "Vermont Statutes Annotated (LexisNexis); West's Vermont Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition tit\\. (?P<title>\\d+), § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "W. Va. Acts": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 W. Va. Acts 8"
+            ],
+            "jurisdiction": "West Virginia",
+            "name": "Acts of the Legislature of West Virginia",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "W. Va. Adv. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999-52 W. Va. Adv. Legis. Serv. 18,7"
+            ],
+            "jurisdiction": "West Virginia",
+            "name": "West Virginia <year> Advance Legislative Service (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year\\-(?P<pamphlet>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "W. Va. Code": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "W. Va. Code § 4-829"
+            ],
+            "jurisdiction": "West Virginia",
+            "name": "West Virginia Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "W. Va. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "W. Va. Code Ann. § 7"
+            ],
+            "jurisdiction": "West Virginia",
+            "name": "Michie's West Virginia Code Annotated (LexisNexis); West's Annotated Code of West Virginia",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "W. Va. Code R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "W. Va. Code R. § 5:3.79"
+            ],
+            "jurisdiction": "West Virginia",
+            "name": "West Virginia Code of State Rules",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "W. Va. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 W. Va. Legis. Serv. 159"
+            ],
+            "jurisdiction": "West Virginia",
+            "name": "West's West Virginia Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "W. Va. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "1 W. Va. Reg. 8939"
+            ],
+            "jurisdiction": "West Virginia",
+            "name": "West Virginia Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$volume $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wash. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Wash. Admin. Code § 6:945"
+            ],
+            "jurisdiction": "Washington",
+            "name": "Washington Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wash. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Wash. Legis. Serv. 1"
+            ],
+            "jurisdiction": "Washington",
+            "name": "West's Washington Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wash. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "07 Wash. Reg. 946"
+            ],
+            "jurisdiction": "Washington",
+            "name": "Washington State Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wash. Rev. Code": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Wash. Rev. Code § 32:7-703"
+            ],
+            "jurisdiction": "Washington",
+            "name": "Revised Code of Washington",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wash. Rev. Code Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Wash. Rev. Code Ann. § 73"
+            ],
+            "jurisdiction": "Washington",
+            "name": "West's Revised Code of Washington Annotated; Annotated Revised Code of Washington (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wash. Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Wash. Sess. Laws 0"
+            ],
+            "jurisdiction": "Washington",
+            "name": "Session Laws of Washington",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wis. Admin. Code": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "Wis. Admin. Code SvTr § 4"
+            ],
+            "jurisdiction": "Wisconsin",
+            "name": "Wisconsin Administrative Code",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition (?P<agency>[A-Z][A-Za-z]+) § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wis. Admin. Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "95 Wis. Admin. Reg. 0198"
+            ],
+            "jurisdiction": "Wisconsin",
+            "name": "Wisconsin Administrative Register",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wis. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Wis. Legis. Serv. 0"
+            ],
+            "jurisdiction": "Wisconsin",
+            "name": "West's Wisconsin Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wis. Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Wis. Sess. Laws 741"
+            ],
+            "jurisdiction": "Wisconsin",
+            "name": "Wisconsin Session Laws",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wis. Stat.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Wis. Stat. § 8-431-7"
+            ],
+            "jurisdiction": "Wisconsin",
+            "name": "Wisconsin Statutes",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wis. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Wis. Stat. Ann. § 32:6"
+            ],
+            "jurisdiction": "Wisconsin",
+            "name": "West's Wisconsin Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wyo. Code R.": [
+        {
+            "cite_type": "admin_compilation",
+            "end": null,
+            "examples": [
+                "6-61 Wyo. Code R. § 194"
+            ],
+            "jurisdiction": "Wyoming",
+            "name": "Code of Wyoming Rules (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<title>\\d+)\\-(?P<chapter>\\d+) $edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wyo. Gov't Reg.": [
+        {
+            "cite_type": "admin_register",
+            "end": null,
+            "examples": [
+                "501 Wyo. Gov't Reg. 1"
+            ],
+            "jurisdiction": "Wyoming",
+            "name": "Wyoming Government Register (LexisNexis)",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "(?P<issue>\\d+) $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wyo. Legis. Serv.": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Wyo. Legis. Serv. 3"
+            ],
+            "jurisdiction": "Wyoming",
+            "name": "West's Wyoming Legislative Service",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wyo. Sess. Laws": [
+        {
+            "cite_type": "leg_session",
+            "end": null,
+            "examples": [
+                "1999 Wyo. Sess. Laws 305"
+            ],
+            "jurisdiction": "Wyoming",
+            "name": "Session Laws of Wyoming",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$law_year $edition $page_with_commas"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ],
+    "Wyo. Stat. Ann.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Wyo. Stat. Ann. § 7-505"
+            ],
+            "jurisdiction": "Wyoming",
+            "name": "Wyoming Statutes Annotated (LexisNexis); West's Wyoming Statutes Annotated",
+            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "regexes": [
+                "$edition § $law_section"
+            ],
+            "start": null,
+            "variations": []
+        }
+    ]
+}

--- a/reporters_db/data/regexes.json
+++ b/reporters_db/data/regexes.json
@@ -44,6 +44,18 @@
         "": "(?P<reporter>$edition)",
         "#": "Standard reporter"
     },
+    "law": {
+        "#": "Regexes used in laws.json",
+        "day": "(?P<day>\\d{1,2}),?",
+        "month": "(?P<month>[A-Z][a-z]+\\.?)",
+        "section": "(?P<section>\\d+(?:[\\-.:]\\d+){,3})",
+        "section#": "Section like 1-2-3, 1.2.3, or 1:2-3.4",
+        "subject": "(?P<subject>$law_subject_word(?: $law_subject_word| &){,4})",
+        "subject#": "One to five word statute subject like 'Parks Rec. & Hist. Preserv.', 'Not-for-Profit Corp.', 'Alt. County Gov’t', 'R.R.'",
+        "subject_word": "[A-Z][.\\-'A-Za-z]*",
+        "subject_word#": "Single word in statute subject, like Rec., Gov't, or Not-for-Profit",
+        "year": "(?P<year>1\\d{3}|20\\d{2})"
+    },
     "volume": {
         "": "(?P<volume>\\d+)",
         "#": "Standard volume number",

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -634,7 +634,7 @@
                 }
             },
             "mlz_jurisdiction": [],
-            "name": "Americans with  Disabilities Decisions",
+            "name": "Americans with Disabilities Decisions",
             "variations": {}
         }
     ],
@@ -5596,7 +5596,7 @@
                 "us:nj;supreme.court"
             ],
             "name": "Gummere's Reports",
-            "notes": "Estimated date range.  https://www.njstatelib.org/research_library/legal_resources/historical_laws/reporters/",
+            "notes": "Estimated date range. https://www.njstatelib.org/research_library/legal_resources/historical_laws/reporters/",
             "variations": {}
         }
     ],
@@ -8055,7 +8055,7 @@
                 }
             },
             "mlz_jurisdiction": [],
-            "name": "Lowell's District  Court Reports (US Mass. Dist.)",
+            "name": "Lowell's District Court Reports (US Mass. Dist.)",
             "variations": {}
         }
     ],
@@ -8125,7 +8125,7 @@
                 "us:md;circuit.court"
             ],
             "name": "Maryland Business and Technology",
-            "notes": "Appears to be a neutral citation, published but not precedential.  See url: https://mdcourts.gov/businesstech/opinions",
+            "notes": "Appears to be a neutral citation, published but not precedential. See url: https://mdcourts.gov/businesstech/opinions",
             "variations": {}
         }
     ],
@@ -10377,7 +10377,7 @@
                 }
             },
             "mlz_jurisdiction": [],
-            "name": "Newberry's  District Court Admiralty Rep. United States (US)",
+            "name": "Newberry's District Court Admiralty Rep. United States (US)",
             "variations": {}
         }
     ],
@@ -11731,7 +11731,7 @@
                 }
             },
             "mlz_jurisdiction": [],
-            "name": "Paine's United  States (US) Circuit Court Reports",
+            "name": "Paine's United States (US) Circuit Court Reports",
             "variations": {}
         }
     ],
@@ -11967,7 +11967,7 @@
                 }
             },
             "mlz_jurisdiction": [],
-            "name": "Peters' District  Court Admiralty Reports",
+            "name": "Peters' District Court Admiralty Reports",
             "variations": {}
         }
     ],
@@ -13304,7 +13304,7 @@
                 }
             },
             "mlz_jurisdiction": [],
-            "name": "Sprague's United  States (US) District Ct. (Admiralty) Decisions",
+            "name": "Sprague's United States (US) District Ct. (Admiralty) Decisions",
             "variations": {}
         }
     ],
@@ -14935,7 +14935,7 @@
                 "us:c2:ny.sd;district.court",
                 "us:c2:ny.wd;district.court"
             ],
-            "name": "Van Ness' Prize  Cases, United States (US) District Court, District of New York (NY)",
+            "name": "Van Ness' Prize Cases, United States (US) District Court, District of New York (NY)",
             "variations": {}
         }
     ],
@@ -15389,7 +15389,7 @@
                 }
             },
             "mlz_jurisdiction": [],
-            "name": "Ware's United  States (US) District Court Reports",
+            "name": "Ware's United States (US) District Court Reports",
             "variations": {}
         }
     ],

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -638,24 +638,6 @@
             "variations": {}
         }
     ],
-    "Am. J. Juris.": [
-        {
-            "cite_type": "federal",
-            "editions": {
-                "Am. J. Juris.": {
-                    "end": null,
-                    "start": "1969-01-01T00:00:00"
-                }
-            },
-            "mlz_jurisdiction": [],
-            "name": "American Journal of Jurisprudence",
-            "notes": "Published by Notre Dame Law School",
-            "variations": {
-                "Am. J. Jurispr": "Am. J. Juris.",
-                "Am. J. Jurisprud": "Am. J. Juris."
-            }
-        }
-    ],
     "Am. Law Reg.": [
         {
             "cite_type": "state",
@@ -1090,6 +1072,20 @@
             }
         }
     ],
+    "B.C.A. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "B.C.A. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Board of Contract Appeals Decisions",
+            "variations": {}
+        }
+    ],
     "B.R.": [
         {
             "cite_type": "specialty",
@@ -1365,6 +1361,20 @@
             "variations": {}
         }
     ],
+    "Banking Rep. (BNA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Banking Rep. (BNA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "BNA's Banking Report",
+            "variations": {}
+        }
+    ],
     "Bankr. Ct. Dec. (CRR)": [
         {
             "cite_type": "specialty",
@@ -1381,6 +1391,20 @@
                 "Bankr. Ct. Dec.": "Bankr. Ct. Dec. (CRR)",
                 "Bankr.Ct.Dec.": "Bankr. Ct. Dec. (CRR)"
             }
+        }
+    ],
+    "Bankr. Ct. Dec. (LRP)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Bankr. Ct. Dec. (LRP)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Bankruptcy Court Decisions",
+            "variations": {}
         }
     ],
     "Bankr. Ct. Rep.": [
@@ -1595,6 +1619,20 @@
             "variations": {}
         }
     ],
+    "Ben. Rev. Bd. Serv. (MB)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Ben. Rev. Bd. Serv. (MB)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Benefits Review Board Service",
+            "variations": {}
+        }
+    ],
     "Bibb": [
         {
             "cite_type": "state",
@@ -1744,6 +1782,20 @@
                 "Blatchf. C.C.": "Blatchf.",
                 "Blatchf. C.C. Rep.": "Blatchf."
             }
+        }
+    ],
+    "Blue Sky L. Rep. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Blue Sky L. Rep. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Blue Sky Law Reports",
+            "variations": {}
         }
     ],
     "Blume Sup. Ct. Trans.": [
@@ -2011,6 +2063,20 @@
                 "Burnett": "Bur.",
                 "Burnett (Wis.)": "Bur."
             }
+        }
+    ],
+    "Bus. Franchise Guide (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Bus. Franchise Guide (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Business Franchise Guide",
+            "variations": {}
         }
     ],
     "Busb.": [
@@ -2583,6 +2649,34 @@
             }
         }
     ],
+    "Can. Com. L. Guide (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Can. Com. L. Guide (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Canadian Commercial Law Guide",
+            "variations": {}
+        }
+    ],
+    "Can. Tax Rep. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Can. Tax Rep. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Canadian Tax Reports",
+            "variations": {}
+        }
+    ],
     "Car. L. Rep.": [
         {
             "cite_type": "state",
@@ -2636,22 +2730,6 @@
             }
         }
     ],
-    "Cent. Law J.": [
-        {
-            "cite_type": "specialty",
-            "editions": {
-                "Cent. Law J.": {
-                    "end": null,
-                    "start": "1750-01-01T00:00:00"
-                }
-            },
-            "mlz_jurisdiction": [],
-            "name": "North Carolina (NC) Central Law Journal",
-            "variations": {
-                "N.C. Cent. L.J.": "Cent. Law J."
-            }
-        }
-    ],
     "Chand.": [
         {
             "cite_type": "state",
@@ -2685,6 +2763,20 @@
             "variations": {
                 "Chase.": "Chase"
             }
+        }
+    ],
+    "Chem. Reg. Rep. (BNA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Chem. Reg. Rep. (BNA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Chemical Regulation Reporter",
+            "variations": {}
         }
     ],
     "Chest.": [
@@ -2758,6 +2850,20 @@
                 "us:c7:il.nd;district.court"
             ],
             "name": "Chicago Legal News (1868-1925) (Illinois)",
+            "variations": {}
+        }
+    ],
+    "Chicago Bd. Options Ex. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Chicago Bd. Options Ex. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Chicago Board Options Exchange",
             "variations": {}
         }
     ],
@@ -2966,6 +3072,20 @@
             }
         }
     ],
+    "Collective Bargaining Negot. & Cont. (BNA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Collective Bargaining Negot. & Cont. (BNA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Collective Bargaining Negotiations & Contracts",
+            "variations": {}
+        }
+    ],
     "Collier Bankr. Cas.": [
         {
             "cite_type": "specialty",
@@ -3076,24 +3196,6 @@
             "variations": {}
         }
     ],
-    "Colo. Law.": [
-        {
-            "cite_type": "state",
-            "editions": {
-                "Colo. Law.": {
-                    "end": null,
-                    "start": "1750-01-01T00:00:00"
-                }
-            },
-            "mlz_jurisdiction": [
-                "us:co;supreme.court"
-            ],
-            "name": "Colorado Lawyer",
-            "variations": {
-                "Colorado Law.": "Colo. Law."
-            }
-        }
-    ],
     "Comm. Fut. L. Rep.": [
         {
             "cite_type": "specialty",
@@ -3108,6 +3210,20 @@
             "variations": {
                 "Comm. Fut. L. Rep. (CCH)": "Comm. Fut. L. Rep."
             }
+        }
+    ],
+    "Commc'ns Reg. (P & F)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Commc'ns Reg. (P & F)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Communications Regulation",
+            "variations": {}
         }
     ],
     "Communications Reg. (P&F)": [
@@ -3129,6 +3245,20 @@
                 "Comm. Reg. (P & F)": "Communications Reg. (P&F)",
                 "Comm. Reg. 2d (P & F)": "Communications Reg. 2d (P&F)"
             }
+        }
+    ],
+    "Cong. Index(CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Cong. Index(CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Congressional Index",
+            "variations": {}
         }
     ],
     "Conn.": [
@@ -3291,6 +3421,48 @@
             }
         }
     ],
+    "Consumer Cred. Guide (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Consumer Cred. Guide (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Consumer Credit Guide",
+            "variations": {}
+        }
+    ],
+    "Consumer Prod. Safety Guide (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Consumer Prod. Safety Guide (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Consumer Product Safety Guide",
+            "variations": {}
+        }
+    ],
+    "Cont. App. Dec. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Cont. App. Dec. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Contract Appeals Decisions",
+            "variations": {}
+        }
+    ],
     "Cont. Cas. Fed.": [
         {
             "cite_type": "federal",
@@ -3344,6 +3516,48 @@
             },
             "mlz_jurisdiction": [],
             "name": "Copyright Law Reporter (CCH)",
+            "variations": {}
+        }
+    ],
+    "Copyright L. Dec. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Copyright L. Dec. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Copyright Law Decisions",
+            "variations": {}
+        }
+    ],
+    "Copyright L. Rep. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Copyright L. Rep. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Copyright Law Reporter",
+            "variations": {}
+        }
+    ],
+    "Cost Accounting Stand. Guide (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Cost Accounting Stand. Guide (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Cost Accounting Standards Guide",
             "variations": {}
         }
     ],
@@ -3421,6 +3635,20 @@
             }
         }
     ],
+    "Crim. L. Rep. (BNA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Crim. L. Rep. (BNA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "The Criminal Law Reporter",
+            "variations": {}
+        }
+    ],
     "Ct. Cl.": [
         {
             "cite_type": "specialty",
@@ -3492,20 +3720,6 @@
             "variations": {
                 "Ct.Int'l Trade": "Ct. Int'l Trade"
             }
-        }
-    ],
-    "Cumb. L. Rev.": [
-        {
-            "cite_type": "federal",
-            "editions": {
-                "Cumb. L. Rev.": {
-                    "end": null,
-                    "start": "1750-01-01T00:00:00"
-                }
-            },
-            "mlz_jurisdiction": [],
-            "name": "Cumberland Law Review",
-            "variations": {}
         }
     ],
     "Curt.": [
@@ -3658,6 +3872,20 @@
                 "us:ca;appeals.court"
             ],
             "name": "California Daily Journal Daily Appellate Reports",
+            "variations": {}
+        }
+    ],
+    "Daily Lab. Rep. (BNA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Daily Lab. Rep. (BNA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Daily Labor Report",
             "variations": {}
         }
     ],
@@ -4114,6 +4342,20 @@
             "variations": {}
         }
     ],
+    "Dominion Tax Cas. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Dominion Tax Cas. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Dominion Tax Cases",
+            "variations": {}
+        }
+    ],
     "Doug.": [
         {
             "cite_type": "state",
@@ -4231,6 +4473,20 @@
             }
         }
     ],
+    "EEOC Compl. Man. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "EEOC Compl. Man. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "EEOC Compliance Manual",
+            "variations": {}
+        }
+    ],
     "ERC": [
         {
             "cite_type": "specialty",
@@ -4321,6 +4577,34 @@
             }
         }
     ],
+    "Empl. Benefits Cas. (BNA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Empl. Benefits Cas. (BNA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Employee Benefits Cases",
+            "variations": {}
+        }
+    ],
+    "Empl. Coordinator (RIA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Empl. Coordinator (RIA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Employee Benefits Compliance Coordinator",
+            "variations": {}
+        }
+    ],
     "Empl. Prac. Dec. (CCH)": [
         {
             "cite_type": "specialty",
@@ -4349,6 +4633,34 @@
             }
         }
     ],
+    "Empl. Prac. Guide (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Empl. Prac. Guide (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Employment Practices Guide",
+            "variations": {}
+        }
+    ],
+    "Empl. Safety & Health Guide (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Empl. Safety & Health Guide (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Employment Safety and Health Guide",
+            "variations": {}
+        }
+    ],
     "Employee Benefits Cas. (BNA)": [
         {
             "cite_type": "specialty",
@@ -4363,6 +4675,48 @@
             "variations": {
                 "Employee Benefits Cas.": "Employee Benefits Cas. (BNA)"
             }
+        }
+    ],
+    "Energy Mgmt. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Energy Mgmt. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Energy Management & Federal Energy Guidelines",
+            "variations": {}
+        }
+    ],
+    "Env't Rep. (BNA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Env't Rep. (BNA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Environment Reporter",
+            "variations": {}
+        }
+    ],
+    "Env't Rep. Cas. (BNA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Env't Rep. Cas. (BNA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Environment Reporter Cases",
+            "variations": {}
         }
     ],
     "Envtl. L. Rep. (Envtl. Law Inst.)": [
@@ -4382,6 +4736,20 @@
                 "Envtl. L. Rep.": "Envtl. L. Rep. (Envtl. Law Inst.)",
                 "Envtl. L.Rep.": "Envtl. L. Rep. (Envtl. Law Inst.)"
             }
+        }
+    ],
+    "Exempt Org. Rep. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Exempt Org. Rep. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Exempt Organizations Reports",
+            "variations": {}
         }
     ],
     "F.": [
@@ -4843,6 +5211,34 @@
             }
         }
     ],
+    "Fam. L. Rep. (BNA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Fam. L. Rep. (BNA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "The Family Law Reporter",
+            "variations": {}
+        }
+    ],
+    "Fam. L. Tax Guide (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Fam. L. Tax Guide (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Family Law Tax Guide",
+            "variations": {}
+        }
+    ],
     "Fed. Appx.": [
         {
             "cite_type": "federal",
@@ -4858,6 +5254,20 @@
             "variations": {
                 "Fed.Appx.": "Fed. Appx."
             }
+        }
+    ],
+    "Fed. Audit Guide (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Fed. Audit Guide (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Federal Audit Guides",
+            "variations": {}
         }
     ],
     "Fed. Banking L. Rep. (CCH)": [
@@ -4895,6 +5305,20 @@
             }
         }
     ],
+    "Fed. Carr. Rep. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Fed. Carr. Rep. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Federal Carriers Reports",
+            "variations": {}
+        }
+    ],
     "Fed. Cl.": [
         {
             "cite_type": "specialty",
@@ -4911,6 +5335,90 @@
             "variations": {
                 "Fed.Cl.": "Fed. Cl."
             }
+        }
+    ],
+    "Fed. Cont. Rep. (BNA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Fed. Cont. Rep. (BNA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Federal Contracts Report",
+            "variations": {}
+        }
+    ],
+    "Fed. Election Camp. Fin. Guide (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Fed. Election Camp. Fin. Guide (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Federal Election Campaign Financing Guide",
+            "variations": {}
+        }
+    ],
+    "Fed. Energy Reg. Comm'n Rep. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Fed. Energy Reg. Comm'n Rep. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Federal Energy Regulatory Commission Reports",
+            "variations": {}
+        }
+    ],
+    "Fed. Est. & Gift Tax Rep. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Fed. Est. & Gift Tax Rep. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Federal Estate and Gift Tax Reporter",
+            "variations": {}
+        }
+    ],
+    "Fed. Ex. Tax Rep. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Fed. Ex. Tax Rep. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Federal Excise Tax Reports",
+            "variations": {}
+        }
+    ],
+    "Fed. Inc. Gift & Est. Tax'n (MB)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Fed. Inc. Gift & Est. Tax'n (MB)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Federal Income, Gift and Estate Taxation",
+            "variations": {}
         }
     ],
     "Fed. R. Serv.": [
@@ -5072,6 +5580,20 @@
             }
         }
     ],
+    "Fed. R. Serv. 2d (West)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Fed. R. Serv. 2d (West)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Federal Rules Service, Second Series",
+            "variations": {}
+        }
+    ],
     "Fed. Sec. L. Rep. (CCH)": [
         {
             "cite_format": "{reporter} {page}",
@@ -5112,6 +5634,34 @@
             "variations": {
                 "Fed. Sent. R.": "Fed. Sent'g Rep"
             }
+        }
+    ],
+    "Fed. Tax Coordinator Second Series (RIA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Fed. Tax Coordinator Second Series (RIA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Federal Tax Coordinator Second",
+            "variations": {}
+        }
+    ],
+    "Fed. Tax Guide Rep. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Fed. Tax Guide Rep. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Federal Tax Guide Reports",
+            "variations": {}
         }
     ],
     "Fire & Casualty Cas.": [
@@ -5266,6 +5816,20 @@
             "variations": {
                 "Flipp. (F.)": "Flip."
             }
+        }
+    ],
+    "Food Drug Cosm. L. Rep. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Food Drug Cosm. L. Rep. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Food Drug Cosmetic Law Reports",
+            "variations": {}
         }
     ],
     "Free. Ch.": [
@@ -5487,6 +6051,34 @@
             "variations": {
                 "Gilp": "Gilp."
             }
+        }
+    ],
+    "Gov't Cont. Rep. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Gov't Cont. Rep. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Government Contracts Reporter",
+            "variations": {}
+        }
+    ],
+    "Gov't Empl. Rel. Rep. (BNA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Gov't Empl. Rel. Rep. (BNA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Government Employee Relations Report",
+            "variations": {}
         }
     ],
     "Grant": [
@@ -5813,21 +6405,6 @@
             },
             "mlz_jurisdiction": [],
             "name": "Haskell's Reports",
-            "variations": {}
-        }
-    ],
-    "Hastings L.J.": [
-        {
-            "cite_type": "specialty",
-            "editions": {
-                "Hastings L.J.": {
-                    "end": null,
-                    "start": "1949-01-01T00:00:00"
-                }
-            },
-            "mlz_jurisdiction": [],
-            "name": "Hastings Law Journal",
-            "notes": "University of California, Hastings College of the Law Journal",
             "variations": {}
         }
     ],
@@ -6184,6 +6761,20 @@
             "variations": {
                 "Hopk. Ch. Rep.": "Hopk. Ch."
             }
+        }
+    ],
+    "Hous. & Dev. Rep. (RIA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Hous. & Dev. Rep. (RIA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Housing & Development Reporter",
+            "variations": {}
         }
     ],
     "Houston": [
@@ -6587,6 +7178,20 @@
             }
         }
     ],
+    "IRS Pos. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "IRS Pos. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "IRS Positions",
+            "variations": {}
+        }
+    ],
     "Idaho": [
         {
             "cite_type": "state",
@@ -6724,6 +7329,20 @@
             }
         }
     ],
+    "Immigr. L. Serv. (West)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Immigr. L. Serv. (West)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Immigration Law Service",
+            "variations": {}
+        }
+    ],
     "Ind.": [
         {
             "cite_type": "state",
@@ -6795,6 +7414,34 @@
                 "Ind. T.": "Indian Terr.",
                 "Ind.T.": "Indian Terr."
             }
+        }
+    ],
+    "Inher. Est. & Gift Tax Rep. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Inher. Est. & Gift Tax Rep. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Inheritance, Estate and Gift Tax Reports",
+            "variations": {}
+        }
+    ],
+    "Ins. L. Rep. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Ins. L. Rep. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Insurance Law Reports",
+            "variations": {}
         }
     ],
     "Ins. L.J.": [
@@ -7670,6 +8317,34 @@
             "variations": {}
         }
     ],
+    "Lab. Arb. Awards (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Lab. Arb. Awards (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Labor Arbitration Awards",
+            "variations": {}
+        }
+    ],
+    "Lab. Arb. Rep. (BNA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Lab. Arb. Rep. (BNA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Labor Arbitration Reports",
+            "variations": {}
+        }
+    ],
     "Lab. Cas. (CCH)": [
         {
             "cite_type": "specialty",
@@ -7698,6 +8373,20 @@
             },
             "mlz_jurisdiction": [],
             "name": "Labor Law Reporter (CCH)",
+            "variations": {}
+        }
+    ],
+    "Lab. Rel. Rep. (BNA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Lab. Rel. Rep. (BNA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Labor Relations Reporter",
             "variations": {}
         }
     ],
@@ -7984,6 +8673,20 @@
             "variations": {
                 "Life. Cas. 2d(CCH)": "Life. Cas. 2d (CCH)"
             }
+        }
+    ],
+    "Liquor Cont. L. Rep. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Liquor Cont. L. Rep. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Liquor Control Law Reports",
+            "variations": {}
         }
     ],
     "Litt.": [
@@ -8814,6 +9517,20 @@
             }
         }
     ],
+    "Med. Devices Rep. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Med. Devices Rep. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Medical Devices Reports",
+            "variations": {}
+        }
+    ],
     "Media L. Rep. (BNA)": [
         {
             "cite_type": "specialty",
@@ -8828,6 +9545,20 @@
             "variations": {
                 "Media L. Rep.": "Media L. Rep. (BNA)"
             }
+        }
+    ],
+    "Medicare & Medicaid Guide (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Medicare & Medicaid Guide (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Medicare and Medicaid Guide",
+            "variations": {}
         }
     ],
     "Meigs": [
@@ -9286,6 +10017,20 @@
                 "Murph.(N.C.)": "Mur.",
                 "N.C.(Mur.)": "Mur."
             }
+        }
+    ],
+    "Mut. Funds Guide (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Mut. Funds Guide (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Mutual Funds Guide",
+            "variations": {}
         }
     ],
     "N. Chip.": [
@@ -10015,6 +10760,20 @@
             }
         }
     ],
+    "N.Y.S.E. Guide (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "N.Y.S.E. Guide (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "New York Stock Exchange Guide",
+            "variations": {}
+        }
+    ],
     "NCA": [
         {
             "cite_type": "state",
@@ -10424,6 +11183,20 @@
             }
         }
     ],
+    "Nuclear Reg. Rep. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Nuclear Reg. Rep. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Nuclear Regulation Reports",
+            "variations": {}
+        }
+    ],
     "O. Supp.": [
         {
             "cite_type": "state",
@@ -10478,6 +11251,34 @@
             }
         }
     ],
+    "O.S.H. Dec. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "O.S.H. Dec. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Occupational Safety and Health Decisions",
+            "variations": {}
+        }
+    ],
+    "O.S.H. Rep. (BNA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "O.S.H. Rep. (BNA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Occupational Safety & Health Reporter",
+            "variations": {}
+        }
+    ],
     "O.S.H.D. (CCH)": [
         {
             "cite_type": "specialty",
@@ -10515,6 +11316,20 @@
                 "Ohio S.U.": "O.S.U.",
                 "Ohio. Unrept.Cas.": "O.S.U."
             }
+        }
+    ],
+    "OFCCP Fed. Cont. Compl. Man. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "OFCCP Fed. Cont. Compl. Man. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "OFCCP Federal Contract Compliance Manual",
+            "variations": {}
         }
     ],
     "OK": [
@@ -10594,6 +11409,20 @@
                 "us:ok;court.ethics"
             ],
             "name": "Oklahoma Neutral Citation (Judicial Ethics Advisory Panel)",
+            "variations": {}
+        }
+    ],
+    "OSHA Comp. Guide (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "OSHA Comp. Guide (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Human Resources Management OSHA Compliance Guide",
             "variations": {}
         }
     ],
@@ -11762,6 +12591,20 @@
             }
         }
     ],
+    "Pat. Trademark & Copyright J. (BNA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Pat. Trademark & Copyright J. (BNA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Patent, Trademark & Copyright Journal",
+            "variations": {}
+        }
+    ],
     "Patton & Heath": [
         {
             "cite_type": "state",
@@ -11933,6 +12776,62 @@
             "variations": {
                 "Pens. & Benefits Rep. (BNA)": "Pens. & Ben. Rep. (BNA)"
             }
+        }
+    ],
+    "Pens. & Profit Sharing 2d (RIA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Pens. & Profit Sharing 2d (RIA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Pension & Profit Sharing Second",
+            "variations": {}
+        }
+    ],
+    "Pens. Plan Guide (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Pens. Plan Guide (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Pension Plan Guide",
+            "variations": {}
+        }
+    ],
+    "Personal and Comm. Liab. Life Health & Accid. Ins. Cas. 2d (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Personal and Comm. Liab. Life Health & Accid. Ins. Cas. 2d (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Personal and Commercial Liability Life, Health & Accident Insurance Cases 2d",
+            "variations": {}
+        }
+    ],
+    "Personnel Mgmt. (BNA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Personnel Mgmt. (BNA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Personnel Management",
+            "variations": {}
         }
     ],
     "Pet.": [
@@ -12198,6 +13097,34 @@
                 "Posey, Unrep. Cas.": "Posey",
                 "Tex. Unrep. Cas.": "Posey"
             }
+        }
+    ],
+    "Prod. Liab. Rep. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Prod. Liab. Rep. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Products Liability Reports",
+            "variations": {}
+        }
+    ],
+    "Prod. Safety & Liab. Rep. (BNA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Prod. Safety & Liab. Rep. (BNA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Product Safety & Liability Reporter",
+            "variations": {}
         }
     ],
     "R.I.": [
@@ -12864,6 +13791,20 @@
             "variations": {}
         }
     ],
+    "SEC Accounting R. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "SEC Accounting R. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "SEC Accounting Rules",
+            "variations": {}
+        }
+    ],
     "SEC Jud. Dec.": [
         {
             "cite_type": "specialty",
@@ -12999,6 +13940,48 @@
             }
         }
     ],
+    "Sec. & Fed. Corp. L. Rep. (West)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Sec. & Fed. Corp. L. Rep. (West)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Securities and Federal Corporate Law Report",
+            "variations": {}
+        }
+    ],
+    "Sec. Reg. & L. Rep. (BNA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Sec. Reg. & L. Rep. (BNA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Securities Regulation & Law Report",
+            "variations": {}
+        }
+    ],
+    "Secured Transactions Guide (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Secured Transactions Guide (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Secured Transactions Guide",
+            "variations": {}
+        }
+    ],
     "Serg. & Rawle": [
         {
             "cite_type": "state",
@@ -13048,6 +14031,20 @@
                 "us:tn;supreme.court"
             ],
             "name": "Shannon's Tennessee Cases",
+            "variations": {}
+        }
+    ],
+    "Shipping Reg. (P & F)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Shipping Reg. (P & F)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Shipping Regulation",
             "variations": {}
         }
     ],
@@ -13207,22 +14204,18 @@
             }
         }
     ],
-    "Soc. Serv. Rev.": [
+    "Soc. Sec. Rep. (CCH)": [
         {
             "cite_type": "specialty",
             "editions": {
-                "Soc. Serv. Rev.": {
+                "Soc. Sec. Rep. (CCH)": {
                     "end": null,
                     "start": "1750-01-01T00:00:00"
                 }
             },
             "mlz_jurisdiction": [],
-            "name": "Social Service Review",
-            "variations": {
-                "Soc. Sec. Rep. Serv.": "Soc. Serv. Rev.",
-                "Soc. Sec. Rep. Service": "Soc. Serv. Rev.",
-                "Soc.Sec.Rep.Serv.": "Soc. Serv. Rev."
-            }
+            "name": "Social Security Reporter",
+            "variations": {}
         }
     ],
     "Som. L.J.": [
@@ -13305,6 +14298,62 @@
             },
             "mlz_jurisdiction": [],
             "name": "Sprague's United States (US) District Ct. (Admiralty) Decisions",
+            "variations": {}
+        }
+    ],
+    "St. & Loc. Tax Serv. (RIA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "St. & Loc. Tax Serv. (RIA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "State and Local Tax Service",
+            "variations": {}
+        }
+    ],
+    "St. Tax Guide (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "St. Tax Guide (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "State Tax Guide",
+            "variations": {}
+        }
+    ],
+    "St. Tax Rep. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "St. Tax Rep. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "State Tax Reporter",
+            "variations": {}
+        }
+    ],
+    "Stand. Fed. Tax Rep. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Stand. Fed. Tax Rep. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Standard Federal Tax Reports",
             "variations": {}
         }
     ],
@@ -13820,6 +14869,34 @@
             "variations": {}
         }
     ],
+    "Tax Ct. Rep. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Tax Ct. Rep. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Tax Court Reports",
+            "variations": {}
+        }
+    ],
+    "Tax Ct. Rep. Dec. (RIA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Tax Ct. Rep. Dec. (RIA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Tax Court Reported Decisions",
+            "variations": {}
+        }
+    ],
     "Tax Ct. Summary LEXIS": [
         {
             "cite_type": "specialty_lexis",
@@ -13833,6 +14910,20 @@
                 "us:c;tax.court"
             ],
             "name": "Lexis Tax Court Summary Decisions",
+            "variations": {}
+        }
+    ],
+    "Tax Treaties (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Tax Treaties (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Tax Treaties",
             "variations": {}
         }
     ],
@@ -14085,24 +15176,6 @@
             "name": "Texas Court of Appeals Reports",
             "variations": {
                 "Tex.Ct.App.R.": "Tex. Ct. App."
-            }
-        }
-    ],
-    "Tex. L. Rev.": [
-        {
-            "cite_type": "state",
-            "editions": {
-                "Tex. L. Rev.": {
-                    "end": "1846-12-31T00:00:00",
-                    "start": "1845-01-01T00:00:00"
-                }
-            },
-            "mlz_jurisdiction": [
-                "us:tx;supreme.court"
-            ],
-            "name": "Texas Law Review",
-            "variations": {
-                "Texas L.Rev.": "Tex. L. Rev."
             }
         }
     ],
@@ -14596,6 +15669,20 @@
             "variations": {}
         }
     ],
+    "U.S. Tax Rep. (RIA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "U.S. Tax Rep. (RIA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "U.S. Tax Reporter",
+            "variations": {}
+        }
+    ],
     "U.S.L.W.": [
         {
             "cite_type": "specialty",
@@ -14612,6 +15699,20 @@
             "variations": {
                 "USLW": "U.S.L.W."
             }
+        }
+    ],
+    "U.S.L.W. (BNA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "U.S.L.W. (BNA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "The United States Law Week",
+            "variations": {}
         }
     ],
     "U.S.P.Q. (BNA)": [
@@ -14721,6 +15822,20 @@
             }
         }
     ],
+    "Union Lab. Rep. (BNA)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Union Lab. Rep. (BNA)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Union Labor Report",
+            "variations": {}
+        }
+    ],
     "Utah": [
         {
             "cite_type": "state",
@@ -14754,6 +15869,20 @@
             "mlz_jurisdiction": [],
             "name": "Utah Advance Reports",
             "publisher": "Code Co.",
+            "variations": {}
+        }
+    ],
+    "Util. L. Rep. (CCH)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Util. L. Rep. (CCH)": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Utilities Law Reports",
             "variations": {}
         }
     ],

--- a/tests.py
+++ b/tests.py
@@ -14,6 +14,7 @@ from reporters_db import (
     NAMES_TO_EDITIONS,
     REGEX_VARIABLES,
     LAWS,
+    JOURNALS,
 )
 from unittest import TestCase
 
@@ -381,6 +382,43 @@ class LawsTest(BaseTestCase):
             self.check_ascii(law["examples"])
 
         self.check_whitespace(REPORTERS)
+
+
+class JournalsTest(BaseTestCase):
+    """Tests for journals.json"""
+
+    @staticmethod
+    def iter_journals():
+        for journal_key, journal_list in JOURNALS.items():
+            yield from ((journal_key, journal) for journal in journal_list)
+
+    def test_regexes(self):
+        """Do custom regexes and examples match up?"""
+        for journal_key, journal in self.iter_journals():
+            regexes = [
+                (
+                    regex_template,
+                    recursive_substitute(regex_template, REGEX_VARIABLES),
+                )
+                for regex_template in journal.get("regexes", [])
+            ]
+            with self.subTest("Check journal regexes", name=journal["name"]):
+                self.check_regexes(regexes, journal.get("examples", []))
+
+    def text_json_format(self):
+        self.check_json_format("journals.json")
+
+    def test_dates(self):
+        for journal_key, journal in self.iter_journals():
+            self.check_dates(journal["start"], journal["end"])
+
+    def test_fields_tidy(self):
+        """Check that fields don't have unexpected characters or whitespace."""
+        for journal_key, journal in self.iter_journals():
+            self.check_ascii(journal_key)
+            self.check_ascii(journal["name"])
+
+        self.check_whitespace(JOURNALS)
 
 
 if __name__ == "__main__":

--- a/tests.py
+++ b/tests.py
@@ -4,6 +4,8 @@ import re
 import datetime
 from difflib import context_diff
 from pathlib import Path
+from string import Template
+
 import six
 from reporters_db import (
     REPORTERS,
@@ -11,6 +13,7 @@ from reporters_db import (
     EDITIONS,
     NAMES_TO_EDITIONS,
     REGEX_VARIABLES,
+    LAWS,
 )
 from unittest import TestCase
 
@@ -62,7 +65,125 @@ def iter_editions():
             yield edition_abbv, edition
 
 
-class ConstantsTest(TestCase):
+class BaseTestCase(TestCase):
+    def check_regexes(self, regexes, examples):
+        """Check that each regex matches at least one example, and each example matches at least one regex.
+        regexes should be a list of [(regex_template, regex)]."""
+        matched_examples = set()
+
+        # check that each regex matches at least one example
+        for regex_template, regex in regexes:
+            has_match = False
+            for example in examples:
+                if re.match(regex + "$", example):
+                    has_match = True
+                    matched_examples.add(example)
+            if not has_match:
+                try:
+                    import exrex
+
+                    candidate = "Possible examples: %s" % [
+                        exrex.getone(regex, limit=3) for _ in range(10)
+                    ]
+                except ImportError:
+                    candidate = "Run 'pip install exrex' to generate a candidate example"
+                self.fail(
+                    "No match in 'examples' for custom regex '%s'.\n"
+                    "Expanded regex: %s.\n"
+                    "Provided examples: %s.\n"
+                    "%s"
+                    % (
+                        regex_template,
+                        regex,
+                        examples,
+                        candidate,
+                    )
+                )
+
+        # check that each example is matched by at least one regex
+        self.assertEqual(
+            set(examples),
+            matched_examples,
+            "Not all examples matched. If custom regexes are provided, all examples should match."
+            "Unmatched examples: %s. Regexes tried: %s"
+            % (set(examples) - matched_examples, regexes),
+        )
+
+    def check_json_format(self, file_name):
+        """Does format of json file match json.dumps(json.loads(), sort_keys=True)?"""
+        json_path = Path(__file__).parent / "reporters_db" / "data" / file_name
+        json_str = json_path.read_text()
+        reformatted = json.dumps(
+            json.loads(json_str),
+            indent=4,
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+        reformatted += "\n"
+        if json_str != reformatted:
+            if os.environ.get("FIX_JSON"):
+                json_path.write_text(reformatted)
+            else:
+                diff = context_diff(
+                    json_str.splitlines(),
+                    reformatted.splitlines(),
+                    fromfile="reporters.json",
+                    tofile="expected.json",
+                )
+                self.fail(
+                    ("%s needs reformatting. " % file_name)
+                    + "Run with env var FIX_JSON=1 to update the file automatically. "
+                    + "Diff of actual vs. expected:\n"
+                    + "\n".join(diff)
+                )
+
+    def check_dates(self, start, end):
+        """Check that start and end dates are valid."""
+        if start is not None:
+            self.assertTrue(
+                isinstance(start, datetime.datetime),
+                f"{repr(start)} should be imported as a date.",
+            )
+        if end is not None:
+            self.assertTrue(
+                isinstance(end, datetime.datetime),
+                f"{repr(end)} should be imported as a date.",
+            )
+        if start is not None and end is not None:
+            self.assertLessEqual(start, end)
+
+    def check_ascii(self, obj):
+        """Check that all strings in obj match a list of expected ascii characters."""
+        allowed_chars = r"[ 0-9a-zA-Z.,\-'&(){}\[\]\\$§_?<>+:/]"
+        for s in emit_strings(obj):
+            remaining_chars = re.sub(allowed_chars, "", s)
+            self.assertFalse(
+                remaining_chars,
+                f"Unexpected characters in {repr(s)}: {repr(remaining_chars)}.",
+            )
+
+    def check_whitespace(self, obj):
+        for s in emit_strings(obj):
+            self.assertEqual(
+                s.strip(), s, msg="Field needs whitespace stripped: '%s'" % s
+            )
+            non_space_whitespace = any(w != " " for w in re.findall(r"\s+", s))
+            self.assertFalse(
+                non_space_whitespace,
+                f"Field has unexpected whitespace: {repr(s)}",
+            )
+
+
+class RegexesTest(BaseTestCase):
+    """Tests for regexes.json"""
+
+    def text_json_format(self):
+        self.check_json_format("regexes.json")
+
+
+class ReportersTest(BaseTestCase):
+    """Tests for reporters.json"""
+
     def test_any_keys_missing_editions(self):
         """Have we added any new reporters that lack a matching edition?"""
         for reporter_abbv, reporter_list, reporter_data in iter_reporters():
@@ -98,37 +219,11 @@ class ConstantsTest(TestCase):
             NAMES_TO_EDITIONS["Illinois Appellate Court Reports"],
         )
 
-    def test_that_all_dates_are_converted_to_dates_not_strings(self):
+    def test_dates(self):
         """Do we properly make the ISO-8601 date strings into Python dates?"""
         # for reporter_abbv, reporter_list, reporter_data in iter_reporters():
-        for e_name, e_dates in iter_editions():
-            # e_name == "A. 2d"
-            # e_dates == {
-            #     "end": "1938-12-31T00:00:00",
-            #     "start": "1885-01-01T00:00:00"
-            # }
-            for key in ["start", "end"]:
-                is_date_or_none = (
-                    isinstance(e_dates[key], datetime.datetime)
-                    or e_dates[key] is None
-                )
-                self.assertTrue(
-                    is_date_or_none,
-                    msg=(
-                        "%s dates in the reporter '%s' appear to be "
-                        "coming through as '%s'"
-                        % (key, e_name, type(e_dates[key]))
-                    ),
-                )
-                if key == "start":
-                    start_is_not_none = e_dates[key] is not None
-                    self.assertTrue(
-                        start_is_not_none,
-                        msg=(
-                            "Start date in reporter '%s' appears to "
-                            "be None, not 1750" % e_name
-                        ),
-                    )
+        for edition_name, edition in iter_editions():
+            self.check_dates(edition["start"], edition["end"])
 
     def test_all_reporters_have_valid_cite_type(self):
         """Do all reporters have valid cite_type values?"""
@@ -203,138 +298,89 @@ class ConstantsTest(TestCase):
                 )
 
     def test_fields_tidy(self):
-        """Do fields have any messiness?
-
-        For example:
-         - some punctuation is not allowed in some keys
-         - spaces at beginning/end not allowed
-        """
-
-        def cleaner(s):
-            return re.sub(r"[^ 0-9a-zA-Z.,\-'&()\[\]]", "", s.strip())
-
-        msg = "Got bad punctuation in: %s"
+        """Check that fields don't have unexpected characters or whitespace."""
         for reporter_abbv, reporter_list, reporter_data in iter_reporters():
-            self.assertEqual(
-                reporter_abbv, cleaner(reporter_abbv), msg=msg % reporter_abbv
-            )
-            for k in reporter_data["editions"].keys():
-                self.assertEqual(cleaner(k), k, msg=msg % k)
-            for k, v in reporter_data["variations"].items():
-                self.assertEqual(cleaner(k), k, msg=msg % k)
-                self.assertEqual(cleaner(v), v, msg=msg % v)
+            self.check_ascii(reporter_abbv)
+            self.check_ascii(list(reporter_data["editions"].keys()))
+            self.check_ascii(reporter_data["variations"])
 
-        for s in emit_strings(REPORTERS):
-            self.assertEqual(
-                s.strip(), s, msg="Fields needs whitespace stripped: '%s'" % s
-            )
-
-    def test_nothing_ends_before_it_starts(self):
-        """Do any editions have end dates before their start dates?"""
-        for k, edition in iter_editions():
-            if edition["start"] and edition["end"]:
-                self.assertLessEqual(
-                    edition["start"],
-                    edition["end"],
-                    msg="It appears that edition %s ends before it "
-                    "starts." % k,
-                )
-
-    def test_json_format(self):
-        """Does format of reporters.json match json.dumps(json.loads(), sort_keys=True)?"""
-        for file_name in ("reporters.json", "regexes.json"):
-            with self.subTest(file_name=file_name):
-                json_path = (
-                    Path(__file__).parent / "reporters_db" / "data" / file_name
-                )
-                json_str = json_path.read_text()
-                reformatted = json.dumps(
-                    json.loads(json_str),
-                    indent=4,
-                    ensure_ascii=False,
-                    sort_keys=True,
-                )
-                reformatted += "\n"
-                if json_str != reformatted:
-                    if os.environ.get("FIX_JSON"):
-                        json_path.write_text(reformatted)
-                    else:
-                        diff = context_diff(
-                            json_str.splitlines(),
-                            reformatted.splitlines(),
-                            fromfile="reporters.json",
-                            tofile="expected.json",
-                        )
-                        self.fail(
-                            ("%s needs reformatting. " % file_name)
-                            + "Run with env var FIX_JSON=1 to update the file automatically. "
-                            + "Diff of actual vs. expected:\n"
-                            + "\n".join(diff)
-                        )
+        self.check_whitespace(REPORTERS)
 
     def test_regexes(self):
         """Do custom regexes and examples match up?"""
         for reporter_abbv, reporter_list, reporter_data in iter_reporters():
-            examples = reporter_data.get("examples", [])
-            matched_examples = set()
-            custom_regexes = {}
 
-            # check that each custom regex matches at least one example
+            # get list of expanded regexes and examples for this reporter
+            examples = reporter_data.get("examples", [])
+            regexes = []
             for edition_abbv, edition in reporter_data["editions"].items():
                 if not edition.get("regexes"):
                     continue
-                with self.subTest(
-                    "Check edition regexes", edition=edition_abbv
-                ):
-                    for edition_regex in edition["regexes"]:
-                        full_regex = recursive_substitute(
-                            edition_regex, REGEX_VARIABLES
-                        )
-                        regexes = substitute_editions(
-                            full_regex,
-                            edition_abbv,
-                            reporter_data["variations"],
-                        )
-                        custom_regexes[edition_regex] = regexes
-                        has_match = False
-                        for example in examples:
-                            for regex in regexes:
-                                if re.match(regex + "$", example):
-                                    has_match = True
-                                    matched_examples.add(example)
-                                    break
-                        if not has_match:
-                            try:
-                                import exrex
-
-                                candidate = "Possible examples: %s" % [
-                                    exrex.getone(regexes[0], limit=3)
-                                    for _ in range(10)
-                                ]
-                            except ImportError:
-                                candidate = "Run 'pip install exrex' to generate a candidate example"
-                            self.fail(
-                                "Reporter '%s' has no match in 'examples' for custom regex '%s'.\nExpanded regexes: %s.\n%s"
-                                % (
-                                    reporter_abbv,
-                                    edition_regex,
-                                    regexes,
-                                    candidate,
-                                )
-                            )
-
-            # check that each example is matched by at least one regex
-            if custom_regexes:
-                with self.subTest(
-                    "Check all examples matched by custom regex",
-                    reporter=reporter_abbv,
-                ):
-                    self.assertEqual(
-                        set(examples),
-                        matched_examples,
-                        "Not all examples matched. If custom regexes are provided, all examples should match. Regexes tried: %s"
-                        % custom_regexes,
+                for regex_template in edition["regexes"]:
+                    edition_strings = [edition_abbv] + [
+                        k
+                        for k, v in reporter_data["variations"].items()
+                        if v == edition_abbv
+                    ]
+                    regex = recursive_substitute(
+                        regex_template, REGEX_VARIABLES
                     )
+                    regex = Template(regex).safe_substitute(
+                        edition="(?:%s)"
+                        % "|".join(re.escape(e) for e in edition_strings)
+                    )
+                    regexes.append((regex_template, regex))
+
+            if not regexes:
+                continue
+
+            with self.subTest(
+                "Check reporter regexes", reporter=reporter_abbv
+            ):
+                self.check_regexes(regexes, examples)
+
+    def text_json_format(self):
+        self.check_json_format("reporters.json")
+
+
+class LawsTest(BaseTestCase):
+    """Tests for laws.json"""
+
+    @staticmethod
+    def iter_laws():
+        for law_key, law_list in LAWS.items():
+            yield from ((law_key, law) for law in law_list)
+
+    def test_regexes(self):
+        """Do custom regexes and examples match up?"""
+        for law_key, law in self.iter_laws():
+            regexes = []
+            # expand regex and substitute $edition value
+            series_strings = [law_key] + law["variations"]
+            for regex_template in law["regexes"]:
+                regex = recursive_substitute(regex_template, REGEX_VARIABLES)
+                regex = Template(regex).safe_substitute(
+                    edition="(?:%s)"
+                    % "|".join(re.escape(e) for e in series_strings)
+                )
+                regexes.append((regex_template, regex))
+            with self.subTest("Check law regexes", name=law["name"]):
+                self.check_regexes(regexes, law["examples"])
+
+    def text_json_format(self):
+        self.check_json_format("laws.json")
+
+    def test_dates(self):
+        for law_key, law in self.iter_laws():
+            self.check_dates(law["start"], law["end"])
+
+    def test_fields_tidy(self):
+        """Check that fields don't have unexpected characters or whitespace."""
+        for law_key, law in self.iter_laws():
+            self.check_ascii(law["regexes"])
+            self.check_ascii(law["examples"])
+
+        self.check_whitespace(REPORTERS)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a first pass at importing the spreadsheet from #13 to a new journals.json file.

Proposed format:

```
"A.B.A. J.": [
        {
            "cite_type": "journal",
            "end": null,
            "name": "ABA Journal",
            "notes": "Automatically generated 2021-05-04.",
            "start": null,
            "variations": {}
        }
    ],
```

Notes and open questions:

* They all have `"cite_type": "journal"`, I guess in case that gets more precise later? Could remove this.
* I didn't keep `"editions"` from reporters.json, but I did keep each entry as a list so there could hypothetically be more than one under a given key like `"A.B.A. J."`. This could be tweaked in either direction.
* I imagine we would add `"regexes"` if and when we find non-standard citation forms for some of these.
* Some of the spreadsheet entries already existed in reporters.json. Any that looked like they were actually law journals, I removed and brought over here, including their name/date range/notes/variations but not cite_type or mlz_jurisdiction.
* Some of the spreadsheet entries were for "services", like (BNA) (CCH) etc. For any entries that ended in `{'(CCH)', '(RIA)', '(West)', '(LRP)', '(MB)', '(BNA)', '(P & F)'}` I updated reporters.json instead of adding to journals.json. That seemed more consistent since many services were already listed in reporters.json.
  * (That could potentially be revisited later -- there's this whole separate [listing of services](https://law.resource.org/pub/us/code/blue/IndigoBook.html#T4) in the Indigo Book, and I'm not sure if they're reporters or journals or their own thing or it varies case by case. I would put "do something sensible with services" in its own issue separate from this journals effort.)
* No tests or imports yet.

Fixes #13 