### PR TITLE
Add variation to Montana Neutral Citation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@
 
 ## Upcoming Changes
 
- - None
+ - Add variation to Montana Neutral Citation
 
 ## Current Version
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,12 +18,12 @@
 
 - 3.2.54 (2025-02-21)
 
-Changes: 
+Changes:
 
-- Add workflow to check for new entries in CHANGES.md file 
+- Add workflow to check for new entries in CHANGES.md file
 - Update S.Ct. Regexes
 - Add Changes to NY variations
- 
+
 ## Past Versions
 
  - 3.2.53 (2025-02-20): Add page variations for NY Slip Op and NY Misc 3d

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -15028,19 +15028,21 @@
                     "end": null,
                     "regexes": [
                         "$full_cite",
-                        "$volume $reporter (?P<page>\\d+[N]?)"
+                        "$volume $reporter (?P<page>\\d+[AN]?)"
                     ],
                     "start": "1750-01-01T00:00:00"
                 }
             },
             "examples": [
                 "108 MT 1",
-                "108 MT 23N"
+                "108 MT 23N",
+                "2021 MT 172A"
             ],
             "mlz_jurisdiction": [
                 "us:mt;supreme.court"
             ],
             "name": "Montana Neutral Citation",
+            "notes": "'A' means the opinion was amended (corrected), and 'N' means it's a noncitable memorandum opinion not usable as precedent.",
             "variations": {
                 "Mt": "MT",
                 "mt": "MT"


### PR DESCRIPTION
- Add variation to Montana Neutral Citation for citations like: `2021 MT 172A`
- Also added a note to know the meaning if the page number has a N or an A