### PR TITLE
Add U.S.C. to laws.json

### DIFF
--- a/reporters_db/data/laws.json
+++ b/reporters_db/data/laws.json
@@ -5000,7 +5000,7 @@
             "examples": [
                 "82 Stat. 6"
             ],
-            "jurisdiction": "District of Columbia",
+            "jurisdiction": "United States",
             "name": "United States Statutes at Large",
             "notes": "Automatically generated. Remove this message if replacing with real examples.",
             "regexes": [
@@ -5297,6 +5297,29 @@
             ],
             "start": null,
             "variations": []
+        }
+    ],
+    "U.S.C.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "1 U.S.C. § 1",
+                "1 U.S.C.A. § 1",
+                "1 U.S.C.S. § 1",
+                "1 U.S.C.U. § 1"
+            ],
+            "jurisdiction": "United States",
+            "name": "United States Code; United States Code Annotated; United States Code Service; Gould’s United States Code Unannotated",
+            "regexes": [
+                "(?P<title>\\d+) $reporter § $law_section"
+            ],
+            "start": null,
+            "variations": [
+                "U.S.C.A.",
+                "U.S.C.S.",
+                "U.S.C.U."
+            ]
         }
     ],
     "Utah Admin. Code": [

--- a/tests.py
+++ b/tests.py
@@ -368,7 +368,7 @@ class LawsTest(BaseTestCase):
             with self.subTest("Check law regexes", name=law["name"]):
                 self.check_regexes(regexes, law["examples"])
 
-    def text_json_format(self):
+    def test_json_format(self):
         self.check_json_format("laws.json")
 
     def test_dates(self):


### PR DESCRIPTION
This covers everything in Indigo Book T1 "[Federal Judicial and Legislative Materials](https://law.resource.org/pub/us/code/blue/IndigoBook.html#T1)" -- I verified that the rest was already covered in reporters.json.

I'll file an issue for T2, the administrative materials, and anything else that looks interesting.