### PR TITLE
New reporters and reporter variations

### DIFF
--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -319,6 +319,7 @@
             "name": "Abbott, United States Circuit and District Court Reports",
             "variations": {
                 "Abb": "Abb.",
+                "Abb. (U. S.)": "Abb.",
                 "Abb. Rep.": "Abb.",
                 "Abb. U. S.": "Abb."
             }
@@ -837,12 +838,12 @@
             "cite_type": "state",
             "editions": {
                 "Am. Law Reg.": {
-                    "end": null,
-                    "start": "1750-01-01T00:00:00"
+                    "end": "1861-12-31T00:00:00",
+                    "start": "1853-01-01T00:00:00"
                 },
                 "Am. Law Reg. (N.S.)": {
-                    "end": null,
-                    "start": "1750-01-01T00:00:00"
+                    "end": "1878-12-31T00:00:00",
+                    "start": "1862-01-01T00:00:00"
                 }
             },
             "mlz_jurisdiction": [
@@ -1920,6 +1921,20 @@
             }
         }
     ],
+    "Balt. Law Trans.": [
+        {
+            "cite_type": "state",
+            "editions": {
+                "Balt. Law Trans.": {
+                    "end": "1870-12-31T00:00:00",
+                    "start": "1868-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Baltimore Law Transcript",
+            "variations": {}
+        }
+    ],
     "Ban. & A.": [
         {
             "cite_type": "specialty",
@@ -2327,7 +2342,9 @@
             },
             "mlz_jurisdiction": [],
             "name": "Benedict United States District Reports",
-            "variations": {}
+            "variations": {
+                "Ben": "Ben."
+            }
         }
     ],
     "Ben. Rev. Bd. Serv. (MB)": [
@@ -2368,6 +2385,7 @@
                 "Betts, D. C. MS.": "Betts' Dec.",
                 "Betts, D. C. MSS.": "Betts' Dec.",
                 "Betts, D. C. Ms.": "Betts' Dec.",
+                "Betts. C. C. MS.": "Betts' Dec.",
                 "Betts. D. C. MS.": "Betts' Dec.",
                 "Betts. D. C. MSS.": "Betts' Dec."
             }
@@ -2815,6 +2833,7 @@
             "mlz_jurisdiction": [],
             "name": "Brockenbrough's Marshall's Decisions, United States Circuit Court",
             "variations": {
+                "Brock,": "Brock.",
                 "Brock. Rep.": "Brock."
             }
         }
@@ -2826,13 +2845,15 @@
                 "Brown Adm.": {
                     "end": null,
                     "regexes": [
-                        "$volume_nominative ?$reporter $page"
+                        "$volume_nominative ?$reporter $page",
+                        "$full_cite_year_included"
                     ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
             "examples": [
-                "Brown, Adm. 124"
+                "Brown, Adm. 124",
+                "1 Brown, Adm. (1876) 193"
             ],
             "mlz_jurisdiction": [],
             "name": "Brown's Admiralty (U.S.)",
@@ -2840,7 +2861,8 @@
                 "Brown Adm": "Brown Adm.",
                 "Brown's Adm": "Brown Adm.",
                 "Brown's Adm.": "Brown Adm.",
-                "Brown, Adm.": "Brown Adm."
+                "Brown, Adm.": "Brown Adm.",
+                "Brown. Adm.": "Brown Adm."
             }
         }
     ],
@@ -4051,9 +4073,17 @@
             "editions": {
                 "Chi. Leg. News": {
                     "end": "1925-12-31T00:00:00",
+                    "regexes": [
+                        "$full_cite",
+                        "$full_cite_year_included"
+                    ],
                     "start": "1868-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "10 Chi. Leg. News (1878) 353",
+                "3 Chi. Leg. News, 260"
+            ],
             "mlz_jurisdiction": [
                 "us:c7:il.nd;district.court"
             ],
@@ -4100,9 +4130,17 @@
             "editions": {
                 "Cin. L. Bull.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite",
+                        "$full_cite_year_included"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "9 Cin. L. Bull. 65",
+                "1 Cin. Law Bul. (1877) 374"
+            ],
             "mlz_jurisdiction": [
                 "us:oh;supreme.court"
             ],
@@ -5254,7 +5292,9 @@
             },
             "mlz_jurisdiction": [],
             "name": "Curtis' United States (US) Circuit Court Decisions",
-            "variations": {}
+            "variations": {
+                "Curt": "Curt."
+            }
         }
     ],
     "Cush.": [
@@ -6091,6 +6131,7 @@
             ],
             "name": "North Carolina Reports, Devereux's Law",
             "variations": {
+                "Dev. (N. C.)": "Dev.",
                 "Dev. Rep.": "Dev.",
                 "Dev.L.": "Dev.",
                 "N.C.(Dev.)": "Dev."
@@ -8582,7 +8623,9 @@
                 "us:md;court.appeals"
             ],
             "name": "Maryland Reports, Harris and Johnson",
-            "variations": {}
+            "variations": {
+                "Har. & J.": "H. & J."
+            }
         }
     ],
     "H. & McH.": [
@@ -9510,6 +9553,7 @@
             "name": "Howard's Practice Reports",
             "variations": {
                 "How. Pr. Rep.": "How. Pr.",
+                "How. Prac.": "How. Pr.",
                 "How.P.R.": "How. Pr.",
                 "How.Prac.(N.Y.)": "How. Pr.",
                 "N.Y.Spec.Term R.": "How. Pr.",
@@ -9575,15 +9619,24 @@
             "editions": {
                 "Hughes": {
                     "end": "1801-12-31T00:00:00",
+                    "regexes": [
+                        "$full_cite",
+                        "$full_cite_year_included"
+                    ],
                     "start": "1785-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "2 Hughes 447",
+                "3 Hughes (1880) 464"
+            ],
             "mlz_jurisdiction": [
                 "us:ky;supreme.court"
             ],
             "name": "Kentucky Reports, Hughes",
             "variations": {
                 "Hugh.": "Hughes",
+                "Hughes (1877)": "Hughes",
                 "Hughes.": "Hughes",
                 "Ky.(Hughes)": "Hughes"
             }
@@ -10821,6 +10874,24 @@
                 "us:c2:ny.ed;district.court"
             ],
             "name": "Journal of the Franklin Institute",
+            "variations": {}
+        }
+    ],
+    "Jour. Jur.": [
+        {
+            "cite_type": "federal",
+            "editions": {
+                "Jour. Jur.": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "1 Jour. Jur. 131"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "Journal of Jurisprudence",
+            "notes": "Sometimes cited as Hall's Amer. Law J., Vol. 7.",
             "variations": {}
         }
     ],
@@ -13778,14 +13849,16 @@
                     "end": "1966-12-31T00:00:00",
                     "regexes": [
                         "$full_cite",
-                        "$volume $reporter \\($volume_nominative(?P<reporter_nominative>S\\. & M\\.|Howard|Walker)\\) $page"
+                        "$volume $reporter \\($volume_nominative(?P<reporter_nominative>S\\. & M\\.|Howard|Walker)\\) $page",
+                        "$volume $reporter,? p. $page"
                     ],
                     "start": "1851-01-01T00:00:00"
                 }
             },
             "examples": [
                 "1 Miss. 1",
-                "9 Miss. (1 S. & M.) 456"
+                "9 Miss. (1 S. & M.) 456",
+                "33 Miss. R., p. 363"
             ],
             "mlz_jurisdiction": [
                 "us:ms;supreme.court"
@@ -21922,6 +21995,7 @@
                 "U. S.": "U.S.",
                 "U. S. R.": "U.S.",
                 "U. S. Rep.": "U.S.",
+                "U.S.R.": "U.S.",
                 "U.S.S.C.Rep.": "U.S.",
                 "US": "U.S.",
                 "USSCR": "U.S."

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -5035,6 +5035,28 @@
             }
         }
     ],
