### PR TITLE
fix(reporters): Two minor tweaks

### DIFF
--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -19525,7 +19525,6 @@
             "name": "Southern Reporter",
             "variations": {
                 "(So. 2nd)": "So. 2d",
-                "S.": "So.",
                 "S. (2nd)": "So. 2d",
                 "SO.": "So.",
                 "So (2nd)": "So. 2d",
@@ -21098,14 +21097,12 @@
                     "end": null,
                     "regexes": [
                         "$full_cite",
-                        "$volume $reporter, at $page",
                         "$volume $reporter\\s*\\($volume_nominative(?P<reporter_nominative>Black|Cranch|Pet.|Wall.|How.|Wheat.|Dall.)\\) $page"
                     ],
                     "start": "1875-01-01T00:00:00"
                 }
             },
             "examples": [
-                "515 U. S., at 314",
                 "1 U.S. 1",
                 "67 U.S. (Black) 17",
                 "1 U.S. (1 Wall.) 12",


### PR DESCRIPTION
A regex pattern was added that matched to a pin
cite and thus not a complete page cite.
Dropped it.

Also ... the S. reporter variation is causing
down stream problems  I dont fully grasp.
Removing it for now.