### PR TITLE
Test json files with jsonschema

### DIFF
--- a/schemas/journals.json
+++ b/schemas/journals.json
@@ -1,0 +1,66 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "patternProperties": {
+        "^.*$": {
+            "type": "array",
+            "items": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "cite_type": {
+                            "type": "string"
+                        },
+                        "end": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "examples": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "notes": {
+                            "type": "string"
+                        },
+                        "regexes": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "start": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "variations": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": [
+                        "cite_type",
+                        "end",
+                        "examples",
+                        "name",
+                        "regexes",
+                        "start",
+                        "variations"
+                    ],
+                    "additionalProperties": false
+                }
+            ]
+        }
+    },
+    "additionalProperties": false
+}

--- a/schemas/laws.json
+++ b/schemas/laws.json
@@ -1,0 +1,67 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "patternProperties": {
+        "^.*$": {
+            "type": "array",
+            "items": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "cite_type": {
+                            "type": "string"
+                        },
+                        "end": {
+                            "type": ["string", "null"]
+                        },
+                        "examples": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "href": {
+                            "type": "string"
+                        },
+                        "jurisdiction": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "notes": {
+                            "type": "string"
+                        },
+                        "regexes": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "start": {
+                            "type": ["string", "null"]
+                        },
+                        "variations": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": [
+                        "cite_type",
+                        "end",
+                        "examples",
+                        "jurisdiction",
+                        "name",
+                        "regexes",
+                        "start",
+                        "variations"
+                    ],
+                    "additionalProperties": false
+                }
+            ]
+        }
+    },
+    "additionalProperties": false
+}

--- a/schemas/regexes.json
+++ b/schemas/regexes.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "regexes": {
+            "type": "object",
+            "patternProperties": {
+                "^[a-z0-9_]*#?$": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/regexes"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+    "$ref": "#/definitions/regexes"
+}

--- a/schemas/reporters.json
+++ b/schemas/reporters.json
@@ -1,0 +1,100 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "patternProperties": {
+        "^.*$": {
+            "type": "array",
+            "items": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "cite_type": {
+                            "type": "string"
+                        },
+                        "cite_format": {
+                            "type": "string"
+                        },
+                        "editions": {
+                            "type": "object",
+                            "patternProperties": {
+                                "^.*$": {
+                                    "type": "object",
+                                    "properties": {
+                                        "end": {
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ]
+                                        },
+                                        "regexes": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        },
+                                        "start": {
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "end",
+                                        "start"
+                                    ]
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "examples": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "href": {
+                            "type": "string"
+                        },
+                        "mlz_jurisdiction": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "notes": {
+                            "type": "string"
+                        },
+                        "publisher": {
+                            "type": "string"
+                        },
+                        "variations": {
+                            "type": "object",
+                            "patternProperties": {
+                                "^.*$": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    },
+                    "required": [
+                        "cite_type",
+                        "editions",
+                        "mlz_jurisdiction",
+                        "name",
+                        "variations"
+                    ],
+                    "additionalProperties": false
+                }
+            ]
+        }
+    },
+    "additionalProperties": false
+}

--- a/setup.py
+++ b/setup.py
@@ -54,5 +54,6 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     install_requires=reqs,
+    tests_require=["jsonschema==3.2.0"],
     test_suite="tests",
 )


### PR DESCRIPTION
This adds schemas for each json file in the `schemas/` dir, and checks that they validate with the [jsonschema](https://pypi.org/project/jsonschema/) library.

So for example if I add a misspelling of "examples" as "exmaples", I get this test failure:

```
E           jsonschema.exceptions.ValidationError: 'examples' is a required property
E
...
E
E           On instance['ASBCA'][0]:
E               {'cite_type': 'admin_docket',
E                'end': None,
E                'exmaples': ['ASBCA No. 43466'],
E                'href': 'https://law.resource.org/pub/us/code/blue/IndigoBook.html#T2',
E                'jurisdiction': 'United States',
E                'name': 'Armed Services Board of Contract Appeals',
E                'regexes': ['$reporter No. (?P<docket_number>\\d+)'],
E                'start': None,
E                'variations': []}
```

Or if I have a `variations` entry that is a dict when it's supposed to be a list, I get this test error:

```
E           jsonschema.exceptions.ValidationError: {} is not of type 'array'
E
E           Failed validating 'type' in schema['patternProperties']['^.*$']['items'][0]['properties']['variations']:
E               {'items': {'type': 'string'}, 'type': 'array'}
E
E           On instance['A.B.A. J.'][0]['variations']:
E               {}
```

This replaces `test_all_required_keys_no_extra_keys` for `reporters.json` (and offers more precise typechecking), and extends checking to the other json files.

I didn't add regexes in the schemas to check string contents, like valid dates, valid cite_types, strip whitespace, etc., but in theory some of those tests could be represented in the schema as well if we wanted.