+    "Cranch, Pat. Dec.": [
+        {
+            "cite_type": "federal",
+            "editions": {
+                "Cranch, Pat. Dec.": {
+                    "end": "1847-12-31T00:00:00",
+                    "regexes": [
+                        "$volume_nominative ?$reporter $page"
+                    ],
+                    "start": "1841-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "Cranch, Pat. Dec. 125"
+            ],
+            "mlz_jurisdiction": [
+                "us;supreme.court"
+            ],
+            "name": "Cranch's Patent Decisions",
+            "variations": {}
+        }
+    ],
     "Crim. L. Rep. (BNA)": [
         {
             "cite_type": "specialty",
@@ -12223,9 +12245,17 @@
             "editions": {
                 "MacA. Pat. Cas.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite",
+                        "$volume_nominative ?$reporter $page"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "McA. Pat. Cas. 510",
+                "1 McA. Pat. Cas. 123"
+            ],
             "mlz_jurisdiction": [],
             "name": "Reports of cases arising upon applications for letters-patent for inventions determined in the Circuit and Supreme Court of the District of Columbia (MacArthur's Patent Cases)",
             "variations": {
@@ -12233,6 +12263,7 @@
                 "Mac. A. Pat. Cas.": "MacA. Pat. Cas.",
                 "MacA. Pat Cas.": "MacA. Pat. Cas.",
                 "MacArth.": "MacA. Pat. Cas.",
+                "Mc.A. Pat. Cas.": "MacA. Pat. Cas.",
                 "McA. Pat. Cas.": "MacA. Pat. Cas."
             }
         }
@@ -19444,6 +19475,7 @@
             "name": "South Western Reporter",
             "variations": {
                 "S. W.": "S.W.",
+                "S.W. Series": "S.W.",
                 "S. W. (2d)": "S.W.2d",
                 "S. W. 2d": "S.W.2d",
                 "S. W. 2d Series.": "S.W.2d",

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -8722,9 +8722,17 @@
             "editions": {
                 "Hask.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite",
+                        "$volume_nominative ?$reporter $page"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "Hask. 236",
+                "1 Hask. 405"
+            ],
             "mlz_jurisdiction": [],
             "name": "Haskell's Reports for U.S. Courts in Maine (Fox's Decisions)",
             "variations": {}
@@ -9223,7 +9231,10 @@
             ],
             "mlz_jurisdiction": [],
             "name": "Hoffman's Land Cases",
-            "variations": {}
+            "variations": {
+                "Hoff Land Cas.": "Hoff. Land Cas.",
+                "Hoff. Land. Cas.": "Hoff. Land Cas."
+            }
         }
     ],
     "Holmes": [
@@ -9232,9 +9243,17 @@
             "editions": {
                 "Holmes": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite",
+                        "$volume_nominative ?$reporter, $page"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "Holmes, 272",
+                "1 Holmes, 299"
+            ],
             "mlz_jurisdiction": [],
             "name": "Holmes Circuit Court Reports (US)",
             "variations": {}
@@ -12974,6 +12993,20 @@
                 "us:md;court.appeals"
             ],
             "name": "LexisNexis Maryland Court Appeals",
+            "variations": {}
+        }
+    ],
+    "Md. Law Rec.": [
+        {
+            "cite_type": "state",
+            "editions": {
+                "Md. Law Rec.": {
+                    "end": "1889-12-31T00:00:00",
+                    "start": "1878-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Maryland Law Record",
             "variations": {}
         }
     ],
@@ -18984,6 +19017,22 @@
             }
         }
     ],
+    "Robb, Pat. Cas.": [
+        {
+            "cite_type": "federal",
+            "editions": {
+                "Robb, Pat. Cas.": {
+                    "end": "1850-12-31T00:00:00",
+                    "start": "1789-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [
+                "us;supreme.court"
+            ],
+            "name": "Robb's Patent Cases",
+            "variations": {}
+        }
+    ],
     "Robb.": [
         {
             "cite_type": "state",
@@ -20249,7 +20298,8 @@
             "mlz_jurisdiction": [],
             "name": "Story's United States Circuit Court Reports",
             "variations": {
-                "Story Rep.": "Story"
+                "Story Rep.": "Story",
+                "Story.": "Story"
             }
         }
     ],

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -800,6 +800,7 @@
             "mlz_jurisdiction": [],
             "name": "American Decisions",
             "variations": {
+                "Am Dec.": "Am. Dec.",
                 "Am. D.": "Am. Dec.",
                 "Am. Dec's.": "Am. Dec."
             }
@@ -865,6 +866,10 @@
             "editions": {
                 "Am. Law Reg.": {
                     "end": "1861-12-31T00:00:00",
+                    "regexes": [
+                        "$full_cite",
+                        "$full_cite_year_included"
+                    ],
                     "start": "1853-01-01T00:00:00"
                 },
                 "Am. Law Reg. (N.S.)": {
@@ -872,6 +877,10 @@
                     "start": "1862-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "9 Am. Law Reg. 661",
+                "5 Am. Law Reg. (1857) 280"
+            ],
             "mlz_jurisdiction": [
                 "us:pa;supreme.court"
             ],
@@ -882,6 +891,21 @@
                 "Amer. Law Reg.": "Am. Law Reg.",
                 "Amer. Law Reg. (N. S.)": "Am. Law Reg. (N.S.)"
             }
+        }
+    ],
+    "Am. Law T.": [
+        {
+            "cite_type": "federal",
+            "editions": {
+                "Am. Law T.": {
+                    "end": "1871-12-31T00:00:00",
+                    "start": "1870-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "American Law Times",
+            "notes": "",
+            "variations": {}
         }
     ],
     "Am. Law T. Rep. (N. S.)": [
@@ -896,7 +920,9 @@
             "mlz_jurisdiction": [],
             "name": "American Law Times Reports, New Series",
             "notes": "",
-            "variations": {}
+            "variations": {
+                "Am. Law T. (N. S.)": "Am. Law T. Rep. (N. S.)"
+            }
         }
     ],
     "Am. Law T. Rep. Bankr.": [
@@ -1115,6 +1141,7 @@
             ],
             "name": "American Law Review",
             "variations": {
+                "Am Law Rev.": "Amer. L. Rev.",
                 "Am. Law Rev.": "Amer. L. Rev.",
                 "Amer. Law Rev.": "Amer. L. Rev."
             }
@@ -1136,7 +1163,8 @@
             "name": "American Law Journal",
             "notes": "It was originally called the American Law Journal and Miscellaneous Repertory",
             "variations": {
-                "Am. Law J.": "Amer. Law J."
+                "Am. Law J.": "Amer. Law J.",
+                "Am. Law J. (U. S.)": "Amer. Law J."
             }
         }
     ],
@@ -1210,7 +1238,11 @@
             "mlz_jurisdiction": [],
             "name": "Appeals from the Commissioner of Patents",
             "variations": {
+                "App. Com'r of Pat.": "App. Com'r Pat.",
+                "App. Com'r. Pat.": "App. Com'r Pat.",
                 "App. Com'rs Pat.": "App. Com'r Pat.",
+                "App. Com. Pat.": "App. Com'r Pat.",
+                "App. Comm. Pat.": "App. Com'r Pat.",
                 "App. Comr. Pat.": "App. Com'r Pat."
             }
         }
@@ -2481,6 +2513,26 @@
             }
         }
     ],
+    "Bigelow. Ins. Rep.": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Bigelow. Ins. Rep.": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "1 Bigelow's Insurance Reports, 672",
+                "2 Bigelow. Ins. Rep. 35"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "Bigelow's Insurance Reports",
+            "variations": {
+                "Bigelow's Insurance Reports": "Bigelow. Ins. Rep."
+            }
+        }
+    ],
     "Binn.": [
         {
             "cite_type": "state",
@@ -2909,6 +2961,26 @@
                 "Brown's Adm.": "Brown Adm.",
                 "Brown, Adm.": "Brown Adm.",
                 "Brown. Adm.": "Brown Adm."
+            }
+        }
+    ],
+    "Browne (Pa.)": [
+        {
+            "cite_type": "state",
+            "editions": {
+                "Browne (Pa.)": {
+                    "end": "1814-12-31T00:00:00",
+                    "start": "1801-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "1 Browne (Pa.), 334",
+                "2 Browne (Pa.) 335"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "Browne's Pennsylvania Reports",
+            "variations": {
+                "Browne, (Pa.)": "Browne (Pa.)"
             }
         }
     ],
@@ -5601,6 +5673,20 @@
             "variations": {}
         }
     ],
+    "DTS": [
+        {
+            "cite_type": "state",
+            "editions": {
+                "DTS": {
+                    "end": null,
+                    "start": "1998-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Decisiones del Tribunal Supremo",
+            "variations": {}
+        }
+    ],
     "Daily Journal DAR": [
         {
             "cite_type": "state",
@@ -5850,6 +5936,20 @@
             "variations": {
                 "Day (Conn)": "Day"
             }
+        }
+    ],
+    "Day.": [
+        {
+            "cite_type": "state",
+            "editions": {
+                "Day.": {
+                    "end": "1813-12-31T00:00:00",
+                    "start": "1802-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Day's Reports (Connecticut)",
+            "variations": {}
         }
     ],
     "Deady": [
@@ -6279,7 +6379,9 @@
             },
             "mlz_jurisdiction": [],
             "name": "Dillon's United States (US) Circuit Court Reports",
-            "variations": {}
+            "variations": {
+                "Dill": "Dill."
+            }
         }
     ],
     "Disney (Ohio)": [
@@ -8732,7 +8834,9 @@
             "mlz_jurisdiction": [],
             "name": "Hall's Law Journal",
             "notes": "Also known as American Law Journal, Hall's (Amer. Law J.)",
-            "variations": {}
+            "variations": {
+                "Hall. Law J.": "Hall, Law J."
+            }
         }
     ],
     "Handy": [
@@ -9056,6 +9160,7 @@
             ],
             "name": "District of Columbia Reports, Hayward & Hazelton",
             "variations": {
+                "Hayw. & Haz.": "Hay. & Haz.",
                 "Hayw.& H.": "Hay. & Haz."
             }
         }
@@ -9480,6 +9585,25 @@
             "name": "Hopkins' Chancery Reports",
             "variations": {
                 "Hopk. Ch. Rep.": "Hopk. Ch."
+            }
+        }
+    ],
+    "Hopk. Works.": [
+        {
+            "cite_type": "scotus_early",
+            "editions": {
+                "Hopk. Works.": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "3 Hopk. Works, 70"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "Hopkinson, Life and Letters of Hon. Francis Hopkinson, District Judge",
+            "variations": {
+                "Hopk. Works": "Hopk. Works."
             }
         }
     ],
@@ -10429,7 +10553,9 @@
             },
             "mlz_jurisdiction": [],
             "name": "Indian Claims Commission",
