### PR TITLE
Add support for treaties

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,7 +134,7 @@ A complete data point has fields like so:
 
     "$citation": [
         {
-            "cite_type": "state|federal|neutral|specialty|specialty_west|specialty_lexis|state_regional|scotus_early",
+            "cite_type": "state|federal|neutral|specialty|specialty_west|specialty_lexis|state_regional|scotus_early|treaty",
             "editions": {
                 "$citation": {
                     "end": null,

--- a/reporters_db/data/laws.json
+++ b/reporters_db/data/laws.json
@@ -475,6 +475,23 @@
             "variations": []
         }
     ],
+    "C.E.T.S.": [
+        {
+            "cite_type": "treaty",
+            "end": null,
+            "examples": [
+                "C.E.T.S. No. 196"
+            ],
+            "href": "https://law.resource.org/pub/us/code/blue/IndigoBook.html#T6",
+            "jurisdiction": "",
+            "name": "Council of Europe Treaty Series",
+            "regexes": [
+                "$reporter\\s*(?:No\\.|Number)?\\s*(?P<number>\\d+)"
+            ],
+            "start": "2004-01-01T00:00:00",
+            "variations": []
+        }
+    ],
     "C.F.R.": [
         {
             "cite_type": "admin_compilation",
@@ -1176,6 +1193,40 @@
             "variations": []
         }
     ],
+    "E.A.S.": [
+        {
+            "cite_type": "treaty",
+            "end": "1945-12-31T23:59:59",
+            "examples": [
+                "E.A.S. 472"
+            ],
+            "href": "https://law.resource.org/pub/us/code/blue/IndigoBook.html#T6",
+            "jurisdiction": "United States",
+            "name": "Executive Agreement Series",
+            "regexes": [
+                "$reporter\\s*(?:No\\.|Number)?\\s*(?P<number>\\d+)"
+            ],
+            "start": "1922-01-01T00:00:00",
+            "variations": []
+        }
+    ],
+    "E.T.S.": [
+        {
+            "cite_type": "treaty",
+            "end": "2003-12-31T23:59:59",
+            "examples": [
+                "E.T.S. 5"
+            ],
+            "href": "https://law.resource.org/pub/us/code/blue/IndigoBook.html#T6",
+            "jurisdiction": "",
+            "name": "European Treaty Series",
+            "regexes": [
+                "$reporter\\s*(?:No\\.|Number)?\\s*(?P<number>\\d+)"
+            ],
+            "start": "1948-01-01T00:00:00",
+            "variations": []
+        }
+    ],
     "FR": [
         {
             "cite_type": "admin_register",
@@ -1584,6 +1635,23 @@
                 "$law_year $reporter $page_with_commas"
             ],
             "start": null,
+            "variations": []
+        }
+    ],
+    "Hein's": [
+        {
+            "cite_type": "treaty",
+            "end": null,
+            "examples": [
+                "Hein's No. KAV 2053"
+            ],
+            "href": "https://law.resource.org/pub/us/code/blue/IndigoBook.html#T6",
+            "jurisdiction": "United States",
+            "name": "Hein’s United States Treaties and Other International Agreements",
+            "regexes": [
+                "$reporter\\s*(?:No\\.|Number)?\\s*KAV\\s*(?P<number>\\d+)"
+            ],
+            "start": "1984-01-01T00:00:00",
             "variations": []
         }
     ],
@@ -4817,6 +4885,67 @@
             "variations": []
         }
     ],
+    "Pan-Am. T.S.": [
+        {
+            "cite_type": "treaty",
+            "end": null,
+            "examples": [
+                "Pan-Am. T.S. No. 22"
+            ],
+            "href": "https://law.resource.org/pub/us/code/blue/IndigoBook.html#T6",
+            "jurisdiction": "",
+            "name": "Pan-American Treaty Series",
+            "regexes": [
+                "$reporter\\s*(?:No\\.|Number)?\\s*(?P<number>\\d+)"
+            ],
+            "start": "1949-01-01T00:00:00",
+            "variations": []
+        }
+    ],
+    "Pub. L.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Pub. L. No. 107-150",
+                "Pub. L. No. 111-148, § 1101",
+                "Public Law No. 117-174",
+                "Pub.L. 107-006",
+                "Public Law Number 107-743"
+            ],
+            "jurisdiction": "United States",
+            "name": "Public Laws",
+            "regexes": [
+                "$reporter \\s*(?:No\\.|Number)?\\s*(?P<title>\\d{1,3}-\\d{1,5}),?\\s*(?:§|Sec|sec|Section|section)?[§|s]?\\.?\\s*$law_section?"
+            ],
+            "start": null,
+            "variations": [
+                "Public Law",
+                "Pub.L."
+            ]
+        }
+    ],
+    "Pvt. L.": [
+        {
+            "cite_type": "leg_statute",
+            "end": null,
+            "examples": [
+                "Private Law 115-1",
+                "Pvt.L. 115-001",
+                "Pvt. L. No. 112-1"
+            ],
+            "jurisdiction": "United States",
+            "name": "Private Laws",
+            "regexes": [
+                "$reporter \\s*(?:No\\.|Number)?\\s*(?P<title>\\d{1,3}-\\d{1,5})"
+            ],
+            "start": null,
+            "variations": [
+                "Private Law",
+                "Pvt.L."
+            ]
+        }
+    ],
     "R.I. Acts & Resolves": [
         {
             "cite_type": "leg_session",
@@ -4985,6 +5114,40 @@
             "variations": []
         }
     ],
+    "S. Exec. Doc.": [
+        {
+            "cite_type": "treaty",
+            "end": "1980-12-31T23:59:59",
+            "examples": [
+                "S. Exec. Doc. No. 38"
+            ],
+            "href": "https://law.resource.org/pub/us/code/blue/IndigoBook.html#T6",
+            "jurisdiction": "United States",
+            "name": "Senate Executive Documents",
+            "regexes": [
+                "$reporter\\s*(?:No\\.|Number)?\\s*(?P<number>\\d*[A-Z]?)"
+            ],
+            "start": "1778-01-01T00:00:00",
+            "variations": []
+        }
+    ],
+    "S. Treaty Doc.": [
+        {
+            "cite_type": "treaty",
+            "end": null,
+            "examples": [
+                "S. Treaty Doc. No. 100-20"
+            ],
+            "href": "https://law.resource.org/pub/us/code/blue/IndigoBook.html#T6",
+            "jurisdiction": "United States",
+            "name": "Senate Treaty Document ",
+            "regexes": [
+                "$reporter\\s*(?:No\\.|Number)?\\s*(?P<number>\\d+-?\\d*)"
+            ],
+            "start": "1981-01-01T00:00:00",
+            "variations": []
+        }
+    ],
     "S.C. Acts": [
         {
             "cite_type": "leg_session",
@@ -5147,11 +5310,45 @@
             ],
             "jurisdiction": "United States",
             "name": "United States Statutes at Large",
-            "notes": "Automatically generated. Remove this message if replacing with real examples.",
+            "notes": "Some of these citations may be to treaties, which were reported here until December 31, 1949. See Ch 1001, Sec. 2, 64 Stat. 980 (1950).",
             "regexes": [
                 "$volume $reporter $page_with_commas"
             ],
             "start": null,
+            "variations": []
+        }
+    ],
+    "T.I.A.S.": [
+        {
+            "cite_type": "treaty",
+            "end": null,
+            "examples": [
+                "T.I.A.S. No. 6577"
+            ],
+            "href": "https://law.resource.org/pub/us/code/blue/IndigoBook.html#T6",
+            "jurisdiction": "United States",
+            "name": "Treaties and Other International Acts Series",
+            "regexes": [
+                "$reporter\\s*(?:No\\.|Number)?\\s*(?P<number>\\d+)"
+            ],
+            "start": "1945-01-01T00:00:00",
+            "variations": []
+        }
+    ],
+    "T.S.": [
+        {
+            "cite_type": "treaty",
+            "end": "1945-12-31T23:59:59",
+            "examples": [
+                " T.S. No. 251"
+            ],
+            "href": "https://law.resource.org/pub/us/code/blue/IndigoBook.html#T6",
+            "jurisdiction": "United States",
+            "name": "Treaty Series",
+            "regexes": [
+                "\\s$reporter\\s*(?:No\\.|Number)?\\s*(?P<number>\\d+)"
+            ],
+            "start": "1778-01-01T00:00:00",
             "variations": []
         }
     ],

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -2207,6 +2207,26 @@
             }
         }
     ],
+    "Bevans": [
+        {
+            "cite_type": "treaty",
+            "editions": {
+                "Bevans": {
+                    "end": "1949-12-31T23:59:59",
+                    "start": "1776-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "4 Bevans 828"
+            ],
+            "href": "https://law.resource.org/pub/us/code/blue/IndigoBook.html#T6",
+            "mlz_jurisdiction": [
+                "us:federal"
+            ],
+            "name": "Bevans",
+            "variations": {}
+        }
+    ],
     "Bibb": [
         {
             "cite_type": "state",
@@ -4515,6 +4535,26 @@
                 "Connoly Sur. Rep.": "Connoly",
                 "Connoly Surr. Rep.": "Connoly"
             }
+        }
+    ],
+    "Consol. T.S.": [
+        {
+            "cite_type": "treaty",
+            "editions": {
+                "Consol. T.S.": {
+                    "end": "1919-12-31T23:59:59",
+                    "start": "1648-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "212 Consol. T.S. 178"
+            ],
+            "href": "https://law.resource.org/pub/us/code/blue/IndigoBook.html#T6",
+            "mlz_jurisdiction": [
+                ""
+            ],
+            "name": "Parry’s Consolidated Treaty Series",
+            "variations": {}
         }
     ],
     "Consumer Cred. Guide (CCH)": [
@@ -9136,6 +9176,26 @@
             }
         }
     ],
+    "I.L.M.": [
+        {
+            "cite_type": "treaty",
+            "editions": {
+                "I.L.M.": {
+                    "end": null,
+                    "start": "1962-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "23 I.L.M. 1027"
+            ],
+            "href": "https://law.resource.org/pub/us/code/blue/IndigoBook.html#T6",
+            "mlz_jurisdiction": [
+                ""
+            ],
+            "name": "International Legal Materials",
+            "variations": {}
+        }
+    ],
     "I.R.B.": [
         {
             "cite_type": "federal",
@@ -10606,6 +10666,26 @@
                 "U.S.L.Ed.2d": "L. Ed. 2d",
                 "U.S.Law.Ed.": "L. Ed."
             }
+        }
+    ],
+    "L.N.T.S.": [
+        {
+            "cite_type": "treaty",
+            "editions": {
+                "L.N.T.S.": {
+                    "end": "1945-12-31T23:59:59",
+                    "start": "1920-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "137 L.N.T.S. 11"
+            ],
+            "href": "https://law.resource.org/pub/us/code/blue/IndigoBook.html#T6",
+            "mlz_jurisdiction": [
+                ""
+            ],
+            "name": "League of Nations Treaty Series",
+            "variations": {}
         }
     ],
     "L.R.A.": [
@@ -15302,6 +15382,26 @@
                 "O. Supp": "O. Supp.",
                 "Ohio Supp.": "O. Supp."
             }
+        }
+    ],
+    "O.A.S.T.S.": [
+        {
+            "cite_type": "treaty",
+            "editions": {
+                "O.A.S.T.S.": {
+                    "end": null,
+                    "start": "1970-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "36 O.A.S.T.S. 1"
+            ],
+            "href": "https://law.resource.org/pub/us/code/blue/IndigoBook.html#T6",
+            "mlz_jurisdiction": [
+                ""
+            ],
+            "name": "Organization of American States Treaty Series",
+            "variations": {}
         }
     ],
     "O.B.A.J.": [
@@ -20776,6 +20876,26 @@
             }
         }
     ],
+    "U.N.T.S.": [
+        {
+            "cite_type": "treaty",
+            "editions": {
+                "U.N.T.S.": {
+                    "end": null,
+                    "start": "1946-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "213 U.N.T.S. 221"
+            ],
+            "href": "https://law.resource.org/pub/us/code/blue/IndigoBook.html#T6",
+            "mlz_jurisdiction": [
+                ""
+            ],
+            "name": "United Nations Treaty Series",
+            "variations": {}
+        }
+    ],
     "U.S.": [
         {
             "cite_type": "federal",
@@ -21162,6 +21282,26 @@
                 "USPQ 2d": "U.S.P.Q. 2d (BNA)",
                 "USPQ 2d (BNA)": "U.S.P.Q. 2d (BNA)"
             }
+        }
+    ],
+    "U.S.T.": [
+        {
+            "cite_type": "treaty",
+            "editions": {
+                "U.S.T.": {
+                    "end": null,
+                    "start": "1950-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "19 U.S.T. 6223"
+            ],
+            "href": "https://law.resource.org/pub/us/code/blue/IndigoBook.html#T6",
+            "mlz_jurisdiction": [
+                "us:federal"
+            ],
+            "name": "United States Treaties and Other International Agreements",
+            "variations": {}
         }
     ],
     "USCMA": [

--- a/tests.py
+++ b/tests.py
@@ -29,6 +29,7 @@ VALID_CITE_TYPES = (
     "specialty_lexis",
     "state",
     "state_regional",
+    "treaty",
 )
 
 


### PR DESCRIPTION
In response to issue #48 I offered to add support for treaty sources to reporters-db. This PR does so for the treaty sources in Indigo Book T6.

Treaty sources are stored in either the laws.json or reporters.json file depending on which style they more closely resemble. Regardless of where they are stored, they all have cite_type "treaty." The test.py and README.rst files have been updated to recognize "treaty" as a valid cite_type. All examples for all treaties are from Court Listener except for the example for Pan-Am. Treaty Series, which is from a law review article.

I omitted two T6 sources from this PR (Statutes at Large and LEXIS) because they are not exclusive to treaties. Both are already present in reporters-db, and I added a note to the Statutes at Large one explaining that citations there could be to treaties. LEXIS citations are already their own specialty type.

Also, the regex and example for Treaty Series (T.S.) begin with a white space. This is to prevent false positives where T.S. is part of the name of another reporter, but it is an inelegant solution. I tried various lookbehinds and negative assertions, but because they are at the beginning of the string they cause problems.
