### PR TITLE
Add 'USPQ2d' variant

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
  - Add Wash App 2d
  - Add Arizona Digest
  - Add variations
+ - Update United States Patents Quarterly with a pattern observed in USPTO and the reporter's own usage
 
 
 ## Current Version

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -26417,7 +26417,8 @@
                 "USPQ": "U.S.P.Q. (BNA)",
                 "USPQ (BNA)": "U.S.P.Q. (BNA)",
                 "USPQ 2d": "U.S.P.Q. 2d (BNA)",
-                "USPQ 2d (BNA)": "U.S.P.Q. 2d (BNA)"
+                "USPQ 2d (BNA)": "U.S.P.Q. 2d (BNA)",
+                "USPQ2d": "U.S.P.Q. 2d (BNA)"
             }
         }
     ],


### PR DESCRIPTION
Observed usage by USPTO and in print version of the reporter

See, e.g., [TBMP section 701](https://tbmp.uspto.gov/RDMS/TBMP/current#/current/TBMP-700d1e1.html), with citations such as "M-Tek Inc. v. CVP Systems Inc., 17 USPQ2d 1070, 1072 (TTAB 1990) (untimely deposition stricken)"