-            "variations": {}
+            "variations": {
+                "Ind. Cl. Com.": "Ind. Cl. Comm."
+            }
         }
     ],
     "Ind. Dec.": [
@@ -10584,7 +10710,9 @@
             "mlz_jurisdiction": [],
             "name": "Insurance Law Journal",
             "variations": {
-                "Ins. Law J.": "Ins. L.J."
+                "Ins Law J.": "Ins. L.J.",
+                "Ins. Law J.": "Ins. L.J.",
+                "Ins. Law. J.": "Ins. L.J."
             }
         }
     ],
@@ -10608,9 +10736,18 @@
             "editions": {
                 "Int. Rev. Rec.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite",
+                        "$full_cite_year_included"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "24 Int. Rev. Rec. 164",
+                "2 Int. Rev. Rec. (1865) 45",
+                "2 Int. Rev. Rec. (1865,) 62"
+            ],
             "mlz_jurisdiction": [],
             "name": "Internal Revenue Record",
             "variations": {
@@ -10753,6 +10890,23 @@
                 "Marsh.(Ky.)": "J.J. Marsh.",
                 "Marsh.J.J.": "J.J. Marsh."
             }
+        }
+    ],
+    "JTS": [
+        {
+            "cite_type": "state",
+            "editions": {
+                "JTS": {
+                    "end": null,
+                    "start": "1899-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "95 JTS 8"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "Jurisprudencia del Tribunal Supremo",
+            "variations": {}
         }
     ],
     "Jeff.": [
@@ -10924,9 +11078,17 @@
             "editions": {
                 "Jour. Fr. Inst.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite",
+                        "$full_cite_year_included"
+                    ],
                     "start": "1826-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "6 Jour. Fr. Inst. 132",
+                "21 Jour. Fr. Inst. (1836) 165"
+            ],
             "mlz_jurisdiction": [
                 "us:ny;supreme.court",
                 "us:c2:ny.ed;district.court"
@@ -11255,6 +11417,7 @@
             "name": "Kentucky Law Reporter",
             "variations": {
                 "Ken.L.Re.": "Ky. L. Rptr.",
+                "Ky. Law Rep.": "Ky. L. Rptr.",
                 "Ky.L.R.": "Ky. L. Rptr.",
                 "Ky.L.Rptr.": "Ky. L. Rptr.",
                 "Ky.Law.Rep.": "Ky. L. Rptr."
@@ -11964,14 +12127,24 @@
             "editions": {
                 "Law Rep.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite",
+                        "$full_cite_year_included"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "5 Law Rep. (1842) 321",
+                "5 Law Rep. 462"
+            ],
             "mlz_jurisdiction": [
                 "us:ma;supreme.court"
             ],
             "name": "Monthly Law Reporter, Boston Mass.",
-            "variations": {}
+            "variations": {
+                "Law, Rep.": "Law Rep."
+            }
         }
     ],
     "Law Reporter": [
@@ -12029,9 +12202,17 @@
             "editions": {
                 "Leg. Int.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite",
+                        "$full_cite_year_included"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "30 Leg. Int. 266",
+                "7 Leg. Int. (1850,) 203"
+            ],
             "mlz_jurisdiction": [
                 "us:pa;supreme.court"
             ],
@@ -12647,6 +12828,7 @@
             ],
             "name": "Louisiana Reports, Martin",
             "variations": {
+                "Mart. (O. S.)": "Mart.",
                 "Mart. (n.s.)": "Mart. (N.S.)",
                 "Mart. (o.s.)": "Mart.",
                 "Mart. Rep.": "Mart.",
@@ -12666,6 +12848,8 @@
             ],
             "name": "North Carolina Reports, Martin",
             "variations": {
+                "Mart. (N. C.)": "Mart.",
+                "Mart. N. C.": "Mart.",
                 "Mart. Rep.": "Mart.",
                 "Mart.Dec.": "Mart.",
                 "Mart.N.C.": "Mart.",
@@ -14407,6 +14591,23 @@
             "variations": {}
         }
     ],
+    "N. Y. City H. Rec.": [
+        {
+            "cite_type": "state",
+            "editions": {
+                "N. Y. City H. Rec.": {
+                    "end": "1822-12-31T00:00:00",
+                    "start": "1816-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "2 N. Y. City H. Rec. 131"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "New York City Hall Recorder",
+            "variations": {}
+        }
+    ],
     "N.B.R. (Supp.)": [
         {
             "cite_type": "specialty",
@@ -14457,6 +14658,7 @@
             ],
             "name": "North Carolina Reports",
             "variations": {
+                "N. C.": "N.C.",
                 "N. C. Rep.": "N.C.",
                 "N.C. (Dev. & Bat.)": "N.C."
             }
@@ -14772,9 +14974,17 @@
             "editions": {
                 "N.J. Law J.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite",
+                        "$full_cite_year_included"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "1 N. J. Law J. 4",
+                "2 N. J. Law J. (1879) 150"
+            ],
             "mlz_jurisdiction": [
                 "us:nj;supreme.court"
             ],
@@ -16215,6 +16425,27 @@
             }
         }
     ],
+    "Niles Reg.": [
+        {
+            "cite_type": "scotus_early",
+            "editions": {
+                "Niles Reg.": {
+                    "end": "1848-12-31T00:00:00",
+                    "start": "1811-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "20 Niles Reg. 346",
+                "2 Niles' Reg. 216"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "Niles' Weekly Register",
+            "variations": {
+                "Niles' Reg.": "Niles Reg.",
+                "Niles, Reg.": "Niles Reg."
+            }
+        }
+    ],
     "Northumb. L.J.": [
         {
             "cite_type": "state_regional",
@@ -16313,9 +16544,17 @@
             "editions": {
                 "O.G.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite",
+                        "$full_cite_year_included"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "3 O. G. (1873,) 688",
+                "15 O. G. 510"
+            ],
             "mlz_jurisdiction": [],
             "name": "Official Gazette, United States Patent Office (Washington, D.C.)",
             "variations": {
@@ -18162,6 +18401,7 @@
                 "Parker's Cr. R.": "Park. Cr.",
                 "Parker's Crim. R.": "Park. Cr.",
                 "Parker's Crim. Rep.": "Park. Cr.",
+                "Parker, Cr. Cas.": "Park. Cr.",
                 "Parker, Cr. R.": "Park. Cr."
             }
         }
@@ -23174,13 +23414,22 @@
             "editions": {
                 "W.L.J.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite",
+                        "$full_cite_year_included"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "3 West. Law J. (1846) 153",
+                "7 West. Law J. 431"
+            ],
             "mlz_jurisdiction": [],
             "name": "Western Law Journal (OH)",
             "variations": {
-                "West. Law J.": "W.L.J."
+                "West. Law J.": "W.L.J.",
+                "West. Law. J.": "W.L.J."
             }
         }
     ],
@@ -23229,7 +23478,8 @@
                 "W.N.C. (Pa.)": "W.N.C.",
                 "Wkly. N.C": "W.N.C.",
                 "Wkly. Notes Cas.": "W.N.C.",
-                "Wkly. Notes Cas. (Pa.)": "W.N.C."
+                "Wkly. Notes Cas. (Pa.)": "W.N.C.",
+                "Wkly. Notes. Cas.": "W.N.C."
             }
         }
     ],

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -15927,9 +15927,15 @@
             "editions": {
                 "Neb.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite"
+                    ],
                     "start": "1860-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "293 Neb. 359"
+            ],
             "mlz_jurisdiction": [
                 "us:ne;supreme.court"
             ],
@@ -15977,9 +15983,15 @@
             "editions": {
                 "Neb. Ct. App.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite"
+                    ],
                     "start": "1922-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "1 Neb. Ct. App. 1"
+            ],
             "mlz_jurisdiction": [
                 "us:ne;supreme.court"
             ],

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -330,9 +330,16 @@
             "editions": {
                 "Abb. Adm.": {
                     "end": null,
+                    "regexes": [
+                        "$volume_nominative ?$reporter $page"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "1 Abb. Adm. 317",
+                "Abb. Adm. 418"
+            ],
             "mlz_jurisdiction": [],
             "name": "Abbott's Admiralty Reports",
             "variations": {}
@@ -844,9 +851,25 @@
             "name": "American Law Register",
             "variations": {
                 "Am. L. Reg., n.s.": "Am. Law Reg. (N.S.)",
+                "Am. Law Reg. (N. S.)": "Am. Law Reg. (N.S.)",
                 "Amer. Law Reg.": "Am. Law Reg.",
                 "Amer. Law Reg. (N. S.)": "Am. Law Reg. (N.S.)"
             }
+        }
+    ],
+    "Am. Law T. Rep. (N. S.)": [
+        {
+            "cite_type": "federal",
+            "editions": {
+                "Am. Law T. Rep. (N. S.)": {
+                    "end": "1877-12-31T00:00:00",
+                    "start": "1874-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "American Law Times Reports, New Series",
+            "notes": "",
+            "variations": {}
         }
     ],
     "Am. Law T. Rep. Bankr.": [
@@ -876,7 +899,10 @@
             },
             "mlz_jurisdiction": [],
             "name": "American Law Times Reports, United States (US) Courts",
-            "variations": {}
+            "variations": {
+                "Am. Law T. Rep. (U. S. Cts.)": "Am. Law T. Rep. U.S. Cts.",
+                "Am. Law T. Rep. U. S. Cts.": "Am. Law T. Rep. U.S. Cts."
+            }
         }
     ],
     "Am. Law. Rec.": [
@@ -1064,6 +1090,26 @@
             "variations": {
                 "Am. Law Rev.": "Amer. L. Rev.",
                 "Amer. Law Rev.": "Amer. L. Rev."
+            }
+        }
+    ],
+    "Amer. Law J. (N. S.)": [
+        {
+            "cite_type": "federal",
+            "editions": {
+                "Amer. Law J. (N. S.)": {
+                    "end": "1852-12-31T00:00:00",
+                    "start": "1848-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "2 Am. Law J. (N. S.) 179"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "American Law Journal, New Series",
+            "notes": "Continuation of Pennsylvania Law Journal",
+            "variations": {
+                "Am. Law J. (N. S.)": "Amer. Law J. (N. S.)"
             }
         }
     ],
@@ -2327,6 +2373,30 @@
             }
         }
     ],
