### PR TITLE
feat(reporters): add "USPQ2d (BNA)" and "[BNA]" variations to U.S.P.Q. (BNA) (#248)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
  - Other features (suggestions welcome)?
 
 ## Upcoming Changes
- -
+ - Add unspaced "USPQ2d (BNA)" and bracketed "[BNA]" variations to U.S.P.Q. (BNA) reporter (#248)
 
 
 ## Current Version

--- a/reporters_db/data/reporters.json
+++ b/reporters_db/data/reporters.json
@@ -26411,14 +26411,22 @@
             "name": "The United States Patents Quarterly",
             "variations": {
                 "U.S.P.Q.": "U.S.P.Q. (BNA)",
+                "U.S.P.Q. 2d [BNA]": "U.S.P.Q. 2d (BNA)",
+                "U.S.P.Q. [BNA]": "U.S.P.Q. (BNA)",
                 "U.S.P.Q.2D (BNA)": "U.S.P.Q. 2d (BNA)",
+                "U.S.P.Q.2D [BNA]": "U.S.P.Q. 2d (BNA)",
                 "U.S.P.Q.2d": "U.S.P.Q. 2d (BNA)",
                 "U.S.P.Q.2d (BNA)": "U.S.P.Q. 2d (BNA)",
+                "U.S.P.Q.2d [BNA]": "U.S.P.Q. 2d (BNA)",
                 "USPQ": "U.S.P.Q. (BNA)",
                 "USPQ (BNA)": "U.S.P.Q. (BNA)",
                 "USPQ 2d": "U.S.P.Q. 2d (BNA)",
                 "USPQ 2d (BNA)": "U.S.P.Q. 2d (BNA)",
-                "USPQ2d": "U.S.P.Q. 2d (BNA)"
+                "USPQ 2d [BNA]": "U.S.P.Q. 2d (BNA)",
+                "USPQ [BNA]": "U.S.P.Q. (BNA)",
+                "USPQ2d": "U.S.P.Q. 2d (BNA)",
+                "USPQ2d (BNA)": "U.S.P.Q. 2d (BNA)",
+                "USPQ2d [BNA]": "U.S.P.Q. 2d (BNA)"
             }
         }
     ],


### PR DESCRIPTION
Closes #248.

Adds variations to the `U.S.P.Q. (BNA)` reporter so common citation forms seen in CourtListener resolve correctly.

### What & why
- **`USPQ2d (BNA)`** (unspaced + parenthetical) — the core ask in the issue. eyecite does *not* make the `USPQ`↔`2d` boundary whitespace-optional, so `5 USPQ2d (BNA) 1601` returned **no match** before this change even though `USPQ 2d (BNA)` was present. Verified empirically with eyecite against the edited data.
- **Bracketed `[BNA]` forms** — mirror each `(BNA)` variation with `[BNA]` for both the first (`USPQ [BNA]`, `U.S.P.Q. [BNA]`) and second series (`USPQ2d [BNA]`, `USPQ 2d [BNA]`, `U.S.P.Q.2d [BNA]`, `U.S.P.Q.2D [BNA]`, `U.S.P.Q. 2d [BNA]`). These are punctuation (not whitespace-only) variants, so they are not auto-handled downstream.
