### PR TITLE
Standardize nominative reporters regex group name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@
 
 ## Upcoming Changes
 
- - None
+ - Standardize nominative reporters regex group names
 
 ## Current Version
 

--- a/reporters_db/data/regexes.json
+++ b/reporters_db/data/regexes.json
@@ -70,7 +70,7 @@
     "volume": {
         "": "(?P<volume>\\d+)",
         "#": "Standard volume number",
-        "nominative": "(?:(?P<volume_nominative>\\d{1,2}) )?",
+        "nominative": "(?:(?P<volume>\\d{1,2}) )?",
         "nominative#": "Nominative volume number embedded in an official cite; made optional for single-volume nominatives",
         "with_alpha_suffix": "(?P<volume>\\d{1,4}A?)",
         "with_alpha_suffix#": "Volume number that may have 'A' appended, like '1A'",

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -4788,7 +4788,7 @@
                 "Chase": {
                     "end": null,
                     "regexes": [
-                        "$reporter $page"
+                        "$volume_nominative ?$reporter $page"
                     ],
                     "start": "1750-01-01T00:00:00"
                 }
@@ -6543,7 +6543,7 @@
                     "end": "1893-12-31T00:00:00",
                     "regexes": [
                         "$full_cite",
-                        "$volume $reporter \\($volume_nominative(?P<reporter_nominative>MacArth\\. & M\\.|Tuck\\. & Cl\\.|MacArth\\.|Mackey|Cranch)\\) $page"
+                        "$volume $reporter \\((?:(?P<volume_nominative>\\d{1,2}) )?(?P<reporter_nominative>MacArth\\. & M\\.|Tuck\\. & Cl\\.|MacArth\\.|Mackey|Cranch)\\) $page"
                     ],
                     "start": "1801-01-01T00:00:00"
                 }
@@ -7002,7 +7002,7 @@
                 "Deady": {
                     "end": null,
                     "regexes": [
-                        "$reporter $page"
+                        "$volume_nominative ?$reporter $page"
                     ],
                     "start": "1750-01-01T00:00:00"
                 }
@@ -7070,7 +7070,7 @@
                     "end": "1966-12-31T00:00:00",
                     "regexes": [
                         "$full_cite",
-                        "$volume $reporter \\($volume_nominative(?P<reporter_nominative>Marv\\.|Penne\\.|Harr\\.|Boyce|Houst\\.)\\) $page"
+                        "$volume $reporter \\((?:(?P<volume_nominative>\\d{1,2}) )?(?P<reporter_nominative>Marv\\.|Penne\\.|Harr\\.|Boyce|Houst\\.)\\) $page"
                     ],
                     "start": "1920-01-01T00:00:00"
                 }
@@ -12290,7 +12290,7 @@
                     "end": null,
                     "regexes": [
                         "$full_cite",
-                        "$volume $reporter \\($volume_nominative(?P<reporter_nominative>Scam\\.|Breese|Gilm\\.)\\) $page"
+                        "$volume $reporter \\((?:(?P<volume_nominative>\\d{1,2}) )?(?P<reporter_nominative>Scam\\.|Breese|Gilm\\.)\\) $page"
                     ],
                     "start": "1849-01-01T00:00:00"
                 },
@@ -13500,7 +13500,7 @@
                     "end": "1951-12-31T00:00:00",
                     "regexes": [
                         "$full_cite",
-                        "$volume $reporter \\($volume_nominative(?P<reporter_nominative>Bush|Duv\\.|Met\\.|B\\. Mon\\.|Dana|J\\.J\\. Marsh\\.|T\\.B\\. Mon\\.|Litt\\.|Litt\\. Sel\\. Cas\\.|A\\.K\\. Marsh\\.|Bibb|Hard\\.|Sneed|Hughes)\\) $page"
+                        "$volume $reporter \\((?:(?P<volume_nominative>\\d{1,2}) )?(?P<reporter_nominative>Bush|Duv\\.|Met\\.|B\\. Mon\\.|Dana|J\\.J\\. Marsh\\.|T\\.B\\. Mon\\.|Litt\\.|Litt\\. Sel\\. Cas\\.|A\\.K\\. Marsh\\.|Bibb|Hard\\.|Sneed|Hughes)\\) $page"
                     ],
                     "start": "1879-01-01T00:00:00"
                 }
