### PR TITLE
Black pre-commit version updated

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
        args: [--line-length=79, --transform-concats]
 
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
      - id: black
 


### PR DESCRIPTION
Black lint action is failing because version mismatch

Black version from pre-commit (22.12.0) is behind lint version (23.1.0)

I updated Black version in pre-commit configuration file to match black lint action version.