### PR TITLE
feat(workflow): check changelog

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -1,0 +1,15 @@
+name: Check release notes
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  Check-Changelog:
+    name: Check Changelog Action
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: tarides/changelog-check-action@v2
+        with:
+          changelog: CHANGES.md

--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   Check-Changelog:
     name: Check Changelog Action
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: tarides/changelog-check-action@v2
         with:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@
 
 ## Upcoming Changes
 
- - N/A
+ - Add workflow to check for new entries in CHANGES.md file
 
 ## Current Version
 


### PR DESCRIPTION
This PR adds a new workflow to verify that we added a new entry to CHANGES.md file. 

If you don't do this, you won't be able to merge the changes.

If any of the changes do not require a new entry in the CHANGES.md file, you can add a label: `no changelog` to the PR to avoid the check and run the action again.

In order to make this PR pass this new check I added the entry in the Upcoming Changes section. 

When a new version is released it would be a matter of moving that message to the Current Version section along with any other changes to be released.