### PR TITLE
chore: Move formatting and linting to Ruff

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,7 @@ updates:
   ignore:
   # Ignore all tooling (it can get old, it's mature enough)
   - dependency-name: selenium
-  - dependency-name: black
-  - dependency-name: pylint
-  - dependency-name: flake8
-  - dependency-name: isort
   - dependency-name: mypy
-  - dependency-name: flynt
   # Ignore all patch updates.
   - dependency-name: '*'
     update-types: ["version-update:semver-patch"]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,5 @@ jobs:
         with:
           # Once codebase is updated, this can easily be changed to any specific version.
           python-version: "3.8"
-      - name: Black Code Formatter
-        uses: psf/black@stable
-        with:
-          version: "22.8.0"
+
+      - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,8 @@
 ci:
   autoupdate_schedule: quarterly
 repos:
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.16.0
-    hooks:
-     - id: pyupgrade
-       args: [--py37-plus]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
      - id: check-added-large-files
      - id: check-ast
@@ -24,20 +19,9 @@ repos:
        args: [--markdown-linebreak-ext=md]
        exclude: ^tests/examples/pacer/nef/s3/.*\.txt$
 
-  - repo: https://github.com/ikamensh/flynt/
-    rev: '1.0.1'
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.8
     hooks:
-     - id: flynt
-       args: [--line-length=79, --transform-concats]
-
-  - repo: https://github.com/psf/black
-    rev: 24.4.2
-    hooks:
-     - id: black
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-     - id: isort
-       name: isort (python)
-       args: ["--profile", "black"]
+      - id: ruff
+        args: [ --fix ]
+      - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,38 @@
-[tool.black]
+[project]
+name = "reporters-db"
+version = "1"
+description = "reporters-db"
+requires-python = ">=3.9"
+
+[tool.ruff]
 line-length = 79
-include = '''.*\.pyi?$'''
+lint.select = [
+  # flake8-bugbear
+  "B",
+  # flake8-comprehensions
+  "C4",
+  # pycodestyle
+  "E",
+  # Pyflakes errors
+  "F",
+  # isort
+  "I",
+  # flake8-simplify
+  "SIM",
+  # flake8-tidy-imports
+  "TID",
+  # pyupgrade
+  "UP",
+  # Pyflakes warnings
+  "W",
+]
+lint.ignore = [
+  # flake8-bugbear opinionated rules
+  "B9",
+  # line-too-long
+  "E501",
+  # suppressible-exception
+  "SIM105",
+  # if-else-block-instead-of-if-exp
+  "SIM108",
+]

--- a/reporters_db/make_csv.py
+++ b/reporters_db/make_csv.py
@@ -40,15 +40,12 @@ def make_editions_dict(editions):
     """
     d = {}
     nums = ["1", "2", "3", "4", "5", "6"]
-    num_counter = 0
-    for k, date_dict in editions.items():
+    for num_counter, (k, date_dict) in enumerate(editions.items()):
         d[f"edition{nums[num_counter]}"] = k
         if date_dict["start"] is not None:
             d[f"start_e{nums[num_counter]}"] = date_dict["start"].isoformat()
         if date_dict["end"] is not None:
             d[f"end_e{nums[num_counter]}"] = date_dict["end"].isoformat()
-
-        num_counter += 1
 
     return d
 

--- a/reporters_db/utils.py
+++ b/reporters_db/utils.py
@@ -17,7 +17,7 @@ def suck_out_variations_only(reporters):
     reporters that it could be possibly referring to.
     """
     variations_out = {}
-    for reporter_key, data_list in reporters.items():
+    for _reporter_key, data_list in reporters.items():
         # For each reporter key...
         for data in data_list:
             # For each book it maps to...
@@ -52,7 +52,7 @@ def suck_out_editions(reporters):
         # For each reporter key...
         for data in data_list:
             # For each book it maps to...
-            for edition_key, edition_value in data["editions"].items():
+            for edition_key, _edition_value in data["editions"].items():
                 try:
                     editions_out[edition_key]
                 except KeyError:
