### PR TITLE
New reporters, new reporters variations and new regex pattern

### DIFF
--- a/reporters_db/data/regexes.json
+++ b/reporters_db/data/regexes.json
@@ -54,6 +54,8 @@
         "with_commas_and_suffix#": "Page number that allows internal commas, plus optional alpha character appended",
         "with_commas_or_periods": "(?P<page>\\d(?:[\\d,.]*\\d)?)",
         "with_commas_or_periods#": "Page number that allows internal punctuation",
+        "with_letter": "(?P<page>\\d+\\w)",
+        "with_letter#": "Page number followed by a letter",
         "with_periods": "(?P<page>\\d(?:[\\d.]*\\d)?)",
         "with_periods#": "Page number that allows internal periods, like '1234.56'",
         "with_roman_numerals": "(?P<page>[cC]?(?:[xX][cC]|[xX][lL]|[lL]?[xX]{1,3})(?:[iI][xX]|[iI][vV]|[vV]?[iI]{0,3})|(?:[cC]?[lL]?)(?:[iI][xX]|[iI][vV]|[vV]?[iI]{1,3})|(?:[lL][vV]|[cC][vV]|[cC][lL]|[cC][lL][vV]))",

--- a/reporters_db/data/regexes.json
+++ b/reporters_db/data/regexes.json
@@ -54,7 +54,7 @@
         "with_commas_and_suffix#": "Page number that allows internal commas, plus optional alpha character appended",
         "with_commas_or_periods": "(?P<page>\\d(?:[\\d,.]*\\d)?)",
         "with_commas_or_periods#": "Page number that allows internal punctuation",
-        "with_letter": "(?P<page>\\d+\\w)",
+        "with_letter": "(?P<page>\\d+[a-zA-Z])",
         "with_letter#": "Page number followed by a letter",
         "with_periods": "(?P<page>\\d(?:[\\d.]*\\d)?)",
         "with_periods#": "Page number that allows internal periods, like '1234.56'",

--- a/reporters_db/data/regexes.json
+++ b/reporters_db/data/regexes.json
@@ -26,7 +26,7 @@
         },
         "single_volume": "(?:(?P<volume>1) )?$reporter $page",
         "year_included": {
-            "": "$volume $reporter \\((?P<year>1[789]\\d{2}|20\\d{2})\\) $page",
+            "": "$volume $reporter \\((?P<year>1[789]\\d{2}|20\\d{2}),?\\) $page",
             "#": "Citation that includes the volume year after the reporter '14 Haz. Reg. Pa. (1834) 10'"
         },
         "year_page": "$reporter $volume_year-$page"

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -16993,7 +16993,7 @@
                 "Pa.": {
                     "end": null,
                     "regexes": [
-                        "(?P<volume>\\d+|81 ?\\*|81 1/2|\\* ?81|81 ?½) $reporter,? $page",
+                        "(?P<volume>\\d+|81 ?\\*|\\* ?81) $reporter,? $page",
                         "$volume $reporter $page_with_letter"
                     ],
                     "start": "1845-01-01T00:00:00"
@@ -17001,8 +17001,6 @@
             },
             "examples": [
                 "1 Pa. 1",
-                "81½ Pa. 9",
-                "81 1/2 Pa. 9",
                 "81* Pa. 57",
                 "81 * Pa. 57",
                 "*81 Pa. 57",

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -13718,20 +13718,6 @@
             "variations": {}
         }
     ],
-    "N.B.R.": [
-        {
-            "cite_type": "specialty",
-            "editions": {
-                "N.B.R.": {
-                    "end": null,
-                    "start": "1750-01-01T00:00:00"
-                }
-            },
-            "mlz_jurisdiction": [],
-            "name": "National Bankruptcy Register Reports",
-            "variations": {}
-        }
-    ],
     "N.B.R. (Supp.)": [
         {
             "cite_type": "specialty",
@@ -15149,12 +15135,12 @@
             "cite_type": "specialty",
             "editions": {
                 "Nat. Bank. Reg.": {
-                    "end": null,
+                    "end": "1882-12-31T00:00:00",
                     "regexes": [
                         "$full_cite",
                         "$full_cite_year_included"
                     ],
-                    "start": "1978-01-01T00:00:00"
+                    "start": "1867-01-01T00:00:00"
                 }
             },
             "examples": [
@@ -15272,6 +15258,7 @@
                 "N. Bk. R.": "Nat. Bank. Reg.",
                 "N. Bkpt. R.": "Nat. Bank. Reg.",
                 "N. Bkpt. Reg.": "Nat. Bank. Reg.",
+                "N.B.R.": "Nat. Bank. Reg.",
                 "Nat. Bankr. Reg.": "Nat. Bank. Reg."
             }
         }

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -16980,7 +16980,7 @@
                 "Pa.": {
                     "end": null,
                     "regexes": [
-                        "(?P<volume>\\d+|81 ?\\*|\\* ?81) $reporter,? $page",
+                        "$full_cite",
                         "$volume $reporter $page_with_letter"
                     ],
                     "start": "1845-01-01T00:00:00"
@@ -16988,9 +16988,6 @@
             },
             "examples": [
                 "1 Pa. 1",
-                "81* Pa. 57",
-                "81 * Pa. 57",
-                "*81 Pa. 57",
                 "323 Pa. 560a"
             ],
             "mlz_jurisdiction": [

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -18069,21 +18069,6 @@
             "variations": {}
         }
     ],
