### PR TITLE
Update reporters and regexes

### DIFF
--- a/reporters_db/data/regexes.json
+++ b/reporters_db/data/regexes.json
@@ -24,7 +24,7 @@
             "with_suffix": "$reporter $paragraph_marker_optional$page_with_commas_and_suffix",
             "with_suffix#": "Paragraph cite with optional alpha character appended"
         },
-        "single_volume": "(?:(?P<volume>1) )?$reporter $page",
+        "single_volume": "(?:(?P<volume>1) )?$reporter,? $page",
         "year_included": {
             "": "$volume $reporter \\((?P<year>1[789]\\d{2}|20\\d{2}),?\\) $page",
             "#": "Citation that includes the volume year after the reporter '14 Haz. Reg. Pa. (1834) 10'"

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -10075,9 +10075,17 @@
             "editions": {
                 "Fulton County D. Rep.": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite",
+                        "$$volume_with_digit_suffix $reporter $page_with_letter"
+                    ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "102-56 Fulton County D. Rep. 16B",
+                "96 Fulton County D. Rep. 1243"
+            ],
             "mlz_jurisdiction": [
                 "us:ga;supreme.court"
             ],

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -14717,16 +14717,25 @@
             "editions": {
                 "Litt. Sel. Cas.": {
                     "end": "1821-12-31T00:00:00",
+                    "regexes": [
+                        "$full_cite_single_volume"
+                    ],
                     "start": "1795-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "Litt. Sel. Cas. 119",
+                "Litt. Sel. Cas. (Ky.) 505",
+                "1 Litt. Sel. Cas., 388"
+            ],
             "mlz_jurisdiction": [
                 "us:ky;supreme.court"
             ],
             "name": "Kentucky Reports, Littell's Selected Cases",
             "variations": {
                 "Ky.(Lit.Sel.Cas.)": "Litt. Sel. Cas.",
-                "Lit.Sel.Ca.": "Litt. Sel. Cas."
+                "Lit.Sel.Ca.": "Litt. Sel. Cas.",
+                "Litt. Sel. Cas. (Ky.)": "Litt. Sel. Cas."
             }
         }
     ],

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -6868,7 +6868,8 @@
                 }
             },
             "examples": [
-                "Dallam 504"
+                "Dallam 504",
+                "Dallam, 597"
             ],
             "mlz_jurisdiction": [
                 "us:tx;supreme.court"
@@ -15599,13 +15600,14 @@
                 "McCahon": {
                     "end": "1868-12-31T00:00:00",
                     "regexes": [
-                        "$volume_nominative ?$reporter, $page"
+                        "$full_cite_single_volume"
                     ],
                     "start": "1858-01-01T00:00:00"
                 }
             },
             "examples": [
-                "McCahon, 206"
+                "McCahon, 206",
+                "McCahon 166"
             ],
             "mlz_jurisdiction": [
                 "us:ks;supreme.court"

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -10369,9 +10369,15 @@
             "editions": {
                 "Gilmer": {
                     "end": "1821-12-31T00:00:00",
+                    "regexes": [
+                        "$full_cite_single_volume"
+                    ],
                     "start": "1820-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "Gilmer 414"
+            ],
             "mlz_jurisdiction": [
                 "us:va;supreme.court"
             ],

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -159,9 +159,17 @@
                 },
                 "A.F.T.R.2d (RIA)": {
                     "end": null,
+                    "regexes": [
+                        "$full_cite",
+                        "$volume_with_alpha_suffix $reporter $page"
+                    ],
                     "start": "1958-01-01T00:00:00"
                 }
             },
+            "examples": [
+                "71A A.F.T.R.2d (RIA) 3011",
+                "42 A.F.T.R.2d (RIA) 6397"
+            ],
             "mlz_jurisdiction": [
                 "us:c;tax.court",
                 "us:c9;court.appeals"

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -10078,7 +10078,7 @@
                     "end": null,
                     "regexes": [
                         "$full_cite",
-                        "$$volume_with_digit_suffix $reporter $page_with_letter"
+                        "$volume_with_digit_suffix $reporter $page_with_letter"
                     ],
                     "start": "1750-01-01T00:00:00"
                 }


### PR DESCRIPTION
Reporters updated: 

- A.F.T.R. (RIA) (Eyecite issue [#24](https://github.com/freelawproject/eyecite/issues/24))
- Fulton County D. Rep. (Eyecite issue [#23](https://github.com/freelawproject/eyecite/issues/23))
- Gilmer (Eyecite issue [#20](https://github.com/freelawproject/eyecite/issues/20))
- McCahon (Eyecite issue 20)
- Litt. Sel. Cas. (Eyecite issue 20)

`full_cite_single_volume` regex updated to allow optional comma