@@ -15302,7 +15302,7 @@
                     "end": null,
                     "regexes": [
                         "$full_cite",
-                        "$volume $reporter \\($volume_nominative(?P<reporter_nominative>Allen|Gray|Cush\\.|Met\\.|Pick\\.|Tyng|Will\\.)\\) $page"
+                        "$volume $reporter \\((?:(?P<volume_nominative>\\d{1,2}) )?(?P<reporter_nominative>Allen|Gray|Cush\\.|Met\\.|Pick\\.|Tyng|Will\\.)\\) $page"
                     ],
                     "start": "1867-01-01T00:00:00"
                 }
@@ -16615,7 +16615,7 @@
                     "end": "1966-12-31T00:00:00",
                     "regexes": [
                         "$full_cite",
-                        "$volume $reporter \\($volume_nominative(?P<reporter_nominative>S\\. & M\\.|Howard|Walker)\\) $page",
+                        "$volume $reporter \\((?:(?P<volume_nominative>\\d{1,2}) )?(?P<reporter_nominative>S\\. & M\\.|Howard|Walker)\\) $page",
                         "$volume $reporter,? p. $page"
                     ],
                     "start": "1851-01-01T00:00:00"
@@ -17172,7 +17172,7 @@
                     "end": null,
                     "regexes": [
                         "$full_cite",
-                        "$volume $reporter \\($volume_nominative(?P<reporter_nominative>Phil\\. Eq\\.|Phil\\.|Win\\.|Jones Eq\\.|Jones|Busb\\. Eq\\.|Busb\\.|Ired\\. Eq\\.|Ired\\.|Dev\\. & Bat\\. Eq\\.|Dev\\. Eq\\.|Dev\\.|Hawks|Mur\\.|Taylor|Car\\. L\\. Rep\\.|Hayw\\.|Cam\\. & Nor\\.|Tay\\.|Mart\\.)\\) $page",
+                        "$volume $reporter \\((?:(?P<volume_nominative>\\d{1,2}) )?(?P<reporter_nominative>Phil\\. Eq\\.|Phil\\.|Win\\.|Jones Eq\\.|Jones|Busb\\. Eq\\.|Busb\\.|Ired\\. Eq\\.|Ired\\.|Dev\\. & Bat\\. Eq\\.|Dev\\. Eq\\.|Dev\\.|Hawks|Mur\\.|Taylor|Car\\. L\\. Rep\\.|Hayw\\.|Cam\\. & Nor\\.|Tay\\.|Mart\\.)\\) $page",
                         "$volume $reporter \\((?P<volume_nominative>3 & 4) (?P<reporter_nominative>Dev\\. & Bat\\.)\\) $page"
                     ],
                     "start": "1868-01-01T00:00:00"
@@ -23320,7 +23320,7 @@
                     "end": "1868-12-31T00:00:00",
                     "regexes": [
                         "$full_cite",
-                        "$volume $reporter \\($volume_nominative(?P<reporter_nominative>Rich\\. Eq\\.|Strob\\. Eq\\.|Speers Eq\\.|McMul\\. Eq\\.|Chev\\. Eq\\.|Rice Eq\\.|Dud\\. Eq\\.|Ril\\. Eq\\.|Hill Eq\\.|Rich\\. Cas\\.|Bail\\. Eq\\.|McCord Eq\\.|Harp\\. Eq\\.|Des\\. Eq\\.)\\) $page"
+                        "$volume $reporter \\((?:(?P<volume_nominative>\\d{1,2}) )?(?P<reporter_nominative>Rich\\. Eq\\.|Strob\\. Eq\\.|Speers Eq\\.|McMul\\. Eq\\.|Chev\\. Eq\\.|Rice Eq\\.|Dud\\. Eq\\.|Ril\\. Eq\\.|Hill Eq\\.|Rich\\. Cas\\.|Bail\\. Eq\\.|McCord Eq\\.|Harp\\. Eq\\.|Des\\. Eq\\.)\\) $page"
                     ],
                     "start": "1784-01-01T00:00:00"
                 }
