### PR TITLE
Add historical citation formats from Georgia and Oregon

### DIFF
--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -15042,7 +15042,8 @@
             "variations": {
                 "O.": "Or.",
                 "Or": "Or.",
-                "Ore.": "Or."
+                "Ore.": "Or.",
+                "Oreg.": "Or."
             }
         }
     ],

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -7185,6 +7185,7 @@
             ],
             "name": "Georgia Reports",
             "variations": {
+                "Ga. (Kelly)": "Ga.",
                 "Ga. Rep.": "Ga."
             }
         }
@@ -9620,9 +9621,7 @@
                 "us:ga;supreme.court"
             ],
             "name": "Kelly's Reports",
-            "variations": {
-                "Ga. (Kelly)": "Kelly"
-            }
+            "variations": {}
         }
     ],
     "Keyes": [

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -9604,6 +9604,27 @@
             "variations": {}
         }
     ],
+    "Kelly": [
+        {
+            "cite_type": "state",
+            "editions": {
+                "Kelly": {
+                    "end": "1849-12-31T00:00:00",
+                    "start": "1847-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "1 Kelly 355"
+            ],
+            "mlz_jurisdiction": [
+                "us:ga;supreme.court"
+            ],
+            "name": "Kelly's Reports",
+            "variations": {
+                "Ga. (Kelly)": "Kelly"
+            }
+        }
+    ],
     "Keyes": [
         {
             "cite_type": "state",


### PR DESCRIPTION
This pull request is a test pull request as discussed in [this issue](https://github.com/freelawproject/eyecite/issues/103) on the eyecite repository. This PR makes two changes adding some historical information:

- Kelly is added as an antique (nominative) reporter for the first five volumes of the Georgia Reports.
- The abbreviation `Oreg.`, frequently used in historical legal documents, is added for Oregon.

Tests in the reporters-db repository pass locally after these changes. Informal tests of whether eyecite can pick up citations in these formats also work. Please let me know if there is a more explicit kind of test that needs to be added when making additions like this.