### PR TITLE
Included requirements.txt in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include README.md LICENSE
+include README.rst LICENSE requirements.txt
 graft reporters_db/data


### PR DESCRIPTION
Included requirements.txt in source distribution and also changed README.md to *.rst as that is the correct name.
This should fix https://github.com/freelawproject/reporters-db/issues/64