### PR TITLE
chore: Bump version to 3.2.55 and update CHANGES.md

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,14 +19,15 @@
 
 ## Current Version
 
-- 3.2.54 (2025-02-21)
+- 3.2.55 (2025-02-23)
 
 Changes:
 
 - Add workflow to check for new entries in CHANGES.md file
 - Update S.Ct. Regexes
 - Add Changes to NY variations
-- Add "P3d" abbreviation to reporters.json
+- Add "P3d" abbreviation to reporters.json #224
+
 
 ## Past Versions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "reporters-db"
-version = "3.2.54"
+version = "3.2.55"
 description = "Database of Court Reporters"
 readme = "README.rst"
 keywords = [ "legal", "reporters" ]


### PR DESCRIPTION
This pull request updates the version of the `reporters-db` project and includes minor changes to documentation and configuration files. The most important changes are as follows:

### Version Update:
* Updated the project version from `3.2.54` to `3.2.55` in `pyproject.toml` to reflect the latest release.

### Documentation Updates:
* Updated the version number in `CHANGES.md` from `3.2.54` to `3.2.55`, added a reference to issue #224 for the "P3d" abbreviation change, and documented other recent updates.