-    "Quarto": [
-        {
-            "cite_type": "specialty",
-            "editions": {
-                "Quarto": {
-                    "end": "1851-12-31T00:00:00",
-                    "start": "1850-01-01T00:00:00"
-                }
-            },
-            "mlz_jurisdiction": [],
-            "name": "Howison's Criminal Trials",
-            "notes": "",
-            "variations": {}
-        }
-    ],
     "R.I.": [
         {
             "cite_type": "state",

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -22580,7 +22580,7 @@
                     "end": "1874-12-31T00:00:00",
                     "regexes": [
                         "$full_cite",
-                        "$reporter,? (p.)? $page"
+                        "$reporter,? p. $page"
                     ],
                     "start": "1863-01-01T00:00:00"
                 }

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -3155,6 +3155,10 @@
                     "end": "1991-12-31T00:00:00",
                     "start": "1969-01-01T00:00:00"
                 },
+                "Cal. 3d Spec. Trib Supp.": {
+                    "end": "1991-12-31T00:00:00",
+                    "start": "1969-01-01T00:00:00"
+                },
                 "Cal. 4th": {
                     "end": null,
                     "start": "1991-01-01T00:00:00"
@@ -13712,6 +13716,30 @@
             "variations": {}
         }
     ],
+    "N.B.R. (Supp.)": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "N.B.R. (Supp.)": {
+                    "end": null,
+                    "regexes": [
+                        "$full_cite_single_volume"
+                    ],
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "Bankr. Reg. Supp. 46",
+                "Bankr. Reg. Supp. 14",
+                "Bankr. Reg. Supp. 19"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "National Bankruptcy Register Reports, Supplement",
+            "variations": {
+                "Bankr. Reg. Supp.": "N.B.R. (Supp.)"
+            }
+        }
+    ],
     "N.C.": [
         {
             "cite_type": "state",
@@ -22534,9 +22562,17 @@
             "editions": {
                 "Wall.": {
                     "end": "1874-12-31T00:00:00",
+                    "regexes": [
+                        "$full_cite",
+                        "$reporter,? (p.)? $page"
+                    ],
                     "start": "1863-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "487 Wall. 141",
+                "Wallace R., p. 573"
+            ],
             "mlz_jurisdiction": [
                 "us;supreme.court"
             ],

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -533,6 +533,7 @@
             ],
             "name": "Alabama Reports",
             "variations": {
+                "Ala. (N.S.)": "Ala.",
                 "Ala. Rep.": "Ala."
             }
         }
@@ -958,6 +959,21 @@
                 "Am. Reports": "Am. Rep.",
                 "Am.Rep.": "Am. Rep."
             }