+    "Betts' Scr. Bk.": [
+        {
+            "cite_type": "state",
+            "editions": {
+                "Betts' Scr. Bk.": {
+                    "end": "1862-12-31T00:00:00",
+                    "regexes": [
+                        "$volume_nominative ?$reporter,? $page"
+                    ],
+                    "start": "1839-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "Betts' Scr. Bk. 139",
+                "Betts, Scr. Bk. 268"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "Betts' Scrap Book.",
+            "notes": "Cases in the United States Circuit and District Courts for the Southern District of New York from 1839 to 1862, with a few cases from other districts. Collected by Hon. Samuel R. Betts, District Judge. On file in the office of the clerk of the District Court for the Southern District of New York.",
+            "variations": {
+                "Betts, Scr. Bk.": "Betts' Scr. Bk."
+            }
+        }
+    ],
     "Bibb": [
         {
             "cite_type": "state",
@@ -2755,9 +2825,15 @@
             "editions": {
                 "Brown Adm.": {
                     "end": null,
+                    "regexes": [
+                        "$volume_nominative ?$reporter $page"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "Brown, Adm. 124"
+            ],
             "mlz_jurisdiction": [],
             "name": "Brown's Admiralty (U.S.)",
             "variations": {
@@ -5092,6 +5168,7 @@
             "name": "Court of Claims Reports (United States)",
             "variations": {
                 "C. Cls.": "Ct. Cl.",
+                "C. Cls. R.": "Ct. Cl.",
                 "Court Cl.": "Ct. Cl.",
                 "Ct. Cl. R.": "Ct. Cl.",
                 "Ct. Cl. Rep.": "Ct. Cl.",
@@ -9041,9 +9118,16 @@
             "editions": {
                 "Hempst.": {
                     "end": null,
+                    "regexes": [
+                        "$volume_nominative ?$reporter $page"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "1 Ark. Terr. Rep. 332",
+                "Hempst. 286"
+            ],
             "mlz_jurisdiction": [
                 "us:ar;supreme.court"
             ],
@@ -9051,7 +9135,8 @@
             "notes": "Territory of Arkansas reporter without a volume",
             "variations": {
                 "Ark. Terr. Rep.": "Hempst.",
-                "Hemp.": "Hempst."
+                "Hemp.": "Hempst.",
+                "Hempst": "Hempst."
             }
         }
     ],
@@ -21835,6 +21920,7 @@
             "notes": "",
             "variations": {
                 "U. S.": "U.S.",
+                "U. S. R.": "U.S.",
                 "U. S. Rep.": "U.S.",
                 "U.S.S.C.Rep.": "U.S.",
                 "US": "U.S.",
@@ -23231,14 +23317,16 @@
                     "end": "1874-12-31T00:00:00",
                     "regexes": [
                         "$full_cite",
-                        "$reporter,? p. $page"
+                        "$reporter,? p. $page",
+                        "$volume $reporter,? p. $page"
                     ],
                     "start": "1863-01-01T00:00:00"
                 }
             },
             "examples": [
                 "487 Wall. 141",
-                "Wallace R., p. 573"
+                "Wallace R., p. 573",
+                "8 Wallace R., p. 269"
             ],
             "mlz_jurisdiction": [
                 "us;supreme.court"

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -833,6 +833,32 @@
             "variations": {}
         }
     ],
+    "Am. Jur.": [
+        {
+            "cite_type": "federal",
+            "editions": {
+                "Am. Jur.": {
+                    "end": "1843-12-31T00:00:00",
+                    "regexes": [
+                        "$full_cite",
+                        "$volume $reporter,? p. $page"
+                    ],
+                    "start": "1829-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "1 Amer. Jur. 441",
+                "40 Amer. Jur., p. 764",
+                "19 Am. Jur. 219"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "American Jurist and Law Magazine",
+            "notes": "",
+            "variations": {
+                "Amer. Jur.": "Am. Jur."
+            }
+        }
+    ],
     "Am. Law Reg.": [
         {
             "cite_type": "state",
@@ -1091,6 +1117,26 @@
             "variations": {
                 "Am. Law Rev.": "Amer. L. Rev.",
                 "Amer. Law Rev.": "Amer. L. Rev."
+            }
+        }
+    ],
+    "Amer. Law J.": [
+        {
+            "cite_type": "federal",
+            "editions": {
+                "Amer. Law J.": {
+                    "end": "1817-12-31T00:00:00",
+                    "start": "1808-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "2 Amer. Law J. 97"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "American Law Journal",
+            "notes": "It was originally called the American Law Journal and Miscellaneous Repertory",
+            "variations": {
+                "Am. Law J.": "Amer. Law J."
             }
         }
     ],
@@ -2298,7 +2344,7 @@
                 "Bee": {
                     "end": null,
                     "regexes": [
-                        "$reporter $page"
+                        "$reporter,? $page"
                     ],
                     "start": "1750-01-01T00:00:00"
                 }
@@ -2311,7 +2357,7 @@
             ],
             "name": "Bee's United States (US) District Court Reports",
             "variations": {
-                "Bee,": "Bee"
+                "Bee.": "Bee"
             }
         }
     ],
@@ -5098,7 +5144,7 @@
                 "Crabbe": {
                     "end": null,
                     "regexes": [
-                        "$reporter, $page"
+                        "$reporter,? $page"
                     ],
                     "start": "1750-01-01T00:00:00"
                 }
@@ -5110,7 +5156,9 @@
             ],
             "mlz_jurisdiction": [],
             "name": "Crabbe's United States (US) District Court Reports",
-            "variations": {}
+            "variations": {
+                "Crabbe.": "Crabbe"
+            }
         }
     ],
     "Cranch": [
@@ -9544,9 +9592,17 @@
             "editions": {
                 "How. Pr.": {
                     "end": "1886-12-31T00:00:00",
+                    "regexes": [
+                        "$full_cite",
+                        "$full_cite_year_included"
+                    ],
                     "start": "1844-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "7 How. Pr. Rep., 305",
+                "18 How. Prac. (1860) 482"
+            ],
             "mlz_jurisdiction": [
                 "us:ny;court.appeals"
             ],
@@ -10557,7 +10613,9 @@
             },
             "mlz_jurisdiction": [],
             "name": "Internal Revenue Record",
-            "variations": {}
+            "variations": {
+                "Int Rev. Rec.": "Int. Rev. Rec."
+            }
         }
     ],
     "Interior Dec.": [
@@ -13036,9 +13094,18 @@
             "editions": {
                 "McCrary's Cir. Ct. Rpts": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite",
+                        "$full_cite_year_included"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "4 McCrary's Cir. Ct. Rpts 567",
+                "1 McCrary, 480",
+                "1 McCrary (1881) 213"
+            ],
             "mlz_jurisdiction": [],
             "name": "McCrary's Circuit Court Reports",
             "variations": {
@@ -15361,6 +15428,7 @@
             ],
             "name": "New York Legal Observer (N.Y.)",
             "variations": {
+                "N. Y. Leg. Ob.": "N.Y. Leg. Obs.",
                 "N. Y. Leg. Obs.": "N.Y. Leg. Obs.",
                 "N.Y. Legal Observer": "N.Y. Leg. Obs."
             }
@@ -15473,7 +15541,9 @@
                 "us:ny;supreme.court"
             ],
             "name": "New York Law Journal",
-            "variations": {}
+            "variations": {
+                "N. Y. Law J.": "N.Y.L.J."
+            }
         }
     ],
     "N.Y.S.": [
@@ -18229,9 +18299,19 @@
             "editions": {
                 "Penn. Law J.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite",
+                        "$full_cite_year_included"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "1 Pa. Law J. 291",
+                "1 Pa. Law J. Rep. 82",
+                "2 Penn. L. J. 299",
+                "1 Pa. Law J. (1842) 225"
+            ],
             "mlz_jurisdiction": [
                 "us:pa;supreme.court",
                 "us:c3:pa.ed;district.court"
@@ -18240,6 +18320,7 @@
             "variations": {
                 "Pa. Law J.": "Penn. Law J.",
                 "Pa. Law J. Rep.": "Penn. Law J.",
+                "Penn. L. J.": "Penn. Law J.",
                 "Penn. L.J.": "Penn. Law J.",
                 "Penn. Law Jour.": "Penn. Law J."
             }
@@ -18616,6 +18697,7 @@
                 "Pittsb. L. Rev.": "Pitts L.J.",
                 "Pittsb. L.J.": "Pitts L.J.",
                 "Pittsb. Leg. J.": "Pitts L.J.",
+                "Pittsb. Leg. J. (O. S.)": "Pitts L.J.",
                 "Pittsb. Leg. J. (Pa.)": "Pitts L.J.",
                 "Pittsb. R. (Pa.)": "Pitts L.J.",
                 "Pittsburgh Leg. J.": "Pitts L.J.",
@@ -18753,9 +18835,17 @@
             "editions": {
                 "Quart. Law J.": {
                     "end": "1859-12-31T00:00:00",
+                    "regexes": [
+                        "$full_cite",
+                        "$full_cite_year_included"
+                    ],
                     "start": "1856-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "3 Quart. Law J. 42",
+                "1 Quart. Law J. (1856,) 153"
+            ],
             "mlz_jurisdiction": [],
             "name": "Quarterly Law Journal",
             "variations": {}
@@ -19899,7 +19989,9 @@
             },
             "mlz_jurisdiction": [],
             "name": "San Francisco Law Journal",
-            "variations": {}
+            "variations": {
+                "San Fran. Law. J.": "San Fran. Law J."
+            }
         }
     ],
     "Sand. Ch.": [
@@ -22234,9 +22326,17 @@
             "editions": {
                 "U.S. Law Int.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite",
+                        "$full_cite_year_included"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "1 U. S. Law Int. 69",
+                "1 U. S. Law Int. (1829) 22"
+            ],
             "mlz_jurisdiction": [],
             "name": "United States Law Intelligencer and Review (Providence and Philadelphia)",
             "variations": {
@@ -23457,6 +23557,7 @@
             "name": "Wallace, Jr.'s Reports of Cases Determined in the Circuit Court of the United States for the Third Circuit",
             "variations": {
                 "Wall. Jr. C.C.": "Wall. Jr.",
+                "Wall., Jr.": "Wall. Jr.",
                 "Wallace, Jr., Rept.": "Wall. Jr."
             }
         }

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -1117,6 +1117,7 @@
             "mlz_jurisdiction": [],
             "name": "Appeals from the Commissioner of Patents",
             "variations": {
+                "App. Com'rs Pat.": "App. Com'r Pat.",
                 "App. Comr. Pat.": "App. Com'r Pat."
             }
         }
@@ -2315,10 +2316,13 @@
                 "Betts D. C. MS.": "Betts' Dec.",
                 "Betts' C. C. MS.": "Betts' Dec.",
                 "Betts' D. C. MS.": "Betts' Dec.",
+                "Betts' D. C. MSS.": "Betts' Dec.",
                 "Betts, C. C. MS.": "Betts' Dec.",
                 "Betts, D. C.": "Betts' Dec.",
                 "Betts, D. C. MS.": "Betts' Dec.",
+                "Betts, D. C. MSS.": "Betts' Dec.",
                 "Betts, D. C. Ms.": "Betts' Dec.",
+                "Betts. D. C. MS.": "Betts' Dec.",
                 "Betts. D. C. MSS.": "Betts' Dec."
             }
         }
