### PR TITLE
feat(reporters): add "Cal.3rd" and "Cal.2nd" variations to California Reports

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
  - Other features (suggestions welcome)?
 
 ## Upcoming Changes
- -
+ - Add "Cal.3rd" variation to California Reports third series ("Cal. 3d") (#262)
 
 
 ## Current Version

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
  - Other features (suggestions welcome)?
 
 ## Upcoming Changes
- - Add "Cal.3rd" variation to California Reports third series ("Cal. 3d") (#262)
+ - Add "Cal.3rd" and "Cal.2nd" variations to California Reports ("Cal. 3d", "Cal. 2d") (#262)
 
 
 ## Current Version

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -4094,6 +4094,7 @@
             "variations": {
                 "Cal. Rep.": "Cal.",
                 "Cal.2d": "Cal. 2d",
+                "Cal.2nd": "Cal. 2d",
                 "Cal.3d": "Cal. 3d",
                 "Cal.3rd": "Cal. 3d",
                 "Cal.4th": "Cal. 4th",

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -4095,6 +4095,7 @@
                 "Cal. Rep.": "Cal.",
                 "Cal.2d": "Cal. 2d",
                 "Cal.3d": "Cal. 3d",
+                "Cal.3rd": "Cal. 3d",
                 "Cal.4th": "Cal. 4th",
                 "Cal.5th": "Cal. 5th",
                 "cal. 4th": "Cal. 4th"


### PR DESCRIPTION
Adds the `Cal.3rd` → `Cal. 3d` spelling variation. Closes #262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)