### PR TITLE
Add various Reporters variations

### DIFF
--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -2341,9 +2341,7 @@
             "name": "Black's Supreme Court Reports",
             "variations": {
                 "Black R.": "Black",
-                "Black Rep.": "Black",
-                "U.S. (Black)": "Black",
-                "U.S.(Black)": "Black"
+                "Black Rep.": "Black"
             }
         }
     ],
@@ -4789,9 +4787,7 @@
             "variations": {
                 "Cra.": "Cranch",
                 "Cranch (US)": "Cranch",
-                "Cranch Rep.": "Cranch",
-                "U.S. (Cranch)": "Cranch",
-                "U.S.(Cranch)": "Cranch"
+                "Cranch Rep.": "Cranch"
             }
         },
         {
@@ -8982,9 +8978,7 @@
             "name": "Howard's Supreme Court Reports",
             "variations": {
                 "HOW": "How.",
-                "How. Rep.": "How.",
-                "U.S. (How.)": "How.",
-                "U.S.(How.)": "How."
+                "How. Rep.": "How."
             }
         }
     ],
@@ -17602,9 +17596,7 @@
                 "Pet. Rep.": "Pet.",
                 "Pet.S.C.": "Pet.",
                 "Peters": "Pet.",
-                "Peters Rep.": "Pet.",
-                "U.S. (Pet.)": "Pet.",
-                "U.S.(Pet.)": "Pet."
+                "Peters Rep.": "Pet."
             }
         }
     ],
@@ -21062,14 +21054,16 @@
                     "end": null,
                     "regexes": [
                         "$full_cite",
-                        "$volume $reporter, at $page"
+                        "$volume $reporter, at $page",
+                        "$volume $reporter\\s*\\($volume_nominative(?P<reporter_nominative>Black|Cranch|Pet.|Wall.|How.)\\) $page"
                     ],
                     "start": "1875-01-01T00:00:00"
                 }
             },
             "examples": [
                 "515 U. S., at 314",
-                "1 U.S. 1"
+                "1 U.S. 1",
+                "67 U.S. (Black) 17"
             ],
             "mlz_jurisdiction": [
                 "us;supreme.court"
@@ -22476,7 +22470,6 @@
             ],
             "name": "Wallace's Supreme Court Reports",
             "variations": {
-                "U.S.(Wall.)": "Wall.",
                 "Wall.Rep.": "Wall.",
                 "Wall.S.C.": "Wall.",
                 "Wallace R.": "Wall."

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -5312,9 +5312,7 @@
                 "Dall. Rep.": "Dall.",
                 "Dall.S.C.": "Dall.",
                 "Dallas": "Dall.",
-                "Dallas Rep.": "Dall.",
-                "U.S. (Dall.)": "Dall.",
-                "U.S.(Dall.)": "Dall."
+                "Dallas Rep.": "Dall."
             }
         },
         {
@@ -21069,7 +21067,7 @@
                     "regexes": [
                         "$full_cite",
                         "$volume $reporter, at $page",
-                        "$volume $reporter\\s*\\($volume_nominative(?P<reporter_nominative>Black|Cranch|Pet.|Wall.|How.)\\) $page"
+                        "$volume $reporter\\s*\\($volume_nominative(?P<reporter_nominative>Black|Cranch|Pet.|Wall.|How.|Wheat.|Dall.)\\) $page"
                     ],
                     "start": "1875-01-01T00:00:00"
                 }
@@ -22943,7 +22941,6 @@
             "name": "Wheaton's Supreme Court Reports",
             "notes": "Note that Wheaton was not a Free Law advocate. From Georgia v. Public.Resources.Org (SCOTUS, 2020, internal citations omitted): \"In this Court’s first copyright case, Wheaton v. Peters, the Court’s third Reporter of Decisions, Wheaton, sued the fourth, Peters, unsuccessfully asserting a copyright interest in the Justices’ opinions. In Wheaton’s view, the opinions 'must have belonged to some one' because 'they were new, original,' and much more 'elaborate' than law or custom required. Wheaton argued that the Justices were the authors and had assigned their ownership interests to him through a tacit 'gift.'\"",
             "variations": {
-                "U.S.(Wheat.)": "Wheat.",
                 "Wheat. Rep.": "Wheat.",
                 "Wheaton": "Wheat.",
                 "Wheaton Rep.": "Wheat."

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -16565,7 +16565,7 @@
             "cite_type": "federal",
             "editions": {
                 "Otto": {
-                    "end": "1881-12-31T00:00:00",
+                    "end": "1883-12-31T00:00:00",
                     "start": "1875-01-01T00:00:00"
                 }
             },
@@ -16573,7 +16573,7 @@
                 "us;supreme.court"
             ],
             "name": "Otto's Reports",