@@ -74,11 +74,11 @@ def suck_out_formats(reporters):
     In other words, this lets you go from an edition match to its parent key.
     """
     formats_out = {}
-    for reporter_key, data_list in reporters.items():
+    for _reporter_key, data_list in reporters.items():
         # For each reporter key...
         for data in data_list:
             # Map the cite_format if it exists
-            for edition_key, edition_value in data["editions"].items():
+            for edition_key, _edition_value in data["editions"].items():
                 try:
                     formats_out[edition_key] = data["cite_format"]
                 except KeyError:
@@ -99,12 +99,13 @@ def names_to_abbreviations(reporters):
     Note that the abbreviations are sorted by start date.
     """
     names = {}
-    for reporter_key, data_list in reporters.items():
+    for _reporter_key, data_list in reporters.items():
         for data in data_list:
             abbrevs = data["editions"].keys()
             # Sort abbreviations by start date of the edition
-            sort_func = lambda x: str(data["editions"][x]["start"]) + x
-            abbrevs = sorted(abbrevs, key=sort_func)
+            abbrevs = sorted(
+                abbrevs, key=lambda x: str(data["editions"][x]["start"]) + x
+            )
             names[data["name"]] = abbrevs
     sorted_names = OrderedDict(sorted(names.items(), key=lambda t: t[0]))
     return sorted_names
@@ -153,7 +154,7 @@ def recursive_substitute(template, variables, max_depth=100):
     Infinite loops will raise a ValueError after max_depth loops.
     """
     old_val = template
-    for i in range(max_depth):
+    for _ in range(max_depth):
         new_val = Template(old_val).safe_substitute(variables)
         if new_val == old_val:
             break

--- a/tests.py
+++ b/tests.py
@@ -58,7 +58,7 @@ def iter_reporters():
 
 
 def iter_editions():
-    for reporter_abbv, reporter_list, reporter_data in iter_reporters():
+    for _reporter_abbv, _reporter_list, reporter_data in iter_reporters():
         yield from reporter_data["editions"].items()
 
 
@@ -105,16 +105,10 @@ class BaseTestCase(TestCase):
                 except ImportError:
                     candidate = "Run 'pip install exrex' to generate a candidate example"
                 self.fail(
-                    "No match in 'examples' for custom regex '%s'.\n"
-                    "Expanded regex: %s.\n"
-                    "Provided examples: %s.\n"
-                    "%s"
-                    % (
-                        regex_template,
-                        regex,
-                        examples,
-                        candidate,
-                    )
+                    f"No match in 'examples' for custom regex {regex_template!r}.\n"
+                    f"Expanded regex: {regex}.\n"
+                    f"Provided examples: {examples}.\n"
+                    f"{candidate}"
                 )
 
         # check that each example is matched by at least one regex
@@ -122,13 +116,12 @@ class BaseTestCase(TestCase):
             set(examples),
             matched_examples,
             "Not all examples matched. If custom regexes are provided, all examples should match."
-            "Unmatched examples: %s. Regexes tried: %s"
-            % (set(examples) - matched_examples, regexes),
+            f"Unmatched examples: {set(examples) - matched_examples}. Regexes tried: {regexes}",
         )
 
     def check_for_matching_groups(self, regexes, examples):
         """Check that each regex has named <reporter> and <page> matching groups."""
-        for regex_template, regex in regexes:
+        for _regex_template, regex in regexes:
             for example in examples:
                 if m := re.match(regex + "$", example):
                     self.assertIn(
@@ -223,7 +216,7 @@ class ReportersTest(BaseTestCase):
 
     def test_any_keys_missing_editions(self):
         """Have we added any new reporters that lack a matching edition?"""
-        for reporter_abbv, reporter_list, reporter_data in iter_reporters():
+        for reporter_abbv, _reporter_list, reporter_data in iter_reporters():
             self.assertIn(
                 reporter_abbv,
                 reporter_data["editions"],
@@ -239,8 +232,7 @@ class ReportersTest(BaseTestCase):
                 self.assertIn(
                     EDITIONS[variation],
                     REPORTERS.keys(),
-                    msg="Could not map variation to a valid reporter: %s"
-                    % variation,
+                    msg=f"Could not map variation to a valid reporter: {variation}",
                 )
 
     def test_basic_names_to_editions(self):
@@ -259,12 +251,12 @@ class ReportersTest(BaseTestCase):
     def test_dates(self):
         """Do we properly make the ISO-8601 date strings into Python dates?"""
         # for reporter_abbv, reporter_list, reporter_data in iter_reporters():
-        for edition_name, edition in iter_editions():
+        for _edition_name, edition in iter_editions():
             self.check_dates(edition["start"], edition["end"])
 
     def test_all_reporters_have_valid_cite_type(self):
         """Do all reporters have valid cite_type values?"""
-        for reporter_abbv, reporter_list, reporter_data in iter_reporters():
+        for reporter_abbv, _reporter_list, reporter_data in iter_reporters():
             self.assertIn(
                 reporter_data["cite_type"],
                 VALID_CITE_TYPES,
@@ -280,13 +272,13 @@ class ReportersTest(BaseTestCase):
                 self.assertNotEqual(
                     variation,
                     key,
-                    "The variation '%s' is identical to the key it's supposed "
-                    "to be a variation of." % variation,
+                    f"The variation '{variation}' is identical to the key it's supposed "
+                    "to be a variation of.",
                 )
 
     def test_fields_tidy(self):
         """Check that fields don't have unexpected characters or whitespace."""