@@ -2580,7 +2584,9 @@
             },
             "mlz_jurisdiction": [],
             "name": "Bond's United States (US) Circuit Reports",
-            "variations": {}
+            "variations": {
+                "Bond.": "Bond"
+            }
         }
     ],
     "Bosw.": [
@@ -8902,6 +8908,8 @@
             "variations": {
                 "Hay.": "Hayw.",
                 "Hay. Rep.": "Hayw.",
+                "Hayw. (N. C.)": "Hayw.",
+                "Hayw. N. C.": "Hayw.",
                 "Hayw. Rep.": "Hayw.",
                 "Hayw.N.C.": "Hayw.",
                 "N.C.(Hayw.)": "Hayw."
@@ -10216,6 +10224,20 @@
             "variations": {}
         }
     ],
+    "Ind. Cl. Comm.": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Ind. Cl. Comm.": {
+                    "end": "1973-12-31T00:00:00",
+                    "start": "1948-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Indian Claims Commission",
+            "variations": {}
+        }
+    ],
     "Ind. Dec.": [
         {
             "cite_type": "state",
@@ -11377,6 +11399,20 @@
             "variations": {}
         }
     ],
+    "La. Law J.": [
+        {
+            "cite_type": "state",
+            "editions": {
+                "La. Law J.": {
+                    "end": "1842-12-31T00:00:00",
+                    "start": "1841-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Louisiana Law Journal",
+            "variations": {}
+        }
+    ],
     "La.App. 1 Cir.": [
         {
             "cite_type": "state",
@@ -11675,6 +11711,21 @@
             }
         }
     ],
+    "Law & Eq. Rep.": [
+        {
+            "cite_type": "federal",
+            "editions": {
+                "Law & Eq. Rep.": {
+                    "end": "1878-12-31T00:00:00",
+                    "start": "1876-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Law and Equity Reporter",
+            "notes": "Continued in Reporter.",
+            "variations": {}
+        }
+    ],
     "Law J. Q.B.": [
         {
             "cite_type": "specialty",
@@ -11706,6 +11757,21 @@
                 "us:ma;supreme.court"
             ],
             "name": "Monthly Law Reporter, Boston Mass.",
+            "variations": {}
+        }
+    ],
+    "Law Reporter": [
+        {
+            "cite_type": "state",
+            "editions": {
+                "Law Reporter": {
+                    "end": "1848-12-31T00:00:00",
+                    "start": "1839-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "The Law Reporter",
+            "notes": "Sometimes cited as Monthly Law Reporter. Vol. 11 and subsequent volumes are the same as Vol 1, etc., New Series.",
             "variations": {}
         }
     ],
@@ -13331,6 +13397,21 @@
             "variations": {}
         }
     ],
+    "Mich. Lawy.": [
+        {
+            "cite_type": "state",
+            "editions": {
+                "Mich. Lawy.": {
+                    "end": "1879-12-31T00:00:00",
+                    "start": "1875-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Michigan Lawyer",
+            "notes": "",
+            "variations": {}
+        }
+    ],
     "Mich. N.P.": [
         {
             "cite_type": "state",
@@ -13886,6 +13967,20 @@
             },
             "mlz_jurisdiction": [],
             "name": "Monthly Jurist",
+            "variations": {}
+        }
+    ],
+    "Month. West. Jur.": [
+        {
+            "cite_type": "state",
+            "editions": {
+                "Month. West. Jur.": {
+                    "end": "1877-12-31T00:00:00",
+                    "start": "1875-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Monthly Western Jurist",
             "variations": {}
         }
     ],
@@ -17799,7 +17894,9 @@
             },
             "mlz_jurisdiction": [],
             "name": "Paine's United States (US) Circuit Court Reports",
-            "variations": {}
+            "variations": {
+                "Paine.": "Paine"
+            }
         }
     ],
     "Park. Cr.": [
@@ -18480,6 +18577,20 @@
             "variations": {}
         }
     ],
+    "Quart. Law J.": [
+        {
+            "cite_type": "state",
+            "editions": {
+                "Quart. Law J.": {
+                    "end": "1859-12-31T00:00:00",
+                    "start": "1856-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Quarterly Law Journal",
+            "variations": {}
+        }
+    ],
     "R.I.": [
         {
             "cite_type": "state",
@@ -18754,7 +18865,9 @@
             },
             "mlz_jurisdiction": [],
             "name": "Reporter. (Continuation of Law and Equity Reporter and of American Law Times Reports, New Series.)",
-            "variations": {}
+            "variations": {
+                "Reporter.": "Reporter,"
+            }
         }
     ],
     "Rice": [
@@ -19475,7 +19588,6 @@
             "name": "South Western Reporter",
             "variations": {
                 "S. W.": "S.W.",
-                "S.W. Series": "S.W.",
                 "S. W. (2d)": "S.W.2d",
                 "S. W. 2d": "S.W.2d",
                 "S. W. 2d Series.": "S.W.2d",
@@ -19489,6 +19601,7 @@
                 "S.W. 2d": "S.W.2d",
                 "S.W. 3d": "S.W.3d",
                 "S.W. Rep.": "S.W.",
+                "S.W. Series": "S.W.",
                 "SW": "S.W.",
                 "SW 2d": "S.W.2d",
                 "SW 3d": "S.W.3d",
@@ -19603,6 +19716,20 @@
                 "Sadl.": "Sadler",
                 "Sadler(Pa.)": "Sadler"
             }
+        }
+    ],
+    "San Fran. Law J.": [
+        {
+            "cite_type": "state",
+            "editions": {
+                "San Fran. Law J.": {
+                    "end": "1878-12-31T00:00:00",
+                    "start": "1877-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "San Francisco Law Journal",
+            "variations": {}
         }
     ],
     "Sand. Ch.": [
@@ -21620,6 +21747,20 @@
             "variations": {
                 "Mass.(Tyng)": "Tyng"
             }
+        }
+    ],
+    "U. S. Law J.": [
+        {
+            "cite_type": "federal",
+            "editions": {
+                "U. S. Law J.": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "United States Law Journal and Civilians' Magazine",
+            "variations": {}
         }
     ],
     "U.C.C. Rep. Serv. (West)": [

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -905,7 +905,9 @@
             "mlz_jurisdiction": [],
             "name": "American Law Times",
             "notes": "",
-            "variations": {}
+            "variations": {
+                "Am. Law T. Rep.": "Am. Law T."
+            }
         }
     ],
     "Am. Law T. Rep. (N. S.)": [
@@ -2459,11 +2461,13 @@
                 "Betts' D. C. MS.": "Betts' Dec.",
                 "Betts' D. C. MSS.": "Betts' Dec.",
                 "Betts, C. C. MS.": "Betts' Dec.",
+                "Betts, D C. MS.": "Betts' Dec.",
                 "Betts, D. C.": "Betts' Dec.",
                 "Betts, D. C. MS.": "Betts' Dec.",
                 "Betts, D. C. MSS.": "Betts' Dec.",
                 "Betts, D. C. Ms.": "Betts' Dec.",
                 "Betts. C. C. MS.": "Betts' Dec.",
+                "Betts. D C. MS.": "Betts' Dec.",
                 "Betts. D. C. MS.": "Betts' Dec.",
                 "Betts. D. C. MSS.": "Betts' Dec."
             }
@@ -2990,14 +2994,23 @@
             "editions": {
                 "Brunn. Coll. Cas.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite",
+                        "$volume_nominative ?$reporter $page"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "Brunner, Col. Cas. 190",
+                "1 Brunn. Coll. Cas. 577"
+            ],
             "mlz_jurisdiction": [],
             "name": "Brunner's Collected Cases (US)",
             "variations": {
                 "Brun. Col. Cas.": "Brunn. Coll. Cas.",
-                "Brunner, Col. Cas.": "Brunn. Coll. Cas."
+                "Brunner, Col. Cas.": "Brunn. Coll. Cas.",
+                "Brunner. Col. Cas.": "Brunn. Coll. Cas."
             }
         }
     ],
