### PR TITLE
Remove repeated reporter and move variation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@
  - Standardize nominative reporters regex group names
  - Drop `six` dependency
  - Support Python 3.13
+ - Remove repeated reporter `C.I.T.` and add it as a variation of `Ct. Int'l Trade`
+ - Move variation `M.,` to correct reporter `Mich.`
 
 ## Current Version
 

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -3755,20 +3755,6 @@
             "variations": {}
         }
     ],
-    "C.I.T.": [
-        {
-            "cite_type": "specialty",
-            "editions": {
-                "C.I.T.": {
-                    "end": null,
-                    "start": "1750-01-01T00:00:00"
-                }
-            },
-            "mlz_jurisdiction": [],
-            "name": "Court of International Trade Reports",
-            "variations": {}
-        }
-    ],
     "C.M.A.": [
         {
             "cite_type": "specialty",
@@ -6346,7 +6332,7 @@
     ],
     "Ct. Int'l Trade": [
         {
-            "cite_type": "federal",
+            "cite_type": "specialty",
             "editions": {
                 "Ct. Int'l Trade": {
                     "end": null,
@@ -6358,6 +6344,7 @@
             ],
             "name": "Court of International Trade Reports",
             "variations": {
+                "C.I.T.": "Ct. Int'l Trade",
                 "Ct.Int'l Trade": "Ct. Int'l Trade"
             }
         }
@@ -15732,7 +15719,6 @@
             "name": "McGrath's Mandamus Cases (Michigan)",
             "notes": "Also known as 'Mandamus cases decided in the Supreme court of Michigan'",
             "variations": {
-                "M.,": "McGrath",
                 "McGrdath": "McGrath"
             }
         }
@@ -16167,6 +16153,7 @@
             ],
             "name": "Michigan Reports",
             "variations": {
+                "M.,": "Mich.",
                 "Mich": "Mich.",
                 "Mich. Rep.": "Mich."
             }


### PR DESCRIPTION
 - Remove repeated reporter `C.I.T.` and add it as a variation of `Ct. Int'l Trade`
 - Move variation `M.,` to correct reporter `Mich.`

You can read more about this here: https://github.com/freelawproject/courtlistener/issues/4930#issuecomment-2884868659
