### PR TITLE
feat(laws): Add real-world KRS and Indiana Code citation forms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,15 @@
  - Other features (suggestions welcome)?
 
 ## Upcoming Changes
- -
+ - Add "KRS", "K.R.S." and "Ky. Rev. Stat." variations, real examples, and a
+   section regex covering letter chapters ("KRS 13A.130") and subtitle-dash
+   sections ("KRS 224.40-100") to Ky. Rev. Stat. Ann.
+ - Add "IC" and "I.C." variations, real examples, and a section regex covering
+   decimal segments ("IC 6-1.1-10-29.5") to Ind. Code and Ind. Code Ann. The
+   Indiana section regex requires all four segments, since "I.C." is also the
+   Idaho Code abbreviation and Idaho sections are shorter
+ - Make the section marker optional for the Kentucky and Indiana statutes, so
+   the dominant unmarked forms ("KRS 342.121", "IC 31-15-7-4") are recognized
 
 
 ## Current Version

--- a/reporters_db/data/laws.json
+++ b/reporters_db/data/laws.json
@@ -1881,16 +1881,26 @@
             "cite_type": "leg_statute",
             "end": null,
             "examples": [
-                "Ind. Code § 79.443"
+                "IC 31-15-7-4",
+                "IC 6-1.1-10-29.5",
+                "IC 26-1-2-612",
+                "I.C. 7.1-5-1-3",
+                "I.C. § 35-31.5-2-29",
+                "Ind. Code § 35-42-2-1.3",
+                "Ind. Code §§ 35-45-10-5",
+                "Ind. Code § 9-30-5-2(a)(2)"
             ],
+            "href": "https://iga.in.gov/laws/current/ic/",
             "jurisdiction": "Indiana",
             "name": "Indiana Code",
-            "notes": "Automatically generated. Remove this message if replacing with real examples.",
             "regexes": [
-                "$reporter § $law_section"
+                "$reporter,?\\s+(?:$section_marker\\s*)?(?P<section>\\d+(?:\\.\\d+)?(?:-\\d+(?:\\.\\d+)?){3}(?:\\((?:[a-zA-Z]{1,2}|\\d{1,2})\\))*)"
             ],
             "start": null,
-            "variations": []
+            "variations": [
+                "IC",
+                "I.C."
+            ]
         }
     ],
     "Ind. Code Ann.": [
@@ -1898,13 +1908,13 @@
             "cite_type": "leg_statute",
             "end": null,
             "examples": [
-                "Ind. Code Ann. § 0-922:28"
+                "Ind. Code Ann. § 35-45-10-5",
+                "Ind. Code Ann. § 31-9-2-14"
             ],
             "jurisdiction": "Indiana",
             "name": "West's Annotated Indiana Code; Burns Indiana Statutes Annotated (LexisNexis)",
-            "notes": "Automatically generated. Remove this message if replacing with real examples.",
             "regexes": [
-                "$reporter § $law_section"
+                "$reporter,?\\s+(?:$section_marker\\s*)?(?P<section>\\d+(?:\\.\\d+)?(?:-\\d+(?:\\.\\d+)?){3}(?:\\((?:[a-zA-Z]{1,2}|\\d{1,2})\\))*)"
             ],
             "start": null,
             "variations": []
@@ -2238,16 +2248,30 @@
             "cite_type": "leg_statute",
             "end": null,
             "examples": [
-                "Ky. Rev. Stat. Ann. § 021.48"
+                "KRS 342.121",
+                "KRS 13A.130",
+                "KRS 224.40-100",
+                "KRS 271B.15-020",
+                "KRS 403.800-403.880",
+                "KRS § 189A.010",
+                "KRS §§ 508.130",
+                "KRS 189A.010(1)(a)",
+                "K.R.S. 508.130",
+                "Ky. Rev. Stat. § 508.130",
+                "Ky. Rev. Stat. Ann. § 508.130"
             ],
+            "href": "https://apps.legislature.ky.gov/law/statutes/",
             "jurisdiction": "Kentucky",
             "name": "Baldwin's Kentucky Revised Statutes Annotated (West); Michie's Kentucky Revised Statutes Annotated (LexisNexis)",
-            "notes": "Automatically generated. Remove this message if replacing with real examples.",
             "regexes": [
-                "$reporter § $law_section"
+                "$reporter,?\\s+(?:$section_marker\\s*)?(?P<section>\\d+[A-Z]?\\.\\d+(?:-\\d+(?:\\.\\d+)?)?(?:\\((?:[a-zA-Z]{1,2}|\\d{1,2})\\))*)"
             ],
             "start": null,
-            "variations": []
+            "variations": [
+                "KRS",
+                "K.R.S.",
+                "Ky. Rev. Stat."
+            ]
         }
     ],
     "La. Acts": [


### PR DESCRIPTION
Kentucky and Indiana statutes were only recognized in their full Bluebook form ("Ky. Rev. Stat. Ann. § 508.130", "Ind. Code § 35-42-1-1"), which is not how either code is actually cited. Measured over the Kentucky and Indiana opinions in the CourtListener bulk corpus (345,255 statute mentions), the canonical "Ky. Rev. Stat. Ann." spelling accounts for 394 occurrences while the bare "KRS" form accounts for 186,545.

Changes to Ky. Rev. Stat. Ann., Ind. Code and Ind. Code Ann.:

  * Add the attested abbreviations as variations: KRS, K.R.S., Ky. Rev. Stat., IC, I.C. Whitespace-only variants are deliberately omitted, since eyecite's _relax_ws() already derives them from the key (periods stay mandatory there, so K.R.S. and KRS are both listed).
  * Make $section_marker optional. The dominant forms in both states omit it entirely ("KRS 342.121", "IC 31-15-7-4").
  * Give each code a section pattern matching its real numbering, since $law_section is digits-only and cannot express Kentucky's letter chapters (13A.130) or Indiana's decimal segments (35-31.5-2-29.5). Inline named groups follow the precedent set by C.F.R. and Ind. Admin. Code.
  * Require all four segments for Indiana. "I.C." is also the Idaho Code abbreviation, and is in fact used more often for Idaho than for Indiana, so the two are separated structurally: the Indiana Code is title-article-chapter-section, while Idaho sections are two segments ("I.C. 18-4006") or three in the UCC title ("I.C. 28-22-104").
  * Replace the auto-generated placeholder examples -- none of which were real citations -- with forms taken from the corpus, and drop the accompanying "Automatically generated" notes.
  * Add href links to the official code publishers.

Weighted by real-world frequency, the new patterns fully parse 95.6% of Kentucky and 93.2% of Indiana statute mentions. Most of the remainder is OCR truncation ("KRS 435.-020") and chapter-level fragments ("KRS 202A", "IC 31-34") that are not resolvable citations.

Checked for false positives by running eyecite over 4,000 opinions from every court except Kentucky and Indiana. Of the 28 distinct IC/I.C. strings that matched, 27 were Idaho Code and are now correctly excluded; the one that remains, "IC 26-1-2-612", is a genuine Indiana Code citation in a federal opinion. The other cross-jurisdictional matches (the Sixth Circuit citing Ky. Rev. Stat. § 503.050(1), the Seventh citing Ind. Code § 35-42-2-2) are correct.

> note: just emailed a signed ICLA to `legal@free.law`