@@ -3039,6 +3052,23 @@
                 "Bur. Rep.": "Bur.",
                 "Burnett": "Bur.",
                 "Burnett (Wis.)": "Bur."
+            }
+        }
+    ],
+    "Burr's Trial": [
+        {
+            "cite_type": "state",
+            "editions": {
+                "Burr's Trial": {
+                    "end": null,
+                    "start": "1864-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "The Trial of Col. Aaron Burr on an Indictment for Treason",
+            "notes": "The Trial of Col. Aaron Burr On an Indictment for Treason: Before the Circuit Court of the United States, Held in Richmond, (Virginia), May Term, 1807 / by T. Carpenter.",
+            "variations": {
+                "Burr’s Trial": "Burr's Trial"
             }
         }
     ],
@@ -3792,6 +3822,26 @@
             "variations": {}
         }
     ],
+    "Cal. Law J. & Lit. Rev.": [
+        {
+            "cite_type": "state",
+            "editions": {
+                "Cal. Law J. & Lit. Rev.": {
+                    "end": "1863-12-31T00:00:00",
+                    "regexes": [
+                        "$volume_nominative ?$reporter,? $page"
+                    ],
+                    "start": "1862-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "Cal. Law J. & Lit. Rev. 137"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "California Law Journal and Literary Review",
+            "variations": {}
+        }
+    ],
     "Cal. Rptr.": [
         {
             "cite_type": "state",
@@ -3993,6 +4043,25 @@
             }
         }
     ],
+    "Carpenter's Report of Burr's Trial": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Carpenter's Report of Burr's Trial": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "3 Carpenter's Report of Burr's Trial, 93"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "Carpenter's Report of Burr's Trial",
+            "variations": {
+                "Carpenter’s Report of Burr’s Trial": "Carpenter's Report of Burr's Trial"
+            }
+        }
+    ],
     "Cates.": [
         {
             "cite_type": "state",
@@ -4093,6 +4162,25 @@
             "variations": {
                 "Chase,": "Chase",
                 "Chase.": "Chase"
+            }
+        }
+    ],
+    "Chase's Trial. Append.": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Chase's Trial. Append.": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "Chase's Trial. Append. 65"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "Chase's Trial. Append",
+            "variations": {
+                "Chase’s Trial. Append.": "Chase's Trial. Append."
             }
         }
     ],
@@ -4207,7 +4295,8 @@
             ],
             "name": "Chicago Legal News (1868-1925) (Illinois)",
             "variations": {
-                "Chi Leg. News": "Chi. Leg. News"
+                "Chi Leg. News": "Chi. Leg. News",
+                "Chi. Leg. News.": "Chi. Leg. News"
             }
         }
     ],
@@ -5100,16 +5189,49 @@
             "editions": {
                 "Cooke": {
                     "end": "1814-12-31T00:00:00",
+                    "regexes": [
+                        "$full_cite",
+                        "$volume_nominative ?$reporter,? $page"
+                    ],
                     "start": "1811-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "Cooke, 130",
+                "Cooke (Tenn.), 298",
+                "3 Tenn.(Cooke), 464"
+            ],
             "mlz_jurisdiction": [
                 "us:tn;supreme.court"
             ],
             "name": "Tennessee Reports, Cooke",
             "variations": {
                 "Cooke (Tenn.)": "Cooke",
+                "Tenn. (Cooke)": "Cooke",
                 "Tenn.(Cooke)": "Cooke"
+            }
+        }
+    ],
+    "Coombs' Trial of Aaron Burr": [
+        {
+            "cite_type": "state",
+            "editions": {
+                "Coombs' Trial of Aaron Burr": {
+                    "end": null,
+                    "regexes": [
+                        "$volume_nominative ?$reporter,? $page"
+                    ],
+                    "start": "1864-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "Coombs’ Trial of Aaron Burr. 1"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "The trial of Aaron Burr for high treason",
+            "notes": "The trial of Aaron Burr for high treason : in the Circuit Court of the United States for the district of Virginia, summer term, 1807 : comprising all the evidence and the opinions of the court upon all motions made in the various stages of the case, with abstracts of arguments of counsel : compiled from authentic reports made during the progress of the trial : to which is added an account of the subsequent proceedings against Burr, Blennerhassett, and Smith, in the same court : with notes by the compiler on the law of treason, as applicable to the existing rebellion : prefaced by a brief historical sketch of Burr's Western expedition in 1806 / by J.J. Coombs.",
+            "variations": {
+                "Coombs’ Trial of Aaron Burr.": "Coombs' Trial of Aaron Burr"
             }
         }
     ],
@@ -5902,6 +6024,21 @@
                 "Dana Rep.": "Dana",
                 "Ky.(Dana)": "Dana"
             }
+        }
+    ],
+    "Dane, Abr.": [
+        {
+            "cite_type": "scotus_early",
+            "editions": {
+                "Dane, Abr.": {
+                    "end": null,
+                    "start": "1823-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Dane's Abridgement and Digest of American Law",
+            "notes": "",
+            "variations": {}
         }
     ],
     "Davis. L. Ct. Cas.": [
@@ -8011,9 +8148,15 @@
             "editions": {
                 "Fish. Prize Cas.": {
                     "end": null,
+                    "regexes": [
+                        "$reporter $page"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "Fish. Pr. Cas. 32"
+            ],
             "mlz_jurisdiction": [],
             "name": "Fisher's United States Prize Cases",
             "variations": {
@@ -9160,6 +9303,7 @@
             ],
             "name": "District of Columbia Reports, Hayward & Hazelton",
             "variations": {
+                "Havw. & H.": "Hay. & Haz.",
                 "Hayw. & Haz.": "Hay. & Haz.",
                 "Hayw.& H.": "Hay. & Haz."
             }
@@ -9214,9 +9358,16 @@
             "editions": {
                 "Hayw. & H.D.C.": {
                     "end": "1941-12-31T00:00:00",
+                    "regexes": [
+                        "$full_cite",
+                        "$volume_nominative ?$reporter $page"
+                    ],
                     "start": "1893-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "1 Hay. & Haz. 176"
+            ],
             "mlz_jurisdiction": [
                 "us:dc;circuit.court"
             ],
@@ -9546,6 +9697,27 @@
                 "Hoff Land Cas.": "Hoff. Land Cas.",
                 "Hoff. Land. Cas.": "Hoff. Land Cas."
             }
+        }
+    ],
+    "Hoff. Op.": [
+        {
+            "cite_type": "scotus_early",
+            "editions": {
+                "Hoff. Op.": {
+                    "end": null,
+                    "regexes": [
+                        "$volume_nominative ?$reporter,? $page"
+                    ],
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "Hoff. Op. 433"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "Hoffman's Opinions",
+            "notes": "An unpublished collection of manuscript and pamphlet decisions by Hon. Ogden Hoffman, District Judge.",
+            "variations": {}
         }
     ],
     "Holmes": [
@@ -10751,7 +10923,8 @@
             "mlz_jurisdiction": [],
             "name": "Internal Revenue Record",
             "variations": {
-                "Int Rev. Rec.": "Int. Rev. Rec."
+                "Int Rev. Rec.": "Int. Rev. Rec.",
+                "Int. Rev. Rec,": "Int. Rev. Rec."
             }
         }
     ],
@@ -12143,7 +12316,8 @@
             ],
             "name": "Monthly Law Reporter, Boston Mass.",
             "variations": {
-                "Law, Rep.": "Law Rep."
+                "Law, Rep.": "Law Rep.",
+                "Law. Rep.": "Law Rep."
             }
         }
     ],
@@ -12416,6 +12590,20 @@
                 "Ky.(Lit.Sel.Cas.)": "Litt. Sel. Cas.",
                 "Lit.Sel.Ca.": "Litt. Sel. Cas."
             }
