### PR TITLE
feat(reporters): Add "I&N Dec" variation to I. & N. Dec. (#257)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
  - Other features (suggestions welcome)?
 
 ## Upcoming Changes
- -
+ - Add "I&N Dec" variation and example to I. & N. Dec. reporter (#257)
 
 
 ## Current Version

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -11966,7 +11966,8 @@
             "examples": [
                 "27 IN Dec. 782",
                 "10 I&NDec. 613",
-                "12 I&N Dec. 432"
+                "12 I&N Dec. 432",
+                "29 I&N Dec 672"
             ],
             "href": "https://law.resource.org/pub/us/code/blue/IndigoBook.html#T2",
             "mlz_jurisdiction": [
@@ -11977,6 +11978,7 @@
             "variations": {
                 "I & N Dec.": "I. & N. Dec.",
                 "I&N": "I. & N. Dec.",
+                "I&N Dec": "I. & N. Dec.",
                 "I&N Dec.": "I. & N. Dec.",
                 "I&NDec.": "I. & N. Dec.",
                 "IN Dec.": "I. & N. Dec."


### PR DESCRIPTION
Adds the `I&N Dec` variation (no trailing period) to the *Administrative Decisions Under Immigration and Nationality Laws* reporter, plus an example. Handles BIA citations like `29 I&N Dec 672`.

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)