### PR TITLE
Add support for U.S. Public and Private Laws

### DIFF
--- a/reporters_db/data/laws.json
+++ b/reporters_db/data/laws.json
@@ -4822,8 +4822,8 @@
             "cite_type": "leg_statute",
             "end": null,
             "examples": [
-                "Family Sponsor Immigration Act of 2002, Pub. L. No. 107-150",
-                "Patient Protection and Affordable Care Act, Pub. L. No. 111-148, § 1101",
+                "Pub. L. No. 107-150",
+                "Pub. L. No. 111-148, § 1101",
                 "Public Law No. 117-174",
                 "Pub.L. 107-006",
                 "Public Law Number 107-743"
@@ -4831,10 +4831,34 @@
             "jurisdiction": "United States",
             "name": "Public Laws",
             "regexes": [
-                "$reporter\s*(?:No\.|Number)?\s*(?P<title>\d{1,3}-\d{1,5}),?\s*(?:§|Sec|sec|Section|section)?[§|s]?\.?\s*$law_section?*
+                "$reporter \\s*(?:No\\.|Number)?\\s*(?P<title>\\d{1,3}-\\d{1,5}),?\\s*(?:§|Sec|sec|Section|section)?[§|s]?\\.?\\s*$law_section?"
             ],
             "start": null,
-            "variations": ["Public Law", "Pub.L."]
+            "variations": [
+                "Public Law",
+                "Pub.L."
+            ]
+        }
+    ],
+    "Pvt. L.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Private Law 115-1",
+                "Pvt.L. 115-001",
+                "Pvt. L. No. 112-1"
+            ],
+            "jurisdiction": "United States",
+            "name": "Private Laws",
+            "regexes": [
+                "$reporter \\s*(?:No\\.|Number)?\\s*(?P<title>\\d{1,3}-\\d{1,5})"
+            ],
+            "start": null,
+            "variations": [
+                "Private Law",
+                "Pvt.L."
+            ]
         }
     ],
     "R.I. Acts & Resolves": [

--- a/reporters_db/data/laws.json
+++ b/reporters_db/data/laws.json
@@ -4817,6 +4817,26 @@
             "variations": []
         }
     ],
+    "Pub. L.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Family Sponsor Immigration Act of 2002, Pub. L. No. 107-150",
+                "Patient Protection and Affordable Care Act, Pub. L. No. 111-148, § 1101",
+                "Public Law No. 117-174",
+                "Pub.L. 107-006",
+                "Public Law Number 107-743"
+            ],
+            "jurisdiction": "United States",
+            "name": "Public Laws",
+            "regexes": [
+                "$reporter\s*(?:No\.|Number)?\s*(?P<title>\d{1,3}-\d{1,5}),?\s*(?:§|Sec|sec|Section|section)?[§|s]?\.?\s*$law_section?*
+            ],
+            "start": null,
+            "variations": ["Public Law", "Pub.L."]
+        }
+    ],
     "R.I. Acts & Resolves": [
         {
             "cite_type": "leg_session",


### PR DESCRIPTION
Addresses #116 by adding support for public law citations. Also has support for private law citations, though these are sufficiently rare that it may not be worth keeping this reporter.