+        }
+    ],
+    "Liv. Law Mag.": [
+        {
+            "cite_type": "state",
+            "editions": {
+                "Liv. Law Mag.": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "mlz_jurisdiction": [],
+            "name": "Livingston's Law Magazine",
+            "variations": {}
         }
     ],
     "Lock. Rev. Cas.": [
@@ -16441,6 +16629,7 @@
             "mlz_jurisdiction": [],
             "name": "Niles' Weekly Register",
             "variations": {
+                "Nile, Reg.": "Niles Reg.",
                 "Niles' Reg.": "Niles Reg.",
                 "Niles, Reg.": "Niles Reg."
             }
@@ -19695,6 +19884,25 @@
                 "Robb. (N.J.)": "Robb.",
                 "Robbins": "Robb.",
                 "Robbins.": "Robb."
+            }
+        }
+    ],
+    "Robertson's Report of the Trial of Aaron Burr.": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Robertson's Report of the Trial of Aaron Burr.": {
+                    "end": null,
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "2 Robertson's Report of the Trial of Aaron Burr. 481"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "Robertson's Report of the Trial of Aaron Burr",
+            "variations": {
+                "Robertson’s Report of the Trial of Aaron Burr.": "Robertson's Report of the Trial of Aaron Burr."
             }
         }
     ],
@@ -23812,6 +24020,26 @@
             }
         }
     ],
+    "Wall. Jr. Append.": [
+        {
+            "cite_type": "specialty",
+            "editions": {
+                "Wall. Jr. Append.": {
+                    "end": null,
+                    "regexes": [
+                        "$volume $reporter $page_with_roman_numerals"
+                    ],
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "1 Wall. Jr. Append. ix"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "Wall. Jr. Append.",
+            "variations": {}
+        }
+    ],
     "Ware": [
         {
             "cite_type": "federal",
@@ -24292,7 +24520,8 @@
             "name": "Wheeler's Criminal Cases",
             "variations": {
                 "Wheeler, Cr. Cas.": "Wheel. Cr. Cas.",
-                "Wheeler, Crim. Cas.": "Wheel. Cr. Cas."
+                "Wheeler, Crim. Cas.": "Wheel. Cr. Cas.",
+                "Wheeler. Cr. Cas.": "Wheel. Cr. Cas."
             }
         }
     ],

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -4153,6 +4153,29 @@
             "variations": {}
         }
     ],
+    "Codd. Dig.": [
+        {
+            "cite_type": "scotus_early",
+            "editions": {
+                "Codd. Dig.": {
+                    "end": null,
+                    "regexes": [
+                        "$reporter $page"
+                    ],
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "Codd. Dig. 341",
+                "Coddington's Digest 312"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "Coddington's Digest of the Law of Trade-Marks",
+            "variations": {
+                "Coddington's Digest": "Codd. Dig."
+            }
+        }
+    ],
     "Code Rep.": [
         {
             "cite_type": "federal",
@@ -4928,6 +4951,26 @@
             }
         }
     ],
+    "Cox. Manual Trade-Mark Cas.": [
+        {
+            "cite_type": "scotus_early",
+            "editions": {
+                "Cox. Manual Trade-Mark Cas.": {
+                    "end": null,
+                    "regexes": [
+                        "$reporter $page"
+                    ],
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "Cox. Manual Trade-Mark Cas. 241"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "Cox's Manual of Trade-Mark Cases",
+            "variations": {}
+        }
+    ],
     "Crabbe": [
         {
             "cite_type": "federal",
@@ -5634,7 +5677,8 @@
             "mlz_jurisdiction": [],
             "name": "Deady's Circuit & District Court Reports",
             "variations": {
-                "Deady,": "Deady"
+                "Deady,": "Deady",
+                "Deady.": "Deady"
             }
         }
     ],
@@ -8910,7 +8954,9 @@
             ],
             "mlz_jurisdiction": [],
             "name": "Hazard's United States Register",
-            "variations": {}
+            "variations": {
+                "Haz. Reg. U. S.": "Haz. U. S. Reg."
+            }
         }
     ],
     "Head": [
@@ -16783,8 +16829,29 @@
             "mlz_jurisdiction": [],
             "name": "Olcott's Admiralty Reports",
             "variations": {
-                "Olc.": "Olcott"
+                "Olc.": "Olcott",
+                "Olcott,": "Olcott"
             }
+        }
+    ],
+    "Oliver's Forms": [
+        {
+            "cite_type": "scotus_early",
+            "editions": {
+                "Oliver's Forms": {
+                    "end": "1843-12-31T00:00:00",
+                    "regexes": [
+                        "$reporter \\(Ed. \\d{4}\\,?\\) $page"
+                    ],
+                    "start": "1788-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "Oliver's Forms (Ed. 1842) 489"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "Oliver's Forms in Chancery, Admiralty, and at Common Law",
+            "variations": {}
         }
     ],
     "Op. Att'y Gen.": [
@@ -20309,6 +20376,26 @@
             }
         }
     ],
+    "Syllabi": [
+        {
+            "cite_type": "state",
+            "editions": {
+                "Syllabi": {
+                    "end": "1879-12-31T00:00:00",
+                    "regexes": [
+                        "$volume_nominative ?$reporter, $page"
+                    ],
+                    "start": "1876-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "Syllabi, 182"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "Syllabi",
+            "variations": {}
+        }
+    ],
     "T.B. Mon.": [
         {
             "cite_type": "state",
@@ -20556,7 +20643,7 @@
                 "Taney": {
                     "end": "1861-12-31T00:00:00",
                     "regexes": [
-                        "$volume_nominative ?$reporter, $page"
+                        "$volume_nominative ?$reporter,? $page"
                     ],
                     "start": "1836-01-01T00:00:00"
                 }
@@ -20568,7 +20655,9 @@
             ],
             "mlz_jurisdiction": [],
             "name": "Taney's United States (US) Circuit Court Reports",
-            "variations": {}
+            "variations": {
+                "Taney.": "Taney"
+            }
         }
     ],
     "Tapp. Rep.": [
@@ -23282,13 +23371,15 @@
                     "end": "1830-12-31T00:00:00",
                     "regexes": [
                         "$full_cite",
-                        "$volume_nominative ?$reporter, $page"
+                        "$volume_nominative ?$reporter, $page",
+                        "$volume_nominative ?$reporter, $page_with_letter"
                     ],
                     "start": "1792-01-01T00:00:00"
                 }
             },
             "examples": [
                 "Wells’ Notebook, 365",
+                "Wells’ Notebook, 356a",
                 "1 Wells’ Notebook, 365"
             ],
             "mlz_jurisdiction": [
@@ -23375,6 +23466,46 @@
                 "Whart.Pa.": "Whart.",
                 "Wharton": "Whart."
             }
+        }
+    ],
+    "Whart. Hom.": [
+        {
+            "cite_type": "state",
+            "editions": {
+                "Whart. Hom.": {
+                    "end": null,
+                    "regexes": [
+                        "$reporter $page"
+                    ],
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "Whart. Hom. 483"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "Wharton, Treatise on the Law of Homicide in the United States",
+            "variations": {}
+        }
+    ],
+    "Whart. St. Tr.": [
+        {
+            "cite_type": "state",
+            "editions": {
+                "Whart. St. Tr.": {
+                    "end": null,
+                    "regexes": [
+                        "$reporter $page"
+                    ],
+                    "start": "1750-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "Whart. St. Tr. 688"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "Wharton's State Trials",
+            "variations": {}
         }
     ],
     "Wheat.": [
@@ -23712,9 +23843,17 @@
             "editions": {
                 "Woolw.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite",
+                        "$volume_nominative ?$reporter $page"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "Woolw. 217",
+                "9 Woolw. Rep., 6"
+            ],
             "mlz_jurisdiction": [],
             "name": "Woolworth's United States Circuit Court Reports",
             "variations": {

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -1062,6 +1062,7 @@
             ],
             "name": "American Law Review",
             "variations": {
+                "Am. Law Rev.": "Amer. L. Rev.",
                 "Amer. Law Rev.": "Amer. L. Rev."
             }
         }
@@ -2234,14 +2235,22 @@
             "editions": {
                 "Bee": {
                     "end": null,
+                    "regexes": [
+                        "$reporter $page"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "Bee, 120"
+            ],
             "mlz_jurisdiction": [
                 "us;supreme.court"
             ],
             "name": "Bee's United States (US) District Court Reports",
-            "variations": {}
+            "variations": {
+                "Bee,": "Bee"
+            }
         }
     ],
     "Beeler": [
@@ -2471,9 +2480,17 @@
             "editions": {
                 "Blatchf. & H.": {
                     "end": "1837-12-31T00:00:00",
+                    "regexes": [
+                        "$full_cite",
+                        "$volume_nominative ?$reporter $page"
+                    ],
                     "start": "1827-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "1 Blatchf. & H. 83",
+                "Blatchf. & H. 114"
+            ],
             "mlz_jurisdiction": [],
             "name": "Blatchford and Howland's Reports.",
             "variations": {}
@@ -2497,7 +2514,9 @@
             ],
             "mlz_jurisdiction": [],
             "name": "Blatchford's United States District Court Prize Cases",
-            "variations": {}
+            "variations": {
+                "Blatchf. Prize Cas.": "Blatchf. Pr. Cas."
+            }
         }
     ],
     "Blue Sky L. Rep. (CCH)": [
@@ -2981,7 +3000,9 @@
                 "us:c;courts.martial"
             ],
             "name": "Court Martial Records",
-            "variations": {}
+            "variations": {
+                "CMR": "C.M.R."
+            }
         }
     ],
     "CAAF LEXIS": [
@@ -3532,6 +3553,23 @@
             "variations": {}
         }
     ],
