### PR TITLE
Specify encoding to ensure cross-platform support when opening file

### DIFF
--- a/reporters_db/__init__.py
+++ b/reporters_db/__init__.py
@@ -19,24 +19,33 @@ def datetime_parser(dct):
 
 
 db_root = os.path.dirname(os.path.realpath(__file__))
-with open(os.path.join(db_root, "data", "reporters.json"), encoding="utf-8") as f:
+with open(
+    os.path.join(db_root, "data", "reporters.json"), encoding="utf-8"
+) as f:
     REPORTERS = json.load(f, object_hook=datetime_parser)
 
-with open(os.path.join(db_root, "data", "state_abbreviations.json"),
-          encoding="utf-8") as f:
+with open(
+    os.path.join(db_root, "data", "state_abbreviations.json"), encoding="utf-8"
+) as f:
     STATE_ABBREVIATIONS = json.load(f)
 
-with open(os.path.join(db_root, "data", "case_name_abbreviations.json"),
-          encoding="utf-8") as f:
+with open(
+    os.path.join(db_root, "data", "case_name_abbreviations.json"),
+    encoding="utf-8",
+) as f:
     CASE_NAME_ABBREVIATIONS = json.load(f)
 
 with open(os.path.join(db_root, "data", "laws.json"), encoding="utf-8") as f:
     LAWS = json.load(f, object_hook=datetime_parser)
 
-with open(os.path.join(db_root, "data", "journals.json"), encoding="utf-8") as f:
+with open(
+    os.path.join(db_root, "data", "journals.json"), encoding="utf-8"
+) as f:
     JOURNALS = json.load(f, object_hook=datetime_parser)
 
-with open(os.path.join(db_root, "data", "regexes.json"), encoding="utf-8") as f:
+with open(
+    os.path.join(db_root, "data", "regexes.json"), encoding="utf-8"
+) as f:
     RAW_REGEX_VARIABLES = json.load(f)
     REGEX_VARIABLES = process_variables(RAW_REGEX_VARIABLES)
 

--- a/reporters_db/__init__.py
+++ b/reporters_db/__init__.py
@@ -19,30 +19,26 @@ def datetime_parser(dct):
 
 
 db_root = os.path.dirname(os.path.realpath(__file__))
-with open(os.path.join(db_root, "data", "reporters.json")) as f:
+with open(os.path.join(db_root, "data", "reporters.json"), encoding="utf-8") as f:
     REPORTERS = json.load(f, object_hook=datetime_parser)
 
-
-with open(os.path.join(db_root, "data", "state_abbreviations.json")) as f:
+with open(os.path.join(db_root, "data", "state_abbreviations.json"),
+          encoding="utf-8") as f:
     STATE_ABBREVIATIONS = json.load(f)
 
-
-with open(os.path.join(db_root, "data", "case_name_abbreviations.json")) as f:
+with open(os.path.join(db_root, "data", "case_name_abbreviations.json"),
+          encoding="utf-8") as f:
     CASE_NAME_ABBREVIATIONS = json.load(f)
-
 
 with open(os.path.join(db_root, "data", "laws.json"), encoding="utf-8") as f:
     LAWS = json.load(f, object_hook=datetime_parser)
 
-
-with open(os.path.join(db_root, "data", "journals.json")) as f:
+with open(os.path.join(db_root, "data", "journals.json"), encoding="utf-8") as f:
     JOURNALS = json.load(f, object_hook=datetime_parser)
 
-
-with open(os.path.join(db_root, "data", "regexes.json")) as f:
+with open(os.path.join(db_root, "data", "regexes.json"), encoding="utf-8") as f:
     RAW_REGEX_VARIABLES = json.load(f)
     REGEX_VARIABLES = process_variables(RAW_REGEX_VARIABLES)
-
 
 VARIATIONS_ONLY = suck_out_variations_only(REPORTERS)
 EDITIONS = suck_out_editions(REPORTERS)


### PR DESCRIPTION
If you work on Windows like me you will probably run into the same problem as me. I'm working with files with Unicode characters, when you use the python open() function to open a file without specifying explicitly the encoding it will be platform dependent, in the case of Windows the function will return cp1252 encoding instead of utf-8.  You can read more about it right here: https://docs.python.org/3/library/functions.html#open

This change specifies encoding to utf-8 to ensure cross-platform compatibility when opening files in text mode. In this case when loading the json files for reporters, state abbreviations, case name abbreviations, etc.