### PR TITLE
Fixed #72: ensured utf-8 when opening laws.json

### DIFF
--- a/reporters_db/__init__.py
+++ b/reporters_db/__init__.py
@@ -30,7 +30,7 @@ with open(os.path.join(db_root, "data", "case_name_abbreviations.json")) as f:
     CASE_NAME_ABBREVIATIONS = json.load(f)
 
 
-with open(os.path.join(db_root, "data", "laws.json")) as f:
+with open(os.path.join(db_root, "data", "laws.json"), encoding="utf-8") as f:
     LAWS = json.load(f, object_hook=datetime_parser)
 
 


### PR DESCRIPTION
`with open(os.path.join(db_root, "data", "laws.json")) as f:` -> 
`with open(os.path.join(db_root, "data", "laws.json"), encoding="utf-8") as f:`

Fixes #72. 

Windows users may have a locale encoder that is not utf-8, and because Python's [`open()`](https://docs.python.org/3/library/functions.html#open) uses the locale encoder, this variance can corrupt symbols (such as § in laws.json) for those Windows users.

Added `encoding="utf-8"` when opening laws.json to solve the locale encoder issue for that file.

If other files with symbols like § were to be opened without encoding="utf-8", they could have the same issue. For now, I only noticed this to affect laws.json so I added it there.

Also, this is my first PR so please give feedback and advice on what to do differently! 