-        for reporter_abbv, reporter_list, reporter_data in iter_reporters():
+        for reporter_abbv, _reporter_list, reporter_data in iter_reporters():
             self.check_ascii(reporter_abbv)
             self.check_ascii(list(reporter_data["editions"].keys()))
             self.check_ascii(reporter_data["variations"])
@@ -298,7 +290,7 @@ class ReportersTest(BaseTestCase):
         (1) Do custom regexes and examples match up?
         (2) Does each regex have named <reporter> and <page> matching groups?
         """
-        for reporter_abbv, reporter_list, reporter_data in iter_reporters():
+        for reporter_abbv, _reporter_list, reporter_data in iter_reporters():
             # get list of expanded regexes and examples for this reporter
             examples = reporter_data.get("examples", [])
             regexes = []
@@ -315,8 +307,7 @@ class ReportersTest(BaseTestCase):
                         regex_template, REGEX_VARIABLES
                     )
                     regex = Template(regex).safe_substitute(
-                        edition="(?:%s)"
-                        % "|".join(re.escape(e) for e in edition_strings)
+                        edition=f"(?:{'|'.join(re.escape(e) for e in edition_strings)})"
                     )
                     regexes.append((regex_template, regex))
 
@@ -353,20 +344,19 @@ class LawsTest(BaseTestCase):
             for regex_template in law["regexes"]:
                 regex = recursive_substitute(regex_template, REGEX_VARIABLES)
                 regex = Template(regex).safe_substitute(
-                    edition="(?:%s)"
-                    % "|".join(re.escape(e) for e in series_strings)
+                    edition=f"(?:{'|'.join(re.escape(e) for e in series_strings)})"
                 )
                 regexes.append((regex_template, regex))
             with self.subTest("Check law regexes", name=law["name"]):
                 self.check_regexes(regexes, law["examples"])
 
     def test_dates(self):
-        for law_key, law in self.iter_laws():
+        for _law_key, law in self.iter_laws():
             self.check_dates(law["start"], law["end"])
 
     def test_fields_tidy(self):
         """Check that fields don't have unexpected characters or whitespace."""
-        for law_key, law in self.iter_laws():
+        for _law_key, law in self.iter_laws():
             self.check_ascii(law["regexes"])
             self.check_ascii(law["examples"])
 
@@ -385,7 +375,7 @@ class JournalsTest(BaseTestCase):
 
     def test_regexes(self):
         """Do custom regexes and examples match up?"""
-        for journal_key, journal in self.iter_journals():
+        for _journal_key, journal in self.iter_journals():
             regexes = [
                 (
                     regex_template,
@@ -397,7 +387,7 @@ class JournalsTest(BaseTestCase):
                 self.check_regexes(regexes, journal.get("examples", []))
 
     def test_dates(self):
-        for journal_key, journal in self.iter_journals():
+        for _journal_key, journal in self.iter_journals():
             self.check_dates(journal["start"], journal["end"])
 
     def test_fields_tidy(self):


### PR DESCRIPTION

Replace Black, isort, and pyupgrade with Ruff.