+    "Cal. Law J.": [
+        {
+            "cite_type": "state",
+            "editions": {
+                "Cal. Law J.": {
+                    "end": "1863-12-31T00:00:00",
+                    "start": "1862-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "1 Cal. Law J. 195"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "California Law Journal",
+            "variations": {}
+        }
+    ],
     "Cal. Rptr.": [
         {
             "cite_type": "state",
@@ -3819,12 +3857,19 @@
             "editions": {
                 "Chase": {
                     "end": null,
+                    "regexes": [
+                        "$reporter $page"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "Chase, 267"
+            ],
             "mlz_jurisdiction": [],
             "name": "Chase's United States Circuit Court Decisions",
             "variations": {
+                "Chase,": "Chase",
                 "Chase.": "Chase"
             }
         }
@@ -3899,6 +3944,23 @@
                 "Cheves Eq.(S.C.)": "Chev. Eq.",
                 "S.C.Eq.(Chev.Eq.)": "Chev. Eq."
             }
+        }
+    ],
+    "Chi. Law J.": [
+        {
+            "cite_type": "state",
+            "editions": {
+                "Chi. Law J.": {
+                    "end": "1907-12-31T00:00:00",
+                    "start": "1878-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "1 Chi. Law J. 524"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "Chicago Law Journal",
+            "variations": {}
         }
     ],
     "Chi. Leg. News": [
@@ -4924,6 +4986,7 @@
                 "Cranch D.C.": "Cranch",
                 "Cranch Rep.": "Cranch",
                 "Cranch, C. C.": "Cranch",
+                "Cranch, C.C.": "Cranch",
                 "Cranch. C. C.": "Cranch",
                 "D.C.(Cranch)": "Cranch"
             }
@@ -4959,6 +5022,7 @@
             "variations": {
                 "C. Cls.": "Ct. Cl.",
                 "Court Cl.": "Ct. Cl.",
+                "Ct. Cl. R.": "Ct. Cl.",
                 "Ct. Cl. Rep.": "Ct. Cl.",
                 "Ct. Cls. R.": "Ct. Cl.",
                 "Ct.Cl.": "Ct. Cl."
@@ -5558,12 +5622,20 @@
             "editions": {
                 "Deady": {
                     "end": null,
+                    "regexes": [
+                        "$reporter $page"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "Deady, 264"
+            ],
             "mlz_jurisdiction": [],
             "name": "Deady's Circuit & District Court Reports",
-            "variations": {}
+            "variations": {
+                "Deady,": "Deady"
+            }
         }
     ],
     "Dec. Com. Pat.": [
@@ -8123,9 +8195,15 @@
             "editions": {
                 "Gilp.": {
                     "end": null,
+                    "regexes": [
+                        "$reporter $page"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "Gilp. 106"
+            ],
             "mlz_jurisdiction": [],
             "name": "Gilpin, United States (US) District Court Reports",
             "variations": {
@@ -9035,6 +9113,28 @@
             "variations": {}
         }
     ],
+    "Hoff.": [
+        {
+            "cite_type": "scotus_early",
+            "editions": {
+                "Hoff.": {
+                    "end": "1858-12-31T00:00:00",
+                    "regexes": [
+                        "$volume_nominative ?$reporter $page"
+                    ],
+                    "start": "1853-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "Hoff. Dec. 10"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "Hoffman's Decisions",
+            "variations": {
+                "Hoff. Dec.": "Hoff."
+            }
+        }
+    ],
     "Hoff. Ch.": [
         {
             "cite_type": "state",
@@ -9056,6 +9156,28 @@
                 "Hoffm.": "Hoff. Ch.",
                 "Hoffm.Ch.(N.Y.)": "Hoff. Ch."
             }
+        }
+    ],
+    "Hoff. Land Cas.": [
+        {
+            "cite_type": "federal",
+            "editions": {
+                "Hoff. Land Cas.": {
+                    "end": "1858-12-31T00:00:00",
+                    "regexes": [
+                        "$full_cite",
+                        "$volume_nominative ?$reporter $page"
+                    ],
+                    "start": "1853-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "1 Hoff. Land Cas. 182",
+                "Hoff. Land Cas. 101"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "Hoffman's Land Cases",
+            "variations": {}
         }
     ],
     "Holmes": [
@@ -9282,6 +9404,7 @@
             "name": "Kentucky Reports, Hughes",
             "variations": {
                 "Hugh.": "Hughes",
+                "Hughes.": "Hughes",
                 "Ky.(Hughes)": "Hughes"
             }
         }
@@ -11785,7 +11908,8 @@
             "variations": {
                 "Low. Dec.": "Low.",
                 "Low. Dis.": "Low.",
-                "Lowell": "Low."
+                "Lowell": "Low.",
+                "Lowell.": "Low."
             }
         }
     ],
@@ -15629,12 +15753,21 @@
             "editions": {
                 "Newb. Adm.": {
                     "end": null,
+                    "regexes": [
+                        "$volume_nominative ?$reporter $page"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "Newb. 101",
+                "1 Newb. Adm. 269"
+            ],
             "mlz_jurisdiction": [],
             "name": "Newberry's District Court Admiralty Rep. United States (US)",
-            "variations": {}
+            "variations": {
+                "Newb.": "Newb. Adm."
+            }
         }
     ],
     "Northumb. L.J.": [
@@ -16638,12 +16771,20 @@
             "editions": {
                 "Olcott": {
                     "end": null,
+                    "regexes": [
+                        "$volume_nominative ?$reporter $page"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "Olc. 12"
+            ],
             "mlz_jurisdiction": [],
             "name": "Olcott's Admiralty Reports",
-            "variations": {}
+            "variations": {
+                "Olc.": "Olcott"
+            }
         }
     ],
     "Op. Att'y Gen.": [
@@ -16866,6 +17007,7 @@
                 "P. (2d)": "P.2d",
                 "P. 2d": "P.2d",
                 "P. 3d": "P.3d",
+                "P. R.": "P.",
                 "P. Rep.": "P.",
                 "P. [2d.]": "P.2d",
                 "P. [2d]": "P.2d",
@@ -20977,6 +21119,23 @@
                 "us:tx;supreme.court"
             ],
             "name": "LexisNexis Texas Supreme Court",
+            "variations": {}
+        }
+    ],
+    "Tex. Law J.": [
+        {
+            "cite_type": "state",
+            "editions": {
+                "Tex. Law J.": {
+                    "end": "1882-12-31T00:00:00",
+                    "start": "1877-01-01T00:00:00"
+                }
+            },
+            "examples": [
+                "1 Tex. Law J. 116"
+            ],
+            "mlz_jurisdiction": [],
+            "name": "Texas Law Journal",
             "variations": {}
         }
     ],


### PR DESCRIPTION
- New reporter Syllabi
- New reporter Oliver's Forms
- New reporter Coddington's Digest of the Law of Trade-Marks
- New reporter Cox's Manual of Trade-Mark Cases
- New reporter Wharton's State Trials
- New reporter Wharton, Treatise on the Law of Homicide in the United States
- New reporter Maryland Law Record
- New reporter Robb's Patent Cases
- New reporter Cranch's Patent Decisions
- New reporter United States Law Journal and Civilians' Magazine
- New reporter Quarterly Law Journal
- New reporter San Francisco Law Journal
- New reporter Louisiana Law Journal
- New reporter Law and Equity Reporter
- New reporter Monthly Western Jurist
- New reporter Indian Claims Commission
- New reporter Law reporter
- New reporter Betts' Scrap Book
- New reporter American Law Journal, New Series
- New reporter American Law Times Reports, New Series
- New reporter Baltimore Law Transcript
- New reporter Journal of Jurisprudence
- New reporter American Law Journal
- New reporter American Jurist and Law Magazine
- New reporter Bigelow's Insurance Reports
- New reporter Browne's Pennsylvania Reports
- New reporter New York City Hall Recorder
- New reporter Niles' Weekly Register
- New reporter Hopkinson, Life and Letters of Hon. Francis Hopkinson, District Judge
- New reporter American Law Times
- New reporter Jurisprudencia del Tribunal Supremo
- New reporter Decisiones del Tribunal Supremo
- New reporter Hoffman's Opinions
- New reporter California Law Journal and Literary Review
- New reporter Coombs' Trial of Aaron Burr
- New reporter Dane's Abridgement and Digest of American Law
- New reporter Burr's Trial
- New reporter Robertson's Report of the Trial of Aaron Burr
- New reporter Carpenter's Report of Burr's Trial
- New reporter Chase's Trial. Append.
- New reporter Wall. Jr. Append.
- Regex updated for some reporters
- Many reporters variations