@@ -23395,7 +23395,7 @@
                     "end": "1868-12-31T00:00:00",
                     "regexes": [
                         "$full_cite",
-                        "$volume $reporter \\($volume_nominative(?P<reporter_nominative>Rich\\.|Strob\\.|Speers|McMul\\.|Chev\\.|Rice|Dud\\.|Ril\\.|Hill|Bail\\.|Harp\\.|McCord|Nott & McC\\.|Mill|Tread\\.|Brev\\.|Bay)\\) $page"
+                        "$volume $reporter \\((?:(?P<volume_nominative>\\d{1,2}) )?(?P<reporter_nominative>Rich\\.|Strob\\.|Speers|McMul\\.|Chev\\.|Rice|Dud\\.|Ril\\.|Hill|Bail\\.|Harp\\.|McCord|Nott & McC\\.|Mill|Tread\\.|Brev\\.|Bay)\\) $page"
                     ],
                     "start": "1783-01-01T00:00:00"
                 }
@@ -25126,7 +25126,7 @@
                     "end": "1971-12-31T00:00:00",
                     "regexes": [
                         "$full_cite",
-                        "$volume $reporter \\($volume_nominative(?P<reporter_nominative>Heisk\\.|Cold\\.|Head|Sneed|Swan|Hum\\.|Meigs|Yer\\.|Mart\\. & Yer\\.|Peck|Hayw\\.|Cooke|Overt\\.)\\) $page"
+                        "$volume $reporter \\((?:(?P<volume_nominative>\\d{1,2}) )?(?P<reporter_nominative>Heisk\\.|Cold\\.|Head|Sneed|Swan|Hum\\.|Meigs|Yer\\.|Mart\\. & Yer\\.|Peck|Hayw\\.|Cooke|Overt\\.)\\) $page"
                     ],
                     "start": "1870-01-01T00:00:00"
                 }
@@ -25913,7 +25913,7 @@
                     "end": null,
                     "regexes": [
                         "$full_cite",
-                        "$volume $reporter\\s*\\($volume_nominative(?P<reporter_nominative>Black|Cranch|Pet.|Wall.|How.|Wheat.|Dall.)\\) $page"
+                        "$volume $reporter\\s*\\((?:(?P<volume_nominative>\\d{1,2}) )?(?P<reporter_nominative>Black|Cranch|Pet.|Wall.|How.|Wheat.|Dall.)\\) $page"
                     ],
                     "start": "1875-01-01T00:00:00"
                 }
@@ -26634,7 +26634,7 @@
                     "end": null,
                     "regexes": [
                         "$full_cite",
-                        "$volume $reporter \\($volume_nominative(?P<reporter_nominative>Gratt\\.|Rob\\.|Leigh|Rand\\.|Gilmer|Munf\\.|Hen\\. & M\\.|Call|Va\\. Cas\\.|Wash\\.)\\) $page"
+                        "$volume $reporter \\((?:(?P<volume_nominative>\\d{1,2}) )?(?P<reporter_nominative>Gratt\\.|Rob\\.|Leigh|Rand\\.|Gilmer|Munf\\.|Hen\\. & M\\.|Call|Va\\. Cas\\.|Wash\\.)\\) $page"
                     ],
                     "start": "1880-01-01T00:00:00"
                 }


### PR DESCRIPTION
- Updated "Chase" regex
- The capturing group for volume for nominative reporters changed from volume_nominative to volume to standardize it.

For example:

"1 Hask. 405"
`FullCaseCitation('1 Hask. 495',groups={'volume': '1', 'reporter': 'Hask.', 'page': '405'}....`

"Hask. 236"
`FullCaseCitation('Hask. 236', groups={'volume': None, 'reporter': 'Hask.', 'page': '236'}.....`

volume_nominative capturing group still exists for a few special cases when we have a parallel citation,it includes both official and nominative reporter citation, for example:

"20 N.C. (3 & 4 Dev. & Bat.) 456"
`FullCaseCitation('20 N.C. (3 & 4 Dev. & Bat.) 456', groups={'volume': '20', 'reporter': 'N.C.', 'volume_nominative': '3 & 4', 'reporter_nominative': 'Dev. & Bat.', 'page': '456'}...`

"21 D.C. (Tuck. & Cl.) 456"
`FullCaseCitation('21 D.C. (Tuck. & Cl.) 456', groups={'volume': '21', 'reporter': 'D.C.', 'volume_nominative': None, 'reporter_nominative': 'Tuck. & Cl.', 'page': '456'},`