-            "notes": "More often cited as United States Reports, are law reports of cases from the United States Supreme Court 1875-1881, and are contained in fifteen volumes. Otto was the first 'anonymous' SCOTUS reporter. In theory, he shouldn't ever have citations under his name.",
+            "notes": "See http://www.indianalegalarchive.com/journal/otto for more details on Otto (the reporter)",
             "variations": {}
         }
     ],

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -1016,7 +1016,9 @@
             },
             "mlz_jurisdiction": [],
             "name": "West's American Tribal Law Reporter",
-            "variations": {}
+            "variations": {
+                "Tribal": "Am. Tribal Law"
+            }
         }
     ],
     "Amer. L. Rev.": [
@@ -2496,7 +2498,9 @@
                 "us:ny;superior.court"
             ],
             "name": "Bosworth's Reports (14-23 New York Superior)",
-            "variations": {}
+            "variations": {
+                "Bosworth Super. Ct. Rep.": "Bosw."
+            }
         }
     ],
     "Boyce": [
@@ -8242,6 +8246,7 @@
             "variations": {
                 "Hall R.": "Hall",
                 "Hall Rep.": "Hall",
+                "Hall Super. Ct. Rep.": "Hall",
                 "Hall's R.": "Hall",
                 "Hall's Sup. Court Rep.": "Hall",
                 "Hall's Sup. Ct. R.": "Hall",
@@ -10240,7 +10245,8 @@
             ],
             "name": "Jones & Spencer's Reports (33-61 New York Superior)",
             "variations": {
-                "Jones & Spencer": "Jones & S."
+                "Jones & Spencer": "Jones & S.",
+                "Jones and Spencer's Super. Ct. Rep.": "Jones & S."
             }
         }
     ],
@@ -15876,7 +15882,8 @@
                 "Ohio Cir.Ct.": "Ohio C.C.",
                 "Ohio Cir.Ct.(N.S.)": "Ohio C.C. (n.s.)",
                 "Ohio Cir.Ct.R.N.S.": "Ohio C.C. (n.s.)",
-                "Ohio Cr.Ct.R.": "Ohio C.C."
+                "Ohio Cr.Ct.R.": "Ohio C.C.",
+                "Jahn": "Ohio C.C."
             }
         }
     ],
@@ -19882,7 +19889,9 @@
                 "us:ny;superior.court"
             ],
             "name": "Sweeny's Reports (31-32 New York Superior)",
-            "variations": {}
+            "variations": {
+                "Sweeney Super. Ct. Rep.": "Sweeny"
+            }
         }
     ],
     "T.B. Mon.": [

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -319,7 +319,8 @@
             "name": "Abbott, United States Circuit and District Court Reports",
             "variations": {
                 "Abb": "Abb.",
-                "Abb. Rep.": "Abb."
+                "Abb. Rep.": "Abb.",
+                "Abb. U. S.": "Abb."
             }
         }
     ],
@@ -3221,6 +3222,7 @@
             "name": "California Appellate Reports",
             "variations": {
                 "Cal. App. Rep.": "Cal. App.",
+                "Cal. App. Supp": "Cal. App.",
                 "Cal. App.2d": "Cal. App. 2d",
                 "Cal. App.3d": "Cal. App. 3d",
                 "Cal. App.4th": "Cal. App. 4th",
@@ -6464,9 +6466,18 @@
             "editions": {
                 "F. Cas.": {
                     "end": "1880-01-01T00:00:00",
+                    "regexes": [
+                        "$full_cite",
+                        "$volume $reporter (p|P)age $page"
+                    ],
                     "start": "1789-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "1 F. Cas. 1",
+                "14 F. Cas. Page 1048",
+                "10 F. Cas. page 164"
+            ],
             "mlz_jurisdiction": [
                 "us:c10;court.appeals",
                 "us:c11;court.appeals",
@@ -6484,6 +6495,7 @@
             "variations": {
                 "F.C.": "F. Cas.",
                 "F.Cas.": "F. Cas.",
+                "Fed. Cas.": "F. Cas.",
                 "Fed.Ca.": "F. Cas."
             }
         }
@@ -7006,6 +7018,7 @@
             "notes": "https://en.wikipedia.org/wiki/Federal_Appendix, Relatively new published book.",
             "variations": {
                 "Fed. App'x": "Fed. Appx.",
+                "Fed.App'x": "Fed. Appx.",
                 "Fed.Appx.": "Fed. Appx."
             }
         }

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -16560,6 +16560,23 @@
             "variations": {}
         }
     ],
+    "Otto": [
+        {
+            "cite_type": "federal",
+            "editions": {
+                "Otto": {
+                    "end": "1881-12-31T00:00:00",
+                    "start": "1875-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [
+                "us;supreme.court"
+            ],
+            "name": "Otto's Reports",
+            "notes": "More often cited as United States Reports, are law reports of cases from the United States Supreme Court 1875-1881, and are contained in fifteen volumes. Otto was the first 'anonymous' SCOTUS reporter. In theory, he shouldn't ever have citations under his name.",
+            "variations": {}
+        }
+    ],
     "Overt.": [
         {
             "cite_type": "state",
@@ -21081,9 +21098,8 @@
                 "us;supreme.court"
             ],
             "name": "United States Supreme Court Reports",
-            "notes": "Otto was the first 'anonymous' SCOTUS reporter. In theory, he shouldn't ever have citations under his name. Nevertheless, he does, so we simply consider these citations to be variations of U.S.",
+            "notes": "",
             "variations": {
-                "Otto": "U.S.",
                 "U. S.": "U.S.",
                 "U. S. Rep.": "U.S.",
                 "U.S. (1 Wall.)": "U.S.",

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -6457,7 +6457,8 @@
             "variations": {
                 "F. App'x.": "F. App'x",
                 "F.App'x": "F. App'x",
-                "F.App'x.": "F. App'x"
+                "F.App'x.": "F. App'x",
+                "F.App’x.": "F. App'x"
             }
         }
     ],
@@ -8982,7 +8983,8 @@
             "variations": {
                 "HOW": "How.",
                 "How. Rep.": "How.",
-                "U.S.(How.)": "How."
+                "U.S.(How.)": "How.",
+                "U.S. (How.)": "How."
             }
         }
     ],
@@ -17601,7 +17603,8 @@
                 "Pet.S.C.": "Pet.",
                 "Peters": "Pet.",
                 "Peters Rep.": "Pet.",
-                "U.S.(Pet.)": "Pet."
+                "U.S.(Pet.)": "Pet.",
+                "U.S. (Pet.)": "Pet."
             }
         }
     ],
@@ -19149,7 +19152,8 @@
             "variations": {
                 "Ill.(Scam.)": "Scam.",
                 "Sc.": "Scam.",
-                "Scam. Rep.": "Scam."
+                "Scam. Rep.": "Scam.",
+                "Ill. (Scam)": "Scam."
             }
         }
     ],

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -8983,8 +8983,8 @@
             "variations": {
                 "HOW": "How.",
                 "How. Rep.": "How.",
-                "U.S.(How.)": "How.",
-                "U.S. (How.)": "How."
+                "U.S. (How.)": "How.",
+                "U.S.(How.)": "How."
             }
         }
     ],
@@ -17603,8 +17603,8 @@
                 "Pet.S.C.": "Pet.",
                 "Peters": "Pet.",
                 "Peters Rep.": "Pet.",
-                "U.S.(Pet.)": "Pet.",
-                "U.S. (Pet.)": "Pet."
+                "U.S. (Pet.)": "Pet.",
+                "U.S.(Pet.)": "Pet."
             }
         }
     ],
@@ -19150,10 +19150,10 @@
             ],
             "name": "Illinois Reports, Scammon",
             "variations": {
+                "Ill. (Scam)": "Scam.",
                 "Ill.(Scam.)": "Scam.",
                 "Sc.": "Scam.",
-                "Scam. Rep.": "Scam.",
-                "Ill. (Scam)": "Scam."
+                "Scam. Rep.": "Scam."
             }
         }
     ],
@@ -19286,7 +19286,9 @@
                 "us:tn;supreme.court"
             ],
             "name": "Shannon's Tennessee Cases",
-            "variations": {}
+            "variations": {
+                "Tenn. Cas.": "Shan. Cas."
+            }
         }
     ],
     "Shipping Reg. (P & F)": [

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -2342,6 +2342,7 @@
             "variations": {
                 "Black R.": "Black",
                 "Black Rep.": "Black",
+                "U.S. (Black)": "Black",
                 "U.S.(Black)": "Black"
             }
         }
@@ -4789,6 +4790,7 @@
                 "Cra.": "Cranch",
                 "Cranch (US)": "Cranch",
                 "Cranch Rep.": "Cranch",
+                "U.S. (Cranch)": "Cranch",
                 "U.S.(Cranch)": "Cranch"
             }
         },
@@ -5313,6 +5315,7 @@
                 "Dall.S.C.": "Dall.",
                 "Dallas": "Dall.",
                 "Dallas Rep.": "Dall.",
+                "U.S. (Dall.)": "Dall.",
                 "U.S.(Dall.)": "Dall."
             }
         },
@@ -6001,7 +6004,9 @@
                 "us:ny;superior.court"
             ],
             "name": "Duer's Reports (8-13 New York Superior)",
-            "variations": {}
+            "variations": {
+                "Duer Super. Ct. Rep.": "Duer"
+            }
         }
     ],
     "Duv.": [
@@ -6450,7 +6455,9 @@
             ],
             "name": "Federal Appendix",
             "variations": {
-                "F. App'x.": "F. App'x"
+                "F. App'x.": "F. App'x",
+                "F.App'x": "F. App'x",
+                "F.App'x.": "F. App'x"
             }
         }
     ],
@@ -12833,6 +12840,7 @@
             "name": "Michigan Appeals Reports",
             "variations": {
                 "Mich App": "Mich. App.",
+                "Mich. Ct. App.": "Mich. App.",
                 "Mich.App.": "Mich. App."
             }
         }
@@ -15871,6 +15879,7 @@
             ],
             "name": "Ohio Circuit Court Reports",
             "variations": {
+                "Jahn": "Ohio C.C.",
                 "O.C.C.N.S.": "Ohio C.C. (n.s.)",
                 "Oh.Cir.Ct.": "Ohio C.C.",
                 "Oh.Cir.Ct.N.S.": "Ohio C.C. (n.s.)",
@@ -15882,8 +15891,7 @@
                 "Ohio Cir.Ct.": "Ohio C.C.",
                 "Ohio Cir.Ct.(N.S.)": "Ohio C.C. (n.s.)",
                 "Ohio Cir.Ct.R.N.S.": "Ohio C.C. (n.s.)",
-                "Ohio Cr.Ct.R.": "Ohio C.C.",
-                "Jahn": "Ohio C.C."
+                "Ohio Cr.Ct.R.": "Ohio C.C."
             }
         }
     ],
@@ -21066,6 +21074,7 @@
                 "Otto": "U.S.",
                 "U. S.": "U.S.",
                 "U. S. Rep.": "U.S.",
+                "U.S. (1 Wall.)": "U.S.",
                 "U.S. (Wall.)": "U.S.",
                 "U.S. (Wheat.)": "U.S.",
                 "U.S.S.C.Rep.": "U.S.",

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -21092,7 +21092,10 @@
             "examples": [
                 "515 U. S., at 314",
                 "1 U.S. 1",
-                "67 U.S. (Black) 17"
+                "67 U.S. (Black) 17",
+                "1 U.S. (1 Wall.) 12",
+                "1 U.S. (Wall.) 12",
+                "55 U.S. (Wheat.) 2"
             ],
             "mlz_jurisdiction": [
                 "us;supreme.court"
@@ -21102,9 +21105,6 @@
             "variations": {
                 "U. S.": "U.S.",
                 "U. S. Rep.": "U.S.",
-                "U.S. (1 Wall.)": "U.S.",
-                "U.S. (Wall.)": "U.S.",
-                "U.S. (Wheat.)": "U.S.",
                 "U.S.S.C.Rep.": "U.S.",
                 "US": "U.S.",
                 "USSCR": "U.S."

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -8657,13 +8657,14 @@
                     "end": "1836-12-31T00:00:00",
                     "regexes": [
                         "$full_cite",
-                        "$volume $reporter \\(\\d{4}\\) $page"
+                        "$volume $reporter \\(\\d{4}\\,?\\) $page"
                     ],
                     "start": "1828-01-01T00:00:00"
                 }
             },
             "examples": [
                 "14 Haz. Reg. Pa. (1834) 10",
+                "14 Haz. Reg. Pa. (1834,) 10",
                 "14 Haz. Reg. Pa. 10"
             ],
             "mlz_jurisdiction": [],

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -12216,7 +12216,8 @@
             ],
             "name": "Massachusetts Law Reporter",
             "variations": {
-                "Mass. Law Rep": "Mass. L. Rptr."
+                "Mass. Law Rep": "Mass. L. Rptr.",
+                "Mass. Law Rep.": "Mass. L. Rptr."
             }
         }
     ],


### PR DESCRIPTION
New reporters variations found in courtlistener logs, some of them include unicode characters but others are very interesing because the  the reporter short name changed drastically, I am attaching a csv with the IA url, case.law url, the old citation and the new citation with some of this short name changes.

[reporters_changes.csv](https://github.com/freelawproject/reporters-db/files/9539309/reporters_changes.csv)