+        }
+    ],
+    "Am. Ry. Rep.": [
+        {
+            "cite_type": "federal",
+            "editions": {
+                "Am. Ry. Rep.": {
+                    "end": "1881-12-31T00:00:00",
+                    "start": "1873-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "American Railway Reports",
+            "notes": "",
+            "variations": {}
         }
     ],
     "Am. Samoa": [
@@ -15962,6 +15978,7 @@
                 "Oh.Cir.Ct.": "Ohio C.C.",
                 "Oh.Cir.Ct.N.S.": "Ohio C.C. (n.s.)",
                 "Ohio C.C. (N.S.)": "Ohio C.C. (n.s.)",
+                "Ohio C.C. (n.s.)": "Ohio C.C. (n.s.)",
                 "Ohio C.C.(n.s.)": "Ohio C.C. (n.s.)",
                 "Ohio C.C.N.S.": "Ohio C.C. (n.s.)",
                 "Ohio C.C.R.": "Ohio C.C.",

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -1079,9 +1079,17 @@
             "editions": {
                 "App. D.C.": {
                     "end": "1941-12-31T00:00:00",
+                    "regexes": [
+                        "$full_cite",
+                        "$volume $reporter $page_with_letter"
+                    ],
                     "start": "1893-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "44 App. D.C. 154b",
+                "48 App. D.C. 606"
+            ],
             "mlz_jurisdiction": [
                 "us:dc;court.appeals"
             ],
@@ -3221,6 +3229,7 @@
             ],
             "name": "California Appellate Reports",
             "variations": {
+                "Cal. App. 2d Supp": "Cal. App. 2d",
                 "Cal. App. Rep.": "Cal. App.",
                 "Cal. App. Supp": "Cal. App.",
                 "Cal. App.2d": "Cal. App. 2d",
@@ -7497,9 +7506,17 @@
             "editions": {
                 "Fla.": {
                     "end": "1948-12-31T00:00:00",
+                    "regexes": [
+                        "$full_cite",
+                        "$volume $reporter $page_with_letter"
+                    ],
                     "start": "1846-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "95 Fla. 736a",
+                "128 Fla. 1"
+            ],
             "mlz_jurisdiction": [
                 "us:fl;supreme.court"
             ],
@@ -7754,7 +7771,8 @@
                     "end": null,
                     "regexes": [
                         "$full_cite",
-                        "(?P<volume>33) $reporter (?P<supp>Supp\\.) $page"
+                        "(?P<volume>33) $reporter (?P<supp>Supp\\.) $page",
+                        "$volume $reporter $page_with_letter"
                     ],
                     "start": "1846-01-01T00:00:00"
                 }
@@ -7762,7 +7780,8 @@
             "examples": [
                 "1 Ga. 1",
                 "33 Ga. Supp. 9",
-                "33 Suppl. Ga. 29"
+                "33 Suppl. Ga. 29",
+                "246 Ga. 822a"
             ],
             "mlz_jurisdiction": [
                 "us:ga;supreme.court"
@@ -9689,9 +9708,17 @@
             "editions": {
                 "Ill. Ct. Cl.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite",
+                        "$volume $reporter $page_with_letter"
+                    ],
                     "start": "1889-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "7 Ill. Ct. Cl. 156a",
+                "49 Ill. Ct. Cl. 42"
+            ],
             "mlz_jurisdiction": [
                 "us:il;supreme.court"
             ],
@@ -16922,7 +16949,8 @@
                 "Pa.": {
                     "end": null,
                     "regexes": [
-                        "(?P<volume>\\d+|81 ?\\*|81 1/2|\\* ?81|81 ?½) $reporter,? $page"
+                        "(?P<volume>\\d+|81 ?\\*|81 1/2|\\* ?81|81 ?½) $reporter,? $page",
+                        "$volume $reporter $page_with_letter"
                     ],
                     "start": "1845-01-01T00:00:00"
                 }
@@ -16933,7 +16961,8 @@
                 "81 1/2 Pa. 9",
                 "81* Pa. 57",
                 "81 * Pa. 57",
-                "*81 Pa. 57"
+                "*81 Pa. 57",
+                "323 Pa. 560a"
             ],
             "mlz_jurisdiction": [
                 "us:pa;supreme.court"

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -15978,7 +15978,6 @@
                 "Oh.Cir.Ct.": "Ohio C.C.",
                 "Oh.Cir.Ct.N.S.": "Ohio C.C. (n.s.)",
                 "Ohio C.C. (N.S.)": "Ohio C.C. (n.s.)",
-                "Ohio C.C. (n.s.)": "Ohio C.C. (n.s.)",
                 "Ohio C.C.(n.s.)": "Ohio C.C. (n.s.)",
                 "Ohio C.C.N.S.": "Ohio C.C. (n.s.)",
                 "Ohio C.C.R.": "Ohio C.C.",
@@ -18067,6 +18066,21 @@
                 "us;federal"
             ],
             "name": "Interior and General Land Office Cases Relating to Public Lands",
+            "variations": {}
+        }
+    ],
+    "Quarto": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Quarto": {
+                    "end": "1851-12-31T00:00:00",
+                    "start": "1850-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Howison's Criminal Trials",
+            "notes": "",
             "variations": {}
         }
     ],


### PR DESCRIPTION
This changes includes:

- New reporters variations found in courtlistener logs.
- New regex pattern for a page number followed by a letter, e.g. 246 Ga. 822a or 44 App. D.C. 154b
- Updated regex pattern: $full_cite_year_included to include optional comma after year, e.g. 3 N. B. R. (1870,) 575
- New reporter N.B.R. (Supp.) (https://law.resource.org/pub/us/case/reporter/F.Cas/0001.f.cas/0001.f.cas.front.html)
- New reporter: American Railway Reports (https://www.legalabbrevs.cardiff.ac.uk/titles/tview/id/283/tsearch//ttype/Exact)
- Alabama reports variation: alabama reports new series (https://www.legalabbrevs.cardiff.ac.uk/titles/tview/id/497/tsearch